### PR TITLE
Document required task worktree workflow

### DIFF
--- a/.agents/skills/gh-issue-capture/SKILL.md
+++ b/.agents/skills/gh-issue-capture/SKILL.md
@@ -16,6 +16,8 @@ Use this skill to record follow-up work in GitHub Issues with consistent detail 
 4. Create the issue with `gh issue create --title "<title>" --body-file <file> --label "<label>"`.
 5. If user approval is expected before remote writes, draft the issue body and labels first.
 
+When implementation starts from an issue, use a task-specific Git worktree under `../sdmay26-02-worktrees/` and delete that worktree after the PR is merged, closed, or abandoned.
+
 ## Title
 
 Use a short actionable title:

--- a/.agents/skills/unity-coding/SKILL.md
+++ b/.agents/skills/unity-coding/SKILL.md
@@ -10,10 +10,11 @@ Use this skill for C# gameplay, tests, architecture refactors, compile fixes, an
 ## Workflow
 
 1. Read `AGENTS.md`, `ProjectSettings/ProjectVersion.txt`, relevant asmdefs, and nearby code before editing.
-2. Keep changes within existing runtime and test assemblies unless a new boundary is clearly needed.
-3. Prefer pure, deterministic logic for combat/rules calculations and thin MonoBehaviour integration.
-4. Add EditMode tests for pure rules/data behavior. Add PlayMode tests for scene, prefab, UI, lifecycle, and interaction behavior.
-5. Run the narrowest useful Unity test command, then broaden when shared behavior changes.
+2. Create or use a task-specific Git worktree under `../sdmay26-02-worktrees/`; do not edit the main checkout directly.
+3. Keep changes within existing runtime and test assemblies unless a new boundary is clearly needed.
+4. Prefer pure, deterministic logic for combat/rules calculations and thin MonoBehaviour integration.
+5. Add EditMode tests for pure rules/data behavior. Add PlayMode tests for scene, prefab, UI, lifecycle, and interaction behavior.
+6. Run the narrowest useful Unity test command, then broaden when shared behavior changes.
 
 ## Guardrails
 
@@ -21,6 +22,7 @@ Use this skill for C# gameplay, tests, architecture refactors, compile fixes, an
 - Avoid new global state. If existing singleton/static-event behavior is involved, isolate it behind a seam before expanding it.
 - Save and restore random state in tests that touch randomness.
 - Keep generated Unity files and results out of version control.
+- Remove the task worktree after the work is merged, closed, or abandoned.
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,17 @@ Do not add `-quit` to Unity Test Framework command-line runs in this project. Th
 
 Write test results outside tracked Unity asset folders. Do not commit `Library/`, `Logs/`, `Temp/`, generated `.csproj` files, generated `.sln` files, coverage output, or crash/recovery artifacts.
 
+## Git Workflow
+
+- Do not make task changes directly in the main repository checkout.
+- Create a local Git worktree for each issue, PR, or task branch.
+- Keep worktrees under the sibling folder `../sdmay26-02-worktrees/`.
+- Use descriptive worktree names tied to the task, for example `../sdmay26-02-worktrees/issue-62-tokenmesh-log-noise`.
+- Create task branches from the intended base branch inside the worktree.
+- Delete task worktrees after the PR is merged, closed, or the work is abandoned.
+- Before deleting a worktree, verify there are no uncommitted changes that should be preserved.
+- Never delete another user's worktree or branch without explicit approval.
+
 ## Coding
 
 - Follow existing C# style and Unity lifecycle patterns.


### PR DESCRIPTION
## Summary
- add a Git Workflow section to AGENTS.md requiring task-specific local worktrees
- standardize the worktree parent folder as ../sdmay26-02-worktrees/
- remind unity-coding and gh-issue-capture workflows to use and clean up task worktrees

## Verification
- quick_validate.py passes for unity-coding
- quick_validate.py passes for gh-issue-capture
- git diff --check passed