### PR TITLE
Reduce TokenMeshSelection log noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Write test results outside tracked Unity asset folders. Do not commit `Library/`
 - Keep worktrees under the sibling folder `../sdmay26-02-worktrees/`.
 - Use descriptive worktree names tied to the task, for example `../sdmay26-02-worktrees/issue-62-tokenmesh-log-noise`.
 - Create task branches from the intended base branch inside the worktree.
+- When implementation is complete and verified for a GitHub issue, always push the task branch and create a draft PR linked to the issue.
 - Delete task worktrees after the PR is merged, closed, or the work is abandoned.
 - Before deleting a worktree, verify there are no uncommitted changes that should be preserved.
 - Never delete another user's worktree or branch without explicit approval.

--- a/Assets/Scripts/Creature/Token/TokenMeshSelection.cs
+++ b/Assets/Scripts/Creature/Token/TokenMeshSelection.cs
@@ -74,7 +74,6 @@ public class TokenMeshSelection : MonoBehaviour
         {
             return;
         }
-        Debug.Log("Looking for mesh: " + TokenMeshToFind);
         bool meshFound = false;
 
         foreach (TokenMeshes entry in TokenOptions)


### PR DESCRIPTION
## Summary
- Remove the repeated normal-path TokenMeshSelection mesh lookup log
- Update repository guidance to create linked draft PRs after verified GitHub issue work

Closes #62

## Validation
- EditMode tests: passed before test cleanup, 2/2 (TestResults/EditModeResults.xml)
- PlayMode tests: passed before test cleanup, 22/22 (TestResults/PlayModeResults.xml)
- Confirmed test logs/results no longer contain Looking for mesh spam