### PR TITLE
Remove Codex model override

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,6 @@
 # Repo-local Codex configuration. Project config is loaded only after the
 # project is trusted by the user.
 
-model = "gpt-5-codex"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 


### PR DESCRIPTION
## Summary
- remove the repo-local Codex model override so Codex can use user/profile/default model selection
- leave approval and sandbox defaults unchanged

## Testing
- not run; config-only change