### PR TITLE
Align Unity Test Framework package version

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.feature.development": "1.0.2",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.multiplayer.center": "1.0.0",
-    "com.unity.test-framework": "1.3.11",
+    "com.unity.test-framework": "1.5.1",
     "com.unity.timeline": "1.8.9",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.7",

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Unity Test Workflow
 
-This project uses Unity `6000.2.1f1`. `Packages/manifest.json` lists Unity Test Framework `1.3.11`; Unity 6 resolves the active package to `1.5.1` through the Development feature set.
+This project uses Unity `6000.2.1f1`. `Packages/manifest.json` lists Unity Test Framework `1.5.1`, matching the version Unity 6 resolves through the Development feature set.
 
 ## Running Tests In The Editor
 


### PR DESCRIPTION
## Summary
- update the direct Unity Test Framework dependency in Packages/manifest.json to 1.5.1
- update TESTING.md so the documented package intent matches Unity 6000.2.1f1 resolution

Closes #63

## Tests
- EditMode: 1 passed, 0 failed
- PlayMode: 22 passed, 0 failed