### PR TITLE
Add PF2e ranged Strike support

### DIFF
--- a/Assets/Scripts/Combat/AIActionController.cs
+++ b/Assets/Scripts/Combat/AIActionController.cs
@@ -97,6 +97,8 @@ public abstract class AIActionController : ActionController
             else if (action is StrikeWeapon)
             {
                 StrikeWeapon strikeWeaponAction = action as StrikeWeapon;
+                if (!strikeWeaponAction.IsUsableBy(gameObject))
+                    continue;
                 damage = strikeWeaponAction.GetStrike().GetAvgDmg();
             }
             if (damage > bestDamage)

--- a/Assets/Scripts/Combat/Actions/AbilityActions/Rage.cs
+++ b/Assets/Scripts/Combat/Actions/AbilityActions/Rage.cs
@@ -88,6 +88,8 @@ public class Rage : MultiFrameEntityAction
         // TODO make rageBonus not hardcoded
         // int rageBonus = 2;
         Debug.Log("Adding Rage damage to strike");
+        if (action == null || action.FlatDamages == null || action.FlatDamages.Count == 0)
+            return;
 
         if (action.getTraits().Contains("agile") || action.getTraits().Contains("unarmed"))
         {

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -9,7 +9,7 @@ public class Strike
     public List<Dice> Damages;
     public List<DamageValue> FlatDamages;
     public List<string> Traits = new List<string>();
-    public int? AttackBonusOverride { get; set; }
+    public int? AttackModifierOverride { get; set; }
     public GameObject From = null;
     public GameObject To = null;
     private StrikeTargetResult TargetingResult = null;
@@ -27,7 +27,7 @@ public class Strike
             this.Damages.Add(new Dice(dice.numberOfDice, dice.sidesPerDie, dice.damageType));
         this.FlatDamages = new List<DamageValue>(strike.FlatDamages);
         this.Traits = new List<string>(strike.Traits);
-        this.AttackBonusOverride = strike.AttackBonusOverride;
+        this.AttackModifierOverride = strike.AttackModifierOverride;
     }
 
     public void Damage(GameObject from_go, GameObject to_go)
@@ -55,7 +55,7 @@ public class Strike
         int rangePenalty = TargetingResult?.RangePenalty ?? 0;
         int coverBonus = TargetingResult?.CoverAcBonus ?? 0;
 
-        int attackBonus = AttackBonusOverride ?? from.attackBonus;
+        int attackBonus = AttackModifierOverride ?? from.attackBonus;
         int targetAc = to.ac + coverBonus;
         int totalModifier = attackBonus - mapPenalty + rangePenalty;
 

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -1,102 +1,139 @@
 using UnityEngine;
 using System.Collections.Generic;
-using System.Collections;
 using Game.Creature;
 using System;
-
+using GridPublic;
 
 public class Strike
 {
     public List<Dice> Damages;
     public List<DamageValue> FlatDamages;
     public List<string> Traits = new List<string>();
-    public GameObject From = null; // for event listeners
-    public GameObject To = null; // for event listeners
+    public int? AttackBonusOverride { get; set; }
+    public GameObject From = null;
+    public GameObject To = null;
+    private StrikeTargetResult TargetingResult = null;
 
     public Strike(List<Dice> damages, List<DamageValue> flatDamages)
     {
         Damages = damages ?? new();
         FlatDamages = flatDamages ?? new();
     }
+
     public Strike(Strike strike)
     {
         this.Damages = new List<Dice>();
-        // Deep Copy Damages
-        foreach(Dice dice in strike.Damages)
+        foreach (Dice dice in strike.Damages)
             this.Damages.Add(new Dice(dice.numberOfDice, dice.sidesPerDie, dice.damageType));
         this.FlatDamages = new List<DamageValue>(strike.FlatDamages);
         this.Traits = new List<string>(strike.Traits);
+        this.AttackBonusOverride = strike.AttackBonusOverride;
     }
 
     public void Damage(GameObject from_go, GameObject to_go)
     {
-        // Create new strike that can be modified by listeners without affecting original action data
+        Damage(from_go, to_go, null);
+    }
+
+    public void Damage(GameObject from_go, GameObject to_go, StrikeTargetResult targetingResult)
+    {
         Strike evaluated = new Strike(this);
         evaluated.From = from_go;
         evaluated.To = to_go;
-        
-        // TEMP for testing strike effects
-        // Debug.Log("Strike pre-eval: " + this.ToString());
-        // Debug.Log("Strike post-eval: " + evaluated.ToString());
-        OnStrikeEvent.Invoke(new(evaluated, from_go)); 
-        // Debug.Log("Strike post-rage: " + evaluated.ToString());
+        evaluated.TargetingResult = targetingResult;
 
+        OnStrikeEvent.Invoke(new(evaluated, from_go));
         evaluated.DamageEvaluate();
     }
 
     protected void DamageEvaluate()
     {
-        // Get Data
         CreatureComponent from = From.GetComponent<CreatureComponent>();
         CreatureComponent to = To.GetComponent<CreatureComponent>();
-        uint penalty = From.GetComponent<ActionController>()?.StrikePenalty ?? 0;
-        if (this.Traits.Contains("agile"))
-        {
-            penalty *= 4;
-        }
-        else
-        {
-            penalty *= 5;
-        }
+        uint strikePenaltyCount = From.GetComponent<ActionController>()?.StrikePenalty ?? 0;
+        int mapPenalty = CalculateMultipleAttackPenalty(strikePenaltyCount);
+        int rangePenalty = TargetingResult?.RangePenalty ?? 0;
+        int coverBonus = TargetingResult?.CoverAcBonus ?? 0;
 
-        // TODO calculate actual bonuses
-        int attackBonus = from.attackBonus;
-        int damageBonus = from.damageBonus;
+        int attackBonus = AttackBonusOverride ?? from.attackBonus;
+        int targetAc = to.ac + coverBonus;
+        int totalModifier = attackBonus - mapPenalty + rangePenalty;
 
-        // Hit Check
-        D20Result attackRoll = D20.Roll(attackBonus - (int)penalty, to.ac);
+        D20Result attackRoll = D20.Roll(totalModifier, targetAc);
 
-        string log = "Attack:\n  AC: " + to.ac + "\n  Attack Roll: " + attackRoll.total
-            + " (" + attackRoll.roll + " + " + attackBonus + " - " + penalty + ")"
-            + "\n  Result: " + attackRoll.degree;
-        
+        string log = "Attack:\n  AC: " + targetAc;
+        if (coverBonus != 0)
+            log += " (" + to.ac + " + " + coverBonus + " cover)";
+        log += "\n  Attack Roll: " + attackRoll.total
+            + " (" + attackRoll.roll + " + " + attackBonus + " - " + mapPenalty;
+        if (rangePenalty != 0)
+            log += " " + rangePenalty;
+        log += ")\n  Result: " + attackRoll.degree;
 
         if (attackRoll.degree == DegreeOfSuccess.Success || attackRoll.degree == DegreeOfSuccess.CriticalSuccess)
         {
             CombatLog.GetInstance().Log(log);
             OnDamageDealt.Invoke(Damages[0].damageType);
-            // Adds a new flat damage for the damage bonus, type matching the first damage type
-            // FlatDamages.Add(new DamageValue(Damages[0].damageType, damageBonus));
             List<DamageValue> damageValues = DamageRoller.RollDamage(Damages, FlatDamages);
             DamageRoller.EvaluateCriticalDamage(attackRoll.degree, damageValues);
+            ApplyDeadlyDamage(attackRoll.degree, damageValues);
             DamageRoller.ApplyWeaknessAndResistance(damageValues, to.weaknesses, to.resistances);
             uint damage = (uint)DamageRoller.SumDamage(damageValues);
             to.TakeDamage(damage);
-            //log += "\nDamage Dealt: ";
-        } else {
+        }
+        else
+        {
             OnAttackMiss.Invoke(From);
             log += "\nAttack Missed!";
             CombatLog.GetInstance().Log(log);
         }
-        // log += "\n";
-        // Debug.Log(log);
-        // CombatLog.GetInstance().Log(log);
+    }
+
+    private int CalculateMultipleAttackPenalty(uint strikePenaltyCount)
+    {
+        if (strikePenaltyCount == 0)
+            return 0;
+
+        bool agile = Traits.Contains("agile");
+        if (strikePenaltyCount == 1)
+            return agile ? 4 : 5;
+        return agile ? 8 : 10;
+    }
+
+    private void ApplyDeadlyDamage(DegreeOfSuccess degree, List<DamageValue> damageValues)
+    {
+        if (degree != DegreeOfSuccess.CriticalSuccess || Traits == null || Damages.Count == 0)
+            return;
+
+        foreach (string trait in Traits)
+        {
+            if (string.IsNullOrWhiteSpace(trait) || !trait.StartsWith("deadly-d", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!int.TryParse(trait.Substring("deadly-d".Length), out int sides))
+                continue;
+
+            DamageValue deadly = new DamageValue(Damages[0].damageType, UnityEngine.Random.Range(1, sides + 1));
+            int index = damageValues.FindIndex(d => d.DamageType == deadly.DamageType);
+            if (index >= 0)
+            {
+                DamageValue existing = damageValues[index];
+                existing.DamageAmount += deadly.DamageAmount;
+                damageValues[index] = existing;
+            }
+            else
+            {
+                damageValues.Add(deadly);
+            }
+            CombatLog.GetInstance().Log("  +" + deadly.DamageAmount + " " + trait + " critical damage!");
+        }
     }
 
     public List<string> getTraits()
     {
         return Traits;
     }
+
     public override string ToString()
     {
         string traits = "";
@@ -112,7 +149,7 @@ public class Strike
         float avg = 0;
         foreach (Dice dice in Damages)
         {
-            avg += dice.numberOfDice * ((float)dice.sidesPerDie + 1) / 2; // average roll of a die is (sides+1)/2
+            avg += dice.numberOfDice * ((float)dice.sidesPerDie + 1) / 2;
         }
         foreach (DamageValue damageValue in FlatDamages)
         {

--- a/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections;
 using UnityEngine;
 using GridPublic;
+using GridPrivate;
 
 namespace Game.Strikes
 {
@@ -10,59 +11,75 @@ namespace Game.Strikes
 [System.Serializable]
 public class StrikeWeapon : MultiFrameEntityAction
 {
-    // Done by Ryan Meyer 04/07/2026
     public override string ActionName => GetWeaponName();
     private Strike Strike;
     private EquipmentWeapon Weapon;
-    private int range =1; // default range of 1 tile
+    private int range = 1;
     public string weaponName;
 
-
-
-    // Auto add strike actions based on equipped weapons
     public static void WeaponStrikeAdder(GameObject creature)
     {
         CreatureComponent cc = creature.GetComponent<CreatureComponent>();
-        // Check each hand for a weapon, and add corresponding strike action
-        // Assumes that CreatureComponent is properly enforcing rules for what can be equipped
-        // TODO prevent duplicate actions if called multiple times
+        if (cc == null)
+            return;
+
         if (cc.HasEquippedRightWeapon())
-        {
-            StrikeWeapon strikeWeaponRight = new StrikeWeapon(1, cc.equippedRightHand, creature);
-            creature.GetComponent<ActionController>().AddAction(strikeWeaponRight);
-            creature.GetComponent<CreatureComponent>().actions.Add("StrikeWeapon " +strikeWeaponRight.weaponName);
-        }
+            AddWeaponStrike(creature, cc.equippedRightHand);
         if (cc.HasEquippedLeftWeapon())
+            AddWeaponStrike(creature, cc.equippedLeftHand);
+    }
+
+    public static void WeaponStrikeAdderAutomatic(GameObject creature)
+    {
+        CreatureComponent cc = creature.GetComponent<CreatureComponent>();
+        if (cc == null)
+            return;
+
+        WeaponStrikeAdder(creature);
+
+        if (cc.weapons != null && cc.weapons.Count > 0)
         {
-            StrikeWeapon strikeWeaponLeft = new StrikeWeapon(1, cc.equippedLeftHand, creature);
-            creature.GetComponent<ActionController>().AddAction(strikeWeaponLeft);
-            creature.GetComponent<CreatureComponent>().actions.Add("StrikeWeapon " +strikeWeaponLeft.weaponName);
+            foreach (EquipmentWeapon weapon in cc.weapons)
+                AddWeaponStrike(creature, weapon);
+        }
+
+        List<string> weaponsList = cc.weaponsList;
+        foreach (string listedWeaponName in weaponsList)
+        {
+            EquipmentWeapon weapon = DataFileInterface.GetWeapon(listedWeaponName);
+            AddWeaponStrike(creature, weapon);
         }
     }
 
-    // Temp method for testing, adds first listed melee weapon as StrikeWeapon action
-    public static void WeaponStrikeAdderAutomatic(GameObject creature)
+    private static void AddWeaponStrike(GameObject creature, EquipmentWeapon weapon)
     {
-        // Debug.Log("WeaponStrikeAdderAutomatic called for " + creature.name);
-        List<string> weaponsList = creature.GetComponent<CreatureComponent>().weaponsList;
-        foreach(string weaponName in weaponsList)
-        {
-            EquipmentWeapon weapon = DataFileInterface.GetWeapon(weaponName);
-            if (weapon.range == 0)
-            {
-                // TEMP approach to bypass equipping elsewhere
-                creature.GetComponent<CreatureComponent>().EquipWeaponRight(weapon); // Temp equip weapon so it can be used by StrikeWeapon constructor
-                WeaponStrikeAdder(creature);  
+        if (creature == null || weapon == null || string.IsNullOrWhiteSpace(weapon.name) || weapon.damage == null)
+            return;
 
-                // TEMP approach to bypass equipping entirely
-                //StrikeWeapon strikeWeaponAction = new StrikeWeapon(1, weapon, creature);
-                //creature.GetComponent<ActionController>().AddAction(strikeWeaponAction);
-                //Debug.Log("WeaponStrikeAdderTEMP added StrikeWeapon action for " + weapon.name + " to " + creature.name);
-                break;
-            }
+        ActionController controller = creature.GetComponent<ActionController>();
+        CreatureComponent cc = creature.GetComponent<CreatureComponent>();
+        if (controller == null || cc == null || HasAction(controller, weapon.name))
+            return;
+
+        StrikeWeapon strikeWeapon = new StrikeWeapon(1, weapon, creature);
+        controller.AddAction(strikeWeapon);
+        if (!cc.actions.Contains("StrikeWeapon " + strikeWeapon.weaponName))
+            cc.actions.Add("StrikeWeapon " + strikeWeapon.weaponName);
+
+        int reloadCost = cc.GetReloadCost(weapon);
+        string reloadActionName = "Reload " + weapon.name;
+        if (reloadCost > 0 && !HasAction(controller, reloadActionName))
+            controller.AddAction(new ReloadWeaponAction((uint)reloadCost, weapon));
+    }
+
+    private static bool HasAction(ActionController controller, string actionName)
+    {
+        foreach (EntityAction action in controller.GetActions())
+        {
+            if (action.ActionName == actionName)
+                return true;
         }
-        // Debug.Log("WeaponStrikeAdderTEMP finished for " + creature.name);
-        //return null;
+        return false;
     }
 
     public string GetWeaponName()
@@ -83,57 +100,121 @@ public class StrikeWeapon : MultiFrameEntityAction
     public int GetRange()
     {
         return range;
-    }  
+    }
 
-    // Variant of Strike action based on a weapon
-    public StrikeWeapon(uint cost, EquipmentWeapon weapon, GameObject creature) :base(cost)
+    public StrikeTargetRequest GetTargetRequest()
     {
-        int flatDamageBonus = creature.GetComponent<CreatureComponent>().damageBonus;
-        // flatDamageBonus += creature.GetComponent<CreatureComponent>().strMod;
+        bool ranged = IsRangedWeapon();
+        int reachFeet = Weapon.traits != null && Weapon.traits.Contains("reach") ? 10 : 5;
+        return new StrikeTargetRequest
+        {
+            ReachFeet = reachFeet,
+            RangeIncrementFeet = ranged ? Weapon.range : 0,
+            IsRanged = ranged,
+            RequiresLineOfEffect = true
+        };
+    }
+
+    public bool CanStrikeTarget(GameObject attacker, GameObject target, Tile[,] tiles)
+    {
+        return StrikeTargeting.Evaluate(attacker, target, tiles, GetTargetRequest()) != null;
+    }
+
+    public bool IsUsableBy(GameObject attacker)
+    {
+        CreatureComponent cc = attacker.GetComponent<CreatureComponent>();
+        return cc == null || (cc.HasAmmoFor(Weapon) && cc.IsWeaponLoaded(Weapon));
+    }
+
+    public bool IsRangedWeapon()
+    {
+        return Weapon != null && Weapon.range > 0;
+    }
+
+    public StrikeWeapon(uint cost, EquipmentWeapon weapon, GameObject creature) : base(cost)
+    {
+        CreatureComponent cc = creature.GetComponent<CreatureComponent>();
         Weapon = weapon;
         weaponName = weapon.name;
-        List<Dice> damageList = new List<Dice>();
-        damageList.Add(Weapon.damage);
+        List<Dice> damageList = new List<Dice> { Weapon.damage };
         List<DamageValue> flatDamageList = new List<DamageValue>();
-        flatDamageList.Add(new DamageValue(Weapon.damage.damageType, flatDamageBonus));
-        // TODO When size>medium creatures are implemented that will need accounted for in range
-        if(Weapon.range > 0)
-        {
-            range = Weapon.range/5; // convert from feet to grid units, assuming 5 foot grid squares
-        }
-        if (Weapon.traits.Contains("reach"))
-        {
-            range += 1; // extend range for reach weapon
-        }
+
+        if (!IsRangedWeapon() || string.IsNullOrWhiteSpace(Weapon.ammo))
+            flatDamageList.Add(new DamageValue(Weapon.damage.damageType, cc.damageBonus));
+
+        if (Weapon.range > 0)
+            range = Weapon.range / 5;
+        if (Weapon.traits != null && Weapon.traits.Contains("reach"))
+            range += 1;
+
         Strike = new Strike(damageList, flatDamageList);
-        Strike.Traits = Weapon.traits;
+        Strike.Traits = Weapon.traits ?? new List<string>();
+        Strike.AttackBonusOverride = cc.GetAttackBonusForWeapon(weapon);
     }
 
     protected override IEnumerator MFInvoke(GameObject attacker)
     {
         ActionController ac = attacker.GetComponent<ActionController>();
-        // Grid get target;
-        CoroutineResult<GameObject> target = new();
-        yield return GridAPI.GetInstance().GetStrikeTarget(attacker, range*5, target);// Convert range(tiles) to ft
-
-        // null target value equates to canceled action
-        if(target.Value)
+        CreatureComponent cc = attacker.GetComponent<CreatureComponent>();
+        if (cc != null && (!cc.HasAmmoFor(Weapon) || !cc.IsWeaponLoaded(Weapon)))
         {
-            CombatLog.GetInstance().Log("- " + attacker.name + " strikes " + target.Value.name + " with " + weaponName + ".");
-            // TODO: need to modify strike/damage to account for character abilities, weapons traits, etc
-            Strike.Damage(attacker, target.Value);
+            CombatLog.GetInstance().Log("- " + attacker.name + " cannot fire " + weaponName + ".");
+            if (ac)
+                ac.IsTakingAction = false;
+            yield break;
+        }
+
+        CoroutineResult<StrikeTargetResult> target = new();
+        yield return GridAPI.GetInstance().GetStrikeTarget(attacker, GetTargetRequest(), target);
+
+        if (target.Value != null && target.Value.Target != null)
+        {
+            if (cc != null && !cc.ConsumeAmmoFor(Weapon))
+            {
+                CombatLog.GetInstance().Log("- " + attacker.name + " has no ammunition for " + weaponName + ".");
+                if (ac)
+                    ac.IsTakingAction = false;
+                yield break;
+            }
+
+            CombatLog.GetInstance().Log("- " + attacker.name + " strikes " + target.Value.Target.name + " with " + weaponName + ".");
+            Strike.Damage(attacker, target.Value.Target, target.Value);
+            cc?.MarkWeaponFired(Weapon);
             if (ac)
             {
                 PayCost(ac);
                 ac.StrikePenalty += 1;
             }
         }
-        if(ac)
+        if (ac)
             ac.IsTakingAction = false;
     }
 }
+
+[System.Serializable]
+public class ReloadWeaponAction : EntityAction
+{
+    private readonly EquipmentWeapon Weapon;
+
+    public override string ActionName => "Reload " + Weapon.name;
+
+    public ReloadWeaponAction(uint cost, EquipmentWeapon weapon) : base(cost)
+    {
+        Weapon = weapon;
+    }
+
+    public override void Invoke(GameObject target)
+    {
+        ActionController ac = target.GetComponent<ActionController>();
+        CreatureComponent cc = target.GetComponent<CreatureComponent>();
+        if (cc != null && cc.ReloadWeapon(Weapon))
+        {
+            CombatLog.GetInstance().Log("- " + target.name + " reloads " + Weapon.name + ".");
+            PayCost(ac);
+        }
+        if (ac)
+            ac.IsTakingAction = false;
+        CombatManager.GetInstance().CheckForEndOfGame();
+    }
 }
-
-
-
-
+}

--- a/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
@@ -11,10 +11,12 @@ namespace Game.Strikes
 [System.Serializable]
 public class StrikeWeapon : MultiFrameEntityAction
 {
+    private const string CreatureActionLabelPrefix = "StrikeWeapon ";
+    private const string ReachTrait = "reach";
+
     public override string ActionName => GetWeaponName();
     private Strike Strike;
     private EquipmentWeapon Weapon;
-    private int range = 1;
     public string weaponName;
 
     public static void WeaponStrikeAdder(GameObject creature)
@@ -58,28 +60,43 @@ public class StrikeWeapon : MultiFrameEntityAction
 
         ActionController controller = creature.GetComponent<ActionController>();
         CreatureComponent cc = creature.GetComponent<CreatureComponent>();
-        if (controller == null || cc == null || HasAction(controller, weapon.name))
+        if (controller == null || cc == null || HasWeaponStrike(controller, weapon))
             return;
 
         StrikeWeapon strikeWeapon = new StrikeWeapon(1, weapon, creature);
         controller.AddAction(strikeWeapon);
-        if (!cc.actions.Contains("StrikeWeapon " + strikeWeapon.weaponName))
-            cc.actions.Add("StrikeWeapon " + strikeWeapon.weaponName);
+        string creatureActionLabel = CreatureActionLabelPrefix + strikeWeapon.weaponName;
+        if (!cc.actions.Contains(creatureActionLabel))
+            cc.actions.Add(creatureActionLabel);
 
         int reloadCost = cc.GetReloadCost(weapon);
-        string reloadActionName = "Reload " + weapon.name;
-        if (reloadCost > 0 && !HasAction(controller, reloadActionName))
+        if (reloadCost > 0 && !HasReloadAction(controller, weapon))
             controller.AddAction(new ReloadWeaponAction((uint)reloadCost, weapon));
     }
 
-    private static bool HasAction(ActionController controller, string actionName)
+    private static bool HasWeaponStrike(ActionController controller, EquipmentWeapon weapon)
     {
         foreach (EntityAction action in controller.GetActions())
         {
-            if (action.ActionName == actionName)
+            if (action is StrikeWeapon strikeWeapon && strikeWeapon.RepresentsWeapon(weapon))
                 return true;
         }
         return false;
+    }
+
+    private static bool HasReloadAction(ActionController controller, EquipmentWeapon weapon)
+    {
+        foreach (EntityAction action in controller.GetActions())
+        {
+            if (action is ReloadWeaponAction reloadAction && reloadAction.RepresentsWeapon(weapon))
+                return true;
+        }
+        return false;
+    }
+
+    private bool RepresentsWeapon(EquipmentWeapon weapon)
+    {
+        return Weapon == weapon || (Weapon != null && weapon != null && string.Equals(Weapon.name, weapon.name, System.StringComparison.OrdinalIgnoreCase));
     }
 
     public string GetWeaponName()
@@ -99,13 +116,13 @@ public class StrikeWeapon : MultiFrameEntityAction
 
     public int GetRange()
     {
-        return range;
+        return Mathf.CeilToInt(GetTargetRequest().MaximumRangeFeet / 5.0f);
     }
 
     public StrikeTargetRequest GetTargetRequest()
     {
         bool ranged = IsRangedWeapon();
-        int reachFeet = Weapon.traits != null && Weapon.traits.Contains("reach") ? 10 : 5;
+        int reachFeet = Weapon.traits != null && Weapon.traits.Contains(ReachTrait) ? 10 : 5;
         return new StrikeTargetRequest
         {
             ReachFeet = reachFeet,
@@ -142,14 +159,9 @@ public class StrikeWeapon : MultiFrameEntityAction
         if (!IsRangedWeapon() || string.IsNullOrWhiteSpace(Weapon.ammo))
             flatDamageList.Add(new DamageValue(Weapon.damage.damageType, cc.damageBonus));
 
-        if (Weapon.range > 0)
-            range = Weapon.range / 5;
-        if (Weapon.traits != null && Weapon.traits.Contains("reach"))
-            range += 1;
-
         Strike = new Strike(damageList, flatDamageList);
         Strike.Traits = Weapon.traits ?? new List<string>();
-        Strike.AttackBonusOverride = cc.GetAttackBonusForWeapon(weapon);
+        Strike.AttackModifierOverride = cc.GetAttackBonusForWeapon(weapon);
     }
 
     protected override IEnumerator MFInvoke(GameObject attacker)
@@ -203,6 +215,11 @@ public class ReloadWeaponAction : EntityAction
         Weapon = weapon;
     }
 
+    public bool RepresentsWeapon(EquipmentWeapon weapon)
+    {
+        return Weapon == weapon || (Weapon != null && weapon != null && string.Equals(Weapon.name, weapon.name, System.StringComparison.OrdinalIgnoreCase));
+    }
+
     public override void Invoke(GameObject target)
     {
         ActionController ac = target.GetComponent<ActionController>();
@@ -214,7 +231,7 @@ public class ReloadWeaponAction : EntityAction
         }
         if (ac)
             ac.IsTakingAction = false;
-        CombatManager.GetInstance().CheckForEndOfGame();
+        base.Invoke(target);
     }
 }
 }

--- a/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
@@ -30,16 +30,21 @@ public class Unarmed : MultiFrameEntityAction
     protected override IEnumerator MFInvoke(GameObject attacker)
     {
         ActionController ac = attacker.GetComponent<ActionController>();
-        // Grid get target;
-        CoroutineResult<GameObject> target = new();
-        yield return GridAPI.GetInstance().GetStrikeTarget(attacker, range*5, target);// Convert range(tiles) to ft
+        CoroutineResult<StrikeTargetResult> target = new();
+        StrikeTargetRequest request = new StrikeTargetRequest
+        {
+            ReachFeet = range * 5,
+            IsRanged = false,
+            RequiresLineOfEffect = true
+        };
+        yield return GridAPI.GetInstance().GetStrikeTarget(attacker, request, target);
             
         // null target value equates to canceled action
-        if(target.Value)
+        if(target.Value != null && target.Value.Target != null)
         {
-            CombatLog.GetInstance().Log("- " + attacker.name + " attacks " + target.Value.name + " with unarmed strike.");
-            Debug.Log(attacker + " Striking " + target.Value);
-            Strike.Damage(attacker, target.Value);
+            CombatLog.GetInstance().Log("- " + attacker.name + " attacks " + target.Value.Target.name + " with unarmed strike.");
+            Debug.Log(attacker + " Striking " + target.Value.Target);
+            Strike.Damage(attacker, target.Value.Target, target.Value);
             if (ac)
             {
                 PayCost(ac);

--- a/Assets/Scripts/Combat/MindlessController.cs
+++ b/Assets/Scripts/Combat/MindlessController.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Game.Creature;
+using Game.Strikes;
 using NUnit.Framework;
 using System;
 using System.Collections;
@@ -117,6 +118,10 @@ public class MindlessController : AIActionController
             }
         }
 
+        EntityAction legalStrike = BestLegalStrike(myTeam);
+        if (legalStrike != null)
+            return legalStrike;
+
         // Attack if best target is in strike range
         if (BestTarget != null)
         {
@@ -171,6 +176,43 @@ public class MindlessController : AIActionController
         return Movements[0];
     }
 
+    private EntityAction BestLegalStrike(string myTeam)
+    {
+        EntityAction bestAction = null;
+        GameObject bestTarget = null;
+        float bestDamage = 0;
+
+        foreach (GameObject target in CombatManagerInterface.GetInstance().GetCombatants())
+        {
+            if (target == this.gameObject || TeamRules.GetInstance().IsFriendly(myTeam, target.GetComponent<Team>().Name))
+                continue;
+
+            foreach (EntityAction action in Actions)
+            {
+                if (action is not StrikeWeapon strikeWeapon || !strikeWeapon.IsUsableBy(gameObject))
+                    continue;
+
+                if (!strikeWeapon.CanStrikeTarget(gameObject, target, Tiles))
+                    continue;
+
+                float damage = strikeWeapon.GetStrike().GetAvgDmg();
+                if (damage > bestDamage)
+                {
+                    bestDamage = damage;
+                    bestAction = action;
+                    bestTarget = target;
+                }
+            }
+        }
+
+        if (bestAction != null)
+        {
+            BestTarget = bestTarget;
+            SelectedTile = Vector3Int.RoundToInt(bestTarget.transform.position);
+        }
+
+        return bestAction;
+    }
     /// <summary>
     /// when the best path to the target is blocked by other entities, this function determines if the AI can take a detour around the obstacle in one turn.
     /// if it takes longer than one turn to take the calculated best path, the AI will choose not to take the detour and get as close as possible to the target instead.

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -13,6 +13,10 @@ namespace Game.Creature
 
     [System.Serializable] public struct ArmorBonus { public string category; public int bonus; }
 
+    [System.Serializable] public struct WeaponActionBonus { public string weaponName; public int bonus; }
+
+    [System.Serializable] public struct AmmoCount { public string ammoName; public int quantity; }
+
 
     // Extension as a Unity MonoBehaviour
     public class CreatureComponent : MonoBehaviour 
@@ -35,6 +39,7 @@ namespace Game.Creature
         [SerializeField] private int _attackBonus;
         [SerializeField] private int _damageBonus;
         [SerializeField] private List<WeaponBonus> _weaponBonuses = new List<WeaponBonus>();
+        [SerializeField] private List<WeaponActionBonus> _weaponActionBonuses = new List<WeaponActionBonus>();
         [SerializeField] private List<ArmorBonus> _armorBonuses = new List<ArmorBonus>();
         [SerializeField] private List<DamageValue> _weaknesses = new List<DamageValue>();
         [SerializeField] private List<DamageValue> _resistances = new List<DamageValue>();
@@ -77,6 +82,8 @@ namespace Game.Creature
         [SerializeField] private List<string> _equipment = new List<string>();
         [SerializeField] private List<string> _weaponsList = new List<string>(); // Temp to display _weapons in inspector
         [SerializeField] private List<EquipmentWeapon> _weapons = new List<EquipmentWeapon>();
+        [SerializeField] private List<AmmoCount> _ammunition = new List<AmmoCount>();
+        [SerializeField] private List<string> _unloadedWeapons = new List<string>();
         [SerializeField] private List<string> _armorList = new List<string>(); // Temp to display armor in inspector
         [SerializeField] private List<EquipmentArmor> _armor = new List<EquipmentArmor>(); // Temp to display armor in inspector
 
@@ -93,6 +100,7 @@ namespace Game.Creature
         public int attackBonus { get => _attackBonus; set => _attackBonus = value; }
         public int damageBonus { get => _damageBonus; set => _damageBonus = value; }
         public List<WeaponBonus> weaponBonuses { get => _weaponBonuses; set => _weaponBonuses = value ?? new List<WeaponBonus>(); }
+        public List<WeaponActionBonus> weaponActionBonuses { get => _weaponActionBonuses; set => _weaponActionBonuses = value ?? new List<WeaponActionBonus>(); }
         public List<ArmorBonus> armorBonuses { get => _armorBonuses; set => _armorBonuses = value ?? new List<ArmorBonus>(); }
         public List<DamageValue> weaknesses { get => _weaknesses; set => _weaknesses = value; }
         public List<DamageValue> resistances { get => _resistances; set => _resistances = value; }
@@ -123,10 +131,119 @@ namespace Game.Creature
         public EquipmentWeapon equippedLeftHand { get => _equippedLeftHand; set => _equippedLeftHand = value; }
         public List<string> weaponsList { get => _weaponsList; set => _weaponsList = value ?? new List<string>(); }
         public List<EquipmentWeapon> weapons { get => _weapons; set => _weapons = value ?? new List<EquipmentWeapon>(); }
+        public List<AmmoCount> ammunition { get => _ammunition; set => _ammunition = value ?? new List<AmmoCount>(); }
+        public List<string> unloadedWeapons { get => _unloadedWeapons; set => _unloadedWeapons = value ?? new List<string>(); }
         public List<string> armorList { get => _armorList; set => _armorList = value ?? new List<string>(); }
         public List<EquipmentArmor> armor { get => _armor; set => _armor = value ?? new List<EquipmentArmor>(); }
 
 
+        public int GetAttackBonusForWeapon(EquipmentWeapon weapon)
+        {
+            if (weapon != null && _weaponActionBonuses != null)
+            {
+                string weaponKey = NormalizeEquipmentKey(weapon.name);
+                foreach (WeaponActionBonus actionBonus in _weaponActionBonuses)
+                {
+                    if (NormalizeEquipmentKey(actionBonus.weaponName) == weaponKey)
+                        return actionBonus.bonus;
+                }
+            }
+            return attackBonus;
+        }
+
+        public int GetAmmoQuantity(string ammoName)
+        {
+            string key = NormalizeEquipmentKey(ammoName);
+            for (int i = 0; i < _ammunition.Count; i++)
+            {
+                if (NormalizeEquipmentKey(_ammunition[i].ammoName) == key)
+                    return _ammunition[i].quantity;
+            }
+            return 0;
+        }
+
+        public void SetAmmoQuantity(string ammoName, int quantity)
+        {
+            string key = NormalizeEquipmentKey(ammoName);
+            for (int i = 0; i < _ammunition.Count; i++)
+            {
+                if (NormalizeEquipmentKey(_ammunition[i].ammoName) == key)
+                {
+                    _ammunition[i] = new AmmoCount { ammoName = ammoName, quantity = Mathf.Max(0, quantity) };
+                    return;
+                }
+            }
+            _ammunition.Add(new AmmoCount { ammoName = ammoName, quantity = Mathf.Max(0, quantity) });
+        }
+
+        public bool HasAmmoFor(EquipmentWeapon weapon)
+        {
+            return weapon == null || string.IsNullOrWhiteSpace(weapon.ammo) || GetAmmoQuantity(weapon.ammo) > 0;
+        }
+
+        public bool ConsumeAmmoFor(EquipmentWeapon weapon)
+        {
+            if (weapon == null || string.IsNullOrWhiteSpace(weapon.ammo))
+                return true;
+
+            int quantity = GetAmmoQuantity(weapon.ammo);
+            if (quantity <= 0)
+                return false;
+
+            SetAmmoQuantity(weapon.ammo, quantity - 1);
+            return true;
+        }
+
+        public bool IsWeaponLoaded(EquipmentWeapon weapon)
+        {
+            if (weapon == null || GetReloadCost(weapon) <= 0)
+                return true;
+            return !_unloadedWeapons.Contains(NormalizeEquipmentKey(weapon.name));
+        }
+
+        public void MarkWeaponFired(EquipmentWeapon weapon)
+        {
+            if (weapon == null || GetReloadCost(weapon) <= 0)
+                return;
+
+            string key = NormalizeEquipmentKey(weapon.name);
+            if (!_unloadedWeapons.Contains(key))
+                _unloadedWeapons.Add(key);
+        }
+
+        public bool ReloadWeapon(EquipmentWeapon weapon)
+        {
+            if (weapon == null || GetReloadCost(weapon) <= 0 || !HasAmmoFor(weapon))
+                return false;
+
+            _unloadedWeapons.Remove(NormalizeEquipmentKey(weapon.name));
+            return true;
+        }
+
+        public int GetReloadCost(EquipmentWeapon weapon)
+        {
+            if (weapon == null)
+                return 0;
+
+            if (!string.IsNullOrWhiteSpace(weapon.reload) && int.TryParse(weapon.reload, out int cost))
+                return Mathf.Max(0, cost);
+
+            if (weapon.traits != null)
+            {
+                foreach (string trait in weapon.traits)
+                {
+                    if (trait != null && trait.StartsWith("reload-", System.StringComparison.OrdinalIgnoreCase) && int.TryParse(trait.Substring(7), out cost))
+                        return Mathf.Max(0, cost);
+                }
+            }
+
+            return 0;
+        }
+
+        private static string NormalizeEquipmentKey(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToLowerInvariant().Replace(' ', '-');
+        }
         // Other attributes
         public List<string> traits { get; set; } = new List<string>();
         public string size { get; set; }

--- a/Assets/Scripts/Creature/CreatureJsonConverter.cs
+++ b/Assets/Scripts/Creature/CreatureJsonConverter.cs
@@ -112,6 +112,7 @@ namespace Game.Creature
         public List<string> runes;
         public string price;
         public int range;
+        public string reload;
         public string ammo;
         public int bulk;
     }
@@ -169,6 +170,17 @@ namespace Game.Creature
             // TODO: temporary, damage bonus directly from str mod 
             target.damageBonus = dto.system.abilities != null ? dto.system.abilities.str : target.strMod;
 
+            // Action-specific weapon attack bonuses from imported creature actions
+            if (target.weaponActionBonuses == null) target.weaponActionBonuses = new List<WeaponActionBonus>();
+            target.weaponActionBonuses.Clear();
+            if (dto.actions != null)
+            {
+                foreach (var action in dto.actions)
+                {
+                    if (!string.IsNullOrWhiteSpace(action?.name) && action.system?.bonus != null)
+                        target.weaponActionBonuses.Add(new WeaponActionBonus { weaponName = action.name, bonus = action.system.bonus.value });
+                }
+            }
             // Weapon attack bonuses by proficiency category
             if (target.weaponBonuses == null) target.weaponBonuses = new List<WeaponBonus>();
             target.weaponBonuses.Clear();
@@ -266,11 +278,16 @@ namespace Game.Creature
             // Equipment
             if (target.equipment == null) target.equipment = new List<string>();
             target.equipment.Clear();
+            target.ammunition.Clear();
             if (dto.equipment != null)
             {
                 foreach (var e in dto.equipment)
+                {
                     if (!string.IsNullOrEmpty(e?.name))
                         target.equipment.Add(e.name);
+                    if (e != null && string.Equals(e.type, "ammo", StringComparison.OrdinalIgnoreCase))
+                        target.SetAmmoQuantity(e.name, e.quantity);
+                }
             }
             // Weapons
             if (target.weapons == null){
@@ -478,6 +495,7 @@ namespace Game.Creature
             weapon.runes = dto.runes;
             weapon.price = double.TryParse(dto.price, out double priceValue) ? priceValue : 0.0; // Handle parsing price string to double
             weapon.range = dto.range;
+            weapon.reload = dto.reload;
             weapon.ammo = dto.ammo;
             weapon.bulk = dto.bulk;
             return weapon;
@@ -563,6 +581,7 @@ namespace Game.Creature
                     weapon.runes = dto.runes;
                     weapon.price = double.TryParse(dto.price, out double priceValue) ? priceValue : 0.0; // Handle parsing price string to double
                     weapon.range = dto.range;
+                    weapon.reload = dto.reload;
                     weapon.ammo = dto.ammo;
                     weapon.bulk = dto.bulk;
                     weapons.Add(weapon);

--- a/Assets/Scripts/Creature/Dice.cs
+++ b/Assets/Scripts/Creature/Dice.cs
@@ -22,24 +22,53 @@ namespace Game.Creature
     public class D20{
         public static D20Result Roll(int modifier, int targetVal){
             int rollResult = UnityEngine.Random.Range(1, 21);
+            return Evaluate(rollResult, modifier, targetVal);
+        }
+
+        public static D20Result Evaluate(int rollResult, int modifier, int targetVal){
             int totalResult = rollResult + modifier;
             DegreeOfSuccess degree;
-            if (rollResult == 20 || totalResult >= targetVal + 10){
+            if (totalResult >= targetVal + 10){
                 degree = DegreeOfSuccess.CriticalSuccess;
-            }
-            else if (rollResult == 1 || totalResult <= targetVal - 10){
-                degree = DegreeOfSuccess.CriticalFail;
             }
             else if (totalResult >= targetVal){
                 degree = DegreeOfSuccess.Success;
             }
+            else if (totalResult <= targetVal - 10){
+                degree = DegreeOfSuccess.CriticalFail;
+            }
             else{
                 degree = DegreeOfSuccess.Fail;
             }
+
+            if (rollResult == 20){
+                degree = Improve(degree);
+            }
+            else if (rollResult == 1){
+                degree = Worsen(degree);
+            }
+
             return new D20Result{ roll = rollResult, total = totalResult, degree = degree };
         }
-    }
 
+        private static DegreeOfSuccess Improve(DegreeOfSuccess degree){
+            return degree switch{
+                DegreeOfSuccess.CriticalFail => DegreeOfSuccess.Fail,
+                DegreeOfSuccess.Fail => DegreeOfSuccess.Success,
+                DegreeOfSuccess.Success => DegreeOfSuccess.CriticalSuccess,
+                _ => DegreeOfSuccess.CriticalSuccess
+            };
+        }
+
+        private static DegreeOfSuccess Worsen(DegreeOfSuccess degree){
+            return degree switch{
+                DegreeOfSuccess.CriticalSuccess => DegreeOfSuccess.Success,
+                DegreeOfSuccess.Success => DegreeOfSuccess.Fail,
+                DegreeOfSuccess.Fail => DegreeOfSuccess.CriticalFail,
+                _ => DegreeOfSuccess.CriticalFail
+            };
+        }
+    }
     // Class for rolling dice of given number and sides
     [System.Serializable]
     public class Dice{

--- a/Assets/Scripts/Creature/EquipmentWeapon.cs
+++ b/Assets/Scripts/Creature/EquipmentWeapon.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Game.Creature;
 using System.Collections.Generic;
 using UnityEngine;
@@ -23,6 +23,7 @@ namespace Game.Creature
         public List<string> runes;   // list of runes, if any
         public double price;         // <int> <currency> --or-- decimal with 1.0=1gp
         public int range;            // for ranged weapons, 0 for melee
+        public string reload;        // action cost to reload, null or "-" for melee
         public string ammo;          // type of ammo used, null for melee
         public double bulk;             // look up uses
         // public string publication { get; set; }   // source book reference, unnnecessary for in game use

--- a/Assets/Scripts/Grid/GridBase.cs
+++ b/Assets/Scripts/Grid/GridBase.cs
@@ -82,21 +82,6 @@ namespace GridPrivate
                 yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
         }
 
-        public override IEnumerator GetStrikeTarget(GameObject attacker, float range, CoroutineResult<GameObject> target)
-        {
-            StrikeTargetRequest request = new StrikeTargetRequest
-            {
-                ReachFeet = Mathf.RoundToInt(range),
-                IsRanged = false,
-                RequiresLineOfEffect = true
-            };
-            CoroutineResult<StrikeTargetResult> result = new();
-            if (Fsm.ChangeState(new StateStrike(attacker, request, result, Fsm)))
-                yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
-
-            target.Value = result.Value?.Target;
-        }
-
         public override IEnumerator GetStrikeTarget(GameObject attacker, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> target)
         {
             if (Fsm.ChangeState(new StateStrike(attacker, request, target, Fsm)))

--- a/Assets/Scripts/Grid/GridBase.cs
+++ b/Assets/Scripts/Grid/GridBase.cs
@@ -84,7 +84,22 @@ namespace GridPrivate
 
         public override IEnumerator GetStrikeTarget(GameObject attacker, float range, CoroutineResult<GameObject> target)
         {
-            if (Fsm.ChangeState(new StateStrike(attacker, range, target, Fsm)))
+            StrikeTargetRequest request = new StrikeTargetRequest
+            {
+                ReachFeet = Mathf.RoundToInt(range),
+                IsRanged = false,
+                RequiresLineOfEffect = true
+            };
+            CoroutineResult<StrikeTargetResult> result = new();
+            if (Fsm.ChangeState(new StateStrike(attacker, request, result, Fsm)))
+                yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
+
+            target.Value = result.Value?.Target;
+        }
+
+        public override IEnumerator GetStrikeTarget(GameObject attacker, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> target)
+        {
+            if (Fsm.ChangeState(new StateStrike(attacker, request, target, Fsm)))
                 yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
         }
 

--- a/Assets/Scripts/Grid/States/StateStrike.cs
+++ b/Assets/Scripts/Grid/States/StateStrike.cs
@@ -11,21 +11,13 @@ namespace GridPrivate
         private readonly GameObject Character;
         private readonly StrikeTargetRequest Request;
         private readonly CoroutineResult<StrikeTargetResult> Selection;
-        private readonly CoroutineResult<GameObject> LegacySelection;
         protected GridAPIPrivate GridAPI = (GridAPIPrivate)GridPublic.GridAPI.GetInstance();
         protected IPathfinder Pathfinder;
         protected Tile[,] Tiles;
         protected List<Vector3Int> inRange = new List<Vector3Int>();
         protected List<GameObject> OccupantsInRange = new List<GameObject>();
         protected Vector3Int HoverCell;
-        protected float Range;
         protected Vector3Int StartPosition;
-
-        public StateStrike(GameObject character, float range, CoroutineResult<GameObject> selection, GridFSM fsm)
-            : this(character, new StrikeTargetRequest { ReachFeet = Mathf.RoundToInt(range), RequiresLineOfEffect = true }, new CoroutineResult<StrikeTargetResult>(), fsm)
-        {
-            LegacySelection = selection;
-        }
 
         public StateStrike(GameObject character, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> selection, GridFSM fsm)
         {
@@ -37,7 +29,6 @@ namespace GridPrivate
             StartPosition = Vector3Int.RoundToInt(Character.transform.position);
             Pathfinder = GridAPI.GetPathfinder();
             Pathfinder.Search(Character, StartPosition);
-            Range = Request.MaximumRangeFeet;
         }
 
         public override void Enter(FiniteStateMachine<GridFSMState> fsm)
@@ -81,9 +72,6 @@ namespace GridPrivate
 
         public override void Exit()
         {
-            if (LegacySelection != null)
-                LegacySelection.Value = Selection.Value?.Target;
-
             OccupantsInRange.Clear();
             OnHover.RemoveListener(Hover);
             OnHighlightRangeEnd.Invoke();

--- a/Assets/Scripts/Grid/States/StateStrike.cs
+++ b/Assets/Scripts/Grid/States/StateStrike.cs
@@ -1,16 +1,17 @@
 using UnityEngine;
 using System.Collections.Generic;
-using Game.Creature;
 using System.Collections;
+using GridPublic;
 
 namespace GridPrivate
 {
     public class StateStrike : GridFSMState
     {
         protected GridFSM Fsm;
-        // target character
-        GameObject Character;
-        CoroutineResult<GameObject> Selection;
+        private readonly GameObject Character;
+        private readonly StrikeTargetRequest Request;
+        private readonly CoroutineResult<StrikeTargetResult> Selection;
+        private readonly CoroutineResult<GameObject> LegacySelection;
         protected GridAPIPrivate GridAPI = (GridAPIPrivate)GridPublic.GridAPI.GetInstance();
         protected IPathfinder Pathfinder;
         protected Tile[,] Tiles;
@@ -20,19 +21,25 @@ namespace GridPrivate
         protected float Range;
         protected Vector3Int StartPosition;
 
-
-        // compact constructor
         public StateStrike(GameObject character, float range, CoroutineResult<GameObject> selection, GridFSM fsm)
+            : this(character, new StrikeTargetRequest { ReachFeet = Mathf.RoundToInt(range), RequiresLineOfEffect = true }, new CoroutineResult<StrikeTargetResult>(), fsm)
+        {
+            LegacySelection = selection;
+        }
+
+        public StateStrike(GameObject character, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> selection, GridFSM fsm)
         {
             Fsm = fsm;
             Character = character;
+            Request = request ?? new StrikeTargetRequest();
             Selection = selection;
             Tiles = GridAPI.GetTiles();
             StartPosition = Vector3Int.RoundToInt(Character.transform.position);
             Pathfinder = GridAPI.GetPathfinder();
             Pathfinder.Search(Character, StartPosition);
-            Range = range;
+            Range = Request.MaximumRangeFeet;
         }
+
         public override void Enter(FiniteStateMachine<GridFSMState> fsm)
         {
             base.Enter(fsm);
@@ -41,51 +48,71 @@ namespace GridPrivate
             AIActionController ai = Character.GetComponent<AIActionController>();
             if (ai != null)
             {
-
-                // grab best target from the AI's controller, this should be set during its decision making process
                 if (ai.BestTarget == null)
                     Debug.LogWarning("AI has no target, skipping strike");
                 else
-                    Selection.Value = ai.BestTarget;
-                CoroutineRunner.Run(ChangeToIdle()); // Used because you shouldn't transition from enter()
+                    Selection.Value = StrikeTargeting.Evaluate(Character, ai.BestTarget, Tiles, Request);
+                CoroutineRunner.Run(ChangeToIdle());
             }
             else
             {
-                inRange = Pathfinder.CalculateEmination(StartPosition, Range);
+                inRange = StrikeTargeting.CellsInRange(Tiles, StartPosition, Request);
                 OnHighlightRange.Invoke(inRange);
                 OnHover.AddListener(Hover);
 
-                foreach(Vector3Int cell in inRange)
+                foreach (Vector3Int cell in inRange)
                 {
                     Tile tile = Tiles[cell.x, cell.z];
-                    if (tile != null)
+                    if (tile == null)
+                        continue;
+
+                    foreach (GameObject occupant in tile.Occupants)
                     {
-                        foreach(GameObject occupant in tile.Occupants)
+                        if (occupant == Character)
+                            continue;
+
+                        StrikeTargetResult result = StrikeTargeting.Evaluate(Character, occupant, Tiles, Request);
+                        if (result != null && result.IsLegal)
                             OccupantsInRange.Add(occupant);
                     }
                 }
-                OccupantsInRange.Remove(Character);
             }
         }
 
         public override void Exit()
         {
+            if (LegacySelection != null)
+                LegacySelection.Value = Selection.Value?.Target;
+
             OccupantsInRange.Clear();
             OnHover.RemoveListener(Hover);
             OnHighlightRangeEnd.Invoke();
             OnActionComplete.Invoke();
         }
+
         public override void Leftclick()
         {
+            if (HoverCell.x < 0 || HoverCell.z < 0 || HoverCell.x >= Tiles.GetLength(0) || HoverCell.z >= Tiles.GetLength(1))
+                return;
+
             Tile tile = Tiles[HoverCell.x, HoverCell.z];
-            if (tile != null && inRange.Contains(HoverCell)) // check that tile is valid and in range
+            if (tile == null || !inRange.Contains(HoverCell))
+                return;
+
+            if (tile.Occupants.Count == 0)
             {
                 OnActionConfirm.Invoke();
-                if (tile.Occupants.Count > 0)
-                    Selection.Value = tile.Occupants[0];
-
                 fsm.ChangeState(fsm.IdleState);
+                return;
             }
+
+            StrikeTargetResult result = StrikeTargeting.Evaluate(Character, tile.Occupants[0], Tiles, Request);
+            if (result == null || !result.IsLegal)
+                return;
+
+            Selection.Value = result;
+            OnActionConfirm.Invoke();
+            fsm.ChangeState(fsm.IdleState);
         }
 
         public override void Rightclick()
@@ -100,14 +127,9 @@ namespace GridPrivate
                 HoverCell = hoverList[0];
         }
 
-        /// <summary>
-        /// Used to transition to idle after a frame
-        /// Necessary to change state from state.Enter
-        /// </summary>
-        /// <returns></returns>
         protected IEnumerator ChangeToIdle()
         {
-            yield return null; // wait a frame
+            yield return null;
             fsm.ChangeState(this.fsm.IdleState);
         }
     }

--- a/Assets/Scripts/Grid/StrikeTargeting.cs
+++ b/Assets/Scripts/Grid/StrikeTargeting.cs
@@ -143,7 +143,7 @@ namespace GridPrivate
             if (!IsWithinStrikeRange(start, targetCell, request))
                 return null;
 
-            int clearRays = CountClearRays(tiles, start, targetCell);
+            int clearRays = BlocksDiagonalCorner(tiles, start, targetCell) ? 0 : CountClearRays(tiles, start, targetCell);
             GridPublic.StrikeLineOfEffect lineOfEffect = clearRays > 0
                 ? GridPublic.StrikeLineOfEffect.Clear
                 : GridPublic.StrikeLineOfEffect.Blocked;
@@ -181,6 +181,25 @@ namespace GridPrivate
                 }
             }
             return clear;
+        }
+
+        private static bool BlocksDiagonalCorner(Tile[,] tiles, Vector3Int start, Vector3Int target)
+        {
+            int dx = target.x - start.x;
+            int dz = target.z - start.z;
+            if (Mathf.Abs(dx) != 1 || Mathf.Abs(dz) != 1)
+                return false;
+
+            int stepX = dx > 0 ? 1 : -1;
+            int stepZ = dz > 0 ? 1 : -1;
+            Vector3Int sideX = new(start.x + stepX, start.y, start.z);
+            Vector3Int sideZ = new(start.x, start.y, start.z + stepZ);
+            return IsBlocking(tiles, sideX) && IsBlocking(tiles, sideZ);
+        }
+
+        private static bool IsBlocking(Tile[,] tiles, Vector3Int cell)
+        {
+            return !IsInBounds(tiles, cell) || tiles[cell.x, cell.z] == null;
         }
 
         private static bool IsRayBlocked(Tile[,] tiles, Vector3Int start, Vector3Int target, Vector2 startOffset, Vector2 targetOffset)

--- a/Assets/Scripts/Grid/StrikeTargeting.cs
+++ b/Assets/Scripts/Grid/StrikeTargeting.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GridPublic
+{
+    public enum StrikeCover
+    {
+        None,
+        Lesser,
+        Standard,
+        Greater
+    }
+
+    public enum StrikeLineOfEffect
+    {
+        Clear,
+        Blocked
+    }
+
+    public class StrikeTargetRequest
+    {
+        public int ReachFeet { get; set; } = 5;
+        public int RangeIncrementFeet { get; set; } = 0;
+        public bool IsRanged { get; set; } = false;
+        public bool RequiresLineOfEffect { get; set; } = true;
+
+        public int MaximumRangeFeet
+        {
+            get
+            {
+                if (IsRanged && RangeIncrementFeet > 0)
+                    return RangeIncrementFeet * 6;
+                return ReachFeet;
+            }
+        }
+    }
+
+    public class StrikeTargetResult
+    {
+        public GameObject Target { get; set; }
+        public int DistanceFeet { get; set; }
+        public StrikeLineOfEffect LineOfEffect { get; set; }
+        public StrikeCover Cover { get; set; }
+        public int RangePenalty { get; set; }
+
+        public int CoverAcBonus
+        {
+            get
+            {
+                return Cover switch
+                {
+                    StrikeCover.Lesser => 1,
+                    StrikeCover.Standard => 2,
+                    StrikeCover.Greater => 4,
+                    _ => 0
+                };
+            }
+        }
+
+        public bool IsLegal => Target != null && LineOfEffect == StrikeLineOfEffect.Clear;
+    }
+}
+
+namespace GridPrivate
+{
+    public static class StrikeTargeting
+    {
+        private const float CornerOffset = 0.4f;
+        private const int SamplesPerCell = 8;
+
+        private static readonly Vector2[] CornerOffsets = new[]
+        {
+            new Vector2(-CornerOffset, -CornerOffset),
+            new Vector2(CornerOffset, -CornerOffset),
+            new Vector2(-CornerOffset, CornerOffset),
+            new Vector2(CornerOffset, CornerOffset)
+        };
+
+        public static int MeasureGridDistanceFeet(Vector3Int start, Vector3Int target)
+        {
+            int dx = Mathf.Abs(target.x - start.x);
+            int dz = Mathf.Abs(target.z - start.z);
+            int diagonals = Mathf.Min(dx, dz);
+            int straight = Mathf.Max(dx, dz) - diagonals;
+            int diagonalFeet = (diagonals / 2) * 15 + (diagonals % 2) * 5;
+            return diagonalFeet + straight * 5;
+        }
+
+        public static bool IsWithinStrikeRange(Vector3Int start, Vector3Int target, GridPublic.StrikeTargetRequest request)
+        {
+            if (request == null)
+                return false;
+
+            int distance = MeasureGridDistanceFeet(start, target);
+            if (request.IsRanged)
+                return request.RangeIncrementFeet > 0 && distance <= request.RangeIncrementFeet * 6;
+            return distance <= request.ReachFeet;
+        }
+
+        public static int CalculateRangePenalty(int distanceFeet, int rangeIncrementFeet)
+        {
+            if (rangeIncrementFeet <= 0 || distanceFeet <= rangeIncrementFeet)
+                return 0;
+
+            int increment = Mathf.CeilToInt(distanceFeet / (float)rangeIncrementFeet);
+            if (increment > 6)
+                throw new ArgumentOutOfRangeException(nameof(distanceFeet), "Ranged Strikes cannot target beyond six range increments.");
+
+            return -2 * (increment - 1);
+        }
+
+        public static List<Vector3Int> CellsInRange(Tile[,] tiles, Vector3Int start, GridPublic.StrikeTargetRequest request)
+        {
+            List<Vector3Int> result = new();
+            if (tiles == null || request == null)
+                return result;
+
+            int maxCells = Mathf.CeilToInt(request.MaximumRangeFeet / 5.0f);
+            for (int x = start.x - maxCells; x <= start.x + maxCells; x++)
+            {
+                for (int z = start.z - maxCells; z <= start.z + maxCells; z++)
+                {
+                    Vector3Int cell = new(x, start.y, z);
+                    if (!IsInBounds(tiles, cell) || cell == start)
+                        continue;
+
+                    if (IsWithinStrikeRange(start, cell, request))
+                        result.Add(cell);
+                }
+            }
+            return result;
+        }
+
+        public static GridPublic.StrikeTargetResult Evaluate(GameObject attacker, GameObject target, Tile[,] tiles, GridPublic.StrikeTargetRequest request)
+        {
+            if (attacker == null || target == null || tiles == null || request == null)
+                return null;
+
+            Vector3Int start = Vector3Int.RoundToInt(attacker.transform.position);
+            Vector3Int targetCell = Vector3Int.RoundToInt(target.transform.position);
+            int distance = MeasureGridDistanceFeet(start, targetCell);
+            if (!IsWithinStrikeRange(start, targetCell, request))
+                return null;
+
+            int clearRays = CountClearRays(tiles, start, targetCell);
+            GridPublic.StrikeLineOfEffect lineOfEffect = clearRays > 0
+                ? GridPublic.StrikeLineOfEffect.Clear
+                : GridPublic.StrikeLineOfEffect.Blocked;
+
+            if (request.RequiresLineOfEffect && lineOfEffect == GridPublic.StrikeLineOfEffect.Blocked)
+                return null;
+
+            GridPublic.StrikeCover cover = GridPublic.StrikeCover.None;
+            if (request.IsRanged && clearRays > 0 && clearRays < 16)
+                cover = GridPublic.StrikeCover.Standard;
+
+            int rangePenalty = request.IsRanged
+                ? CalculateRangePenalty(distance, request.RangeIncrementFeet)
+                : 0;
+
+            return new GridPublic.StrikeTargetResult
+            {
+                Target = target,
+                DistanceFeet = distance,
+                LineOfEffect = lineOfEffect,
+                Cover = cover,
+                RangePenalty = rangePenalty
+            };
+        }
+
+        public static int CountClearRays(Tile[,] tiles, Vector3Int start, Vector3Int target)
+        {
+            int clear = 0;
+            foreach (Vector2 startOffset in CornerOffsets)
+            {
+                foreach (Vector2 targetOffset in CornerOffsets)
+                {
+                    if (!IsRayBlocked(tiles, start, target, startOffset, targetOffset))
+                        clear++;
+                }
+            }
+            return clear;
+        }
+
+        private static bool IsRayBlocked(Tile[,] tiles, Vector3Int start, Vector3Int target, Vector2 startOffset, Vector2 targetOffset)
+        {
+            Vector2 rayStart = new(start.x + 0.5f + startOffset.x, start.z + 0.5f + startOffset.y);
+            Vector2 rayEnd = new(target.x + 0.5f + targetOffset.x, target.z + 0.5f + targetOffset.y);
+            Vector2 delta = rayEnd - rayStart;
+            float distance = delta.magnitude;
+            if (distance <= Mathf.Epsilon)
+                return false;
+
+            int samples = Mathf.Max(1, Mathf.CeilToInt(distance * SamplesPerCell));
+            for (int i = 1; i < samples; i++)
+            {
+                Vector2 sample = rayStart + delta * (i / (float)samples);
+                Vector3Int cell = new(Mathf.FloorToInt(sample.x), start.y, Mathf.FloorToInt(sample.y));
+                if (cell == start || cell == target)
+                    continue;
+
+                if (!IsInBounds(tiles, cell) || tiles[cell.x, cell.z] == null)
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool IsInBounds(Tile[,] tiles, Vector3Int cell)
+        {
+            return cell.x >= 0 && cell.z >= 0 && cell.x < tiles.GetLength(0) && cell.z < tiles.GetLength(1);
+        }
+    }
+}

--- a/Assets/Scripts/Grid/StrikeTargeting.cs.meta
+++ b/Assets/Scripts/Grid/StrikeTargeting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56d281b1d8994d3a819c88492cfe34fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interfaces/GridAPI.cs
+++ b/Assets/Scripts/Interfaces/GridAPI.cs
@@ -14,15 +14,6 @@ namespace GridPublic
         public abstract IEnumerator Stride(GameObject character);
         
         /// <summary>
-        /// The given character performs a strike action
-        /// </summary>
-        /// <param name="attacker"></param>
-        /// <param name="range">of the strike</param>
-        /// <param name="target">selected target in range, null if none</param>
-        /// <returns></returns>
-        public abstract IEnumerator GetStrikeTarget(GameObject attacker, float range, CoroutineResult<GameObject> target);
-
-        /// <summary>
         /// The given character selects a target for a Strike-style action.
         /// </summary>
         /// <param name="attacker"></param>

--- a/Assets/Scripts/Interfaces/GridAPI.cs
+++ b/Assets/Scripts/Interfaces/GridAPI.cs
@@ -23,6 +23,15 @@ namespace GridPublic
         public abstract IEnumerator GetStrikeTarget(GameObject attacker, float range, CoroutineResult<GameObject> target);
 
         /// <summary>
+        /// The given character selects a target for a Strike-style action.
+        /// </summary>
+        /// <param name="attacker"></param>
+        /// <param name="request">targeting constraints for the Strike</param>
+        /// <param name="target">selected target result, null if canceled or illegal</param>
+        /// <returns></returns>
+        public abstract IEnumerator GetStrikeTarget(GameObject attacker, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> target);
+
+        /// <summary>
         /// Destroys a gameobject from the grid
         /// </summary>
         /// <param name="token">Token to remove</param>

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Game.AbilityActions;
 using Game.Creature;
 using Game.Strikes;
 using GridPrivate;
@@ -13,6 +17,7 @@ namespace TestsCombat
         [Test]
         public void NaturalTwentyAndOneAdjustDegreeByOneStep()
         {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2287
             D20Result naturalTwenty = D20.Evaluate(20, -20, 25);
             D20Result naturalOne = D20.Evaluate(1, 30, 20);
 
@@ -21,8 +26,19 @@ namespace TestsCombat
         }
 
         [Test]
+        public void D20DegreeBoundariesUseDcAndTenOverUnder()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2286
+            Assert.AreEqual(DegreeOfSuccess.CriticalFail, D20.Evaluate(1, 8, 20).degree);
+            Assert.AreEqual(DegreeOfSuccess.Fail, D20.Evaluate(10, 9, 20).degree);
+            Assert.AreEqual(DegreeOfSuccess.Success, D20.Evaluate(10, 10, 20).degree);
+            Assert.AreEqual(DegreeOfSuccess.CriticalSuccess, D20.Evaluate(20, 10, 20).degree);
+        }
+
+        [Test]
         public void GridDistanceUsesAlternatingDiagonalCosts()
         {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2357
             Assert.AreEqual(5, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(1, 0, 1)));
             Assert.AreEqual(15, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(2, 0, 2)));
             Assert.AreEqual(30, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(4, 0, 4)));
@@ -31,6 +47,7 @@ namespace TestsCombat
         [Test]
         public void RangedIncrementPenaltyCapsAtSixIncrements()
         {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2288
             Assert.AreEqual(0, StrikeTargeting.CalculateRangePenalty(60, 60));
             Assert.AreEqual(-2, StrikeTargeting.CalculateRangePenalty(65, 60));
             Assert.AreEqual(-10, StrikeTargeting.CalculateRangePenalty(360, 60));
@@ -38,8 +55,40 @@ namespace TestsCombat
         }
 
         [Test]
+        public void EvaluateEnforcesSixRangedIncrements()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2288
+            Tile[,] tiles = BuildTiles(75, 1);
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.transform.position = new Vector3(0, 0, 0);
+            target.transform.position = new Vector3(72, 0, 0);
+
+            StrikeTargetResult legal = StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = true,
+                RangeIncrementFeet = 60
+            });
+
+            Assert.IsNotNull(legal);
+            Assert.AreEqual(360, legal.DistanceFeet);
+            Assert.AreEqual(-10, legal.RangePenalty);
+
+            target.transform.position = new Vector3(73, 0, 0);
+            Assert.IsNull(StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = true,
+                RangeIncrementFeet = 60
+            }));
+
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
         public void SolidWallBlocksLineOfEffect()
         {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2372
             Tile[,] tiles = BuildTiles(5, 1);
             tiles[2, 0] = null;
             GameObject attacker = new GameObject("attacker");
@@ -61,6 +110,7 @@ namespace TestsCombat
         [Test]
         public void PartialWallGivesStandardCover()
         {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2372
             Tile[,] tiles = BuildTiles(3, 2);
             tiles[1, 0] = null;
             GameObject attacker = new GameObject("attacker");
@@ -82,6 +132,138 @@ namespace TestsCombat
         }
 
         [Test]
+        public void ClearLineHasNoCover()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2372
+            Tile[,] tiles = BuildTiles(5, 1);
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.transform.position = new Vector3(0, 0, 0);
+            target.transform.position = new Vector3(4, 0, 0);
+
+            StrikeTargetResult result = StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = true,
+                RangeIncrementFeet = 60
+            });
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StrikeCover.None, result.Cover);
+            Assert.AreEqual(0, result.CoverAcBonus);
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void BlockedCornerPreventsLineOfEffect()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2372
+            Tile[,] tiles = BuildTiles(2, 2);
+            tiles[0, 1] = null;
+            tiles[1, 0] = null;
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.transform.position = new Vector3(0, 0, 0);
+            target.transform.position = new Vector3(1, 0, 1);
+
+            StrikeTargetResult result = StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = false,
+                ReachFeet = 5
+            });
+
+            Assert.IsNull(result);
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void MultipleAttackPenaltyUsesAgileValues()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2288
+            MethodInfo method = typeof(Strike).GetMethod("CalculateMultipleAttackPenalty", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method);
+
+            Strike normal = new Strike(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>());
+            Strike agile = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+            {
+                Traits = new List<string> { "agile" }
+            };
+
+            Assert.AreEqual(0, (int)method.Invoke(normal, new object[] { 0u }));
+            Assert.AreEqual(5, (int)method.Invoke(normal, new object[] { 1u }));
+            Assert.AreEqual(10, (int)method.Invoke(normal, new object[] { 2u }));
+            Assert.AreEqual(4, (int)method.Invoke(agile, new object[] { 1u }));
+            Assert.AreEqual(8, (int)method.Invoke(agile, new object[] { 2u }));
+        }
+
+        [Test]
+        public void StrikeAttackLogIncludesMapRangePenaltyAndCoverAc()
+        {
+            // PF2e sources:
+            // Attack rolls, MAP, and range penalty: https://2e.aonprd.com/Rules.aspx?ID=2288
+            // Cover AC bonus: https://2e.aonprd.com/Rules.aspx?ID=2372
+            GameObject logObject = new GameObject("test-combat-log");
+            TestCombatLog log = InstallTestCombatLog(logObject);
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.AddComponent<TestActionController>().StrikePenalty = 1;
+            CreatureComponent attackerCreature = attacker.AddComponent<CreatureComponent>();
+            CreatureComponent targetCreature = target.AddComponent<CreatureComponent>();
+            attackerCreature.attackBonus = 7;
+            targetCreature.ac = 100;
+            targetCreature.hp = 100;
+
+            Strike strike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
+            strike.Damage(attacker, target, new StrikeTargetResult
+            {
+                Target = target,
+                LineOfEffect = StrikeLineOfEffect.Clear,
+                Cover = StrikeCover.Standard,
+                RangePenalty = -2
+            });
+
+            string attackLog = log.Messages.FirstOrDefault(message => message.StartsWith("Attack:", StringComparison.Ordinal));
+            Assert.IsNotNull(attackLog);
+            StringAssert.Contains("AC: 102 (100 + 2 cover)", attackLog);
+            StringAssert.Contains("+ 7 - 5 -2", attackLog);
+
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+            UnityEngine.Object.DestroyImmediate(logObject);
+        }
+
+        [Test]
+        public void DeadlyTraitAddsExtraDieOnlyOnCritical()
+        {
+            // PF2e sources:
+            // Strike critical damage: https://2e.aonprd.com/Rules.aspx?ID=2343
+            // Deadly trait: https://2e.aonprd.com/Traits.aspx?ID=570
+            GameObject logObject = new GameObject("test-combat-log");
+            InstallTestCombatLog(logObject);
+            MethodInfo method = typeof(Strike).GetMethod("ApplyDeadlyDamage", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method);
+
+            Strike strike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+            {
+                Traits = new List<string> { "deadly-d10" }
+            };
+            List<DamageValue> normalDamage = new() { new DamageValue("piercing", 6) };
+            List<DamageValue> criticalDamage = new() { new DamageValue("piercing", 12) };
+            UnityEngine.Random.State randomState = UnityEngine.Random.state;
+            UnityEngine.Random.InitState(76);
+
+            method.Invoke(strike, new object[] { DegreeOfSuccess.Success, normalDamage });
+            method.Invoke(strike, new object[] { DegreeOfSuccess.CriticalSuccess, criticalDamage });
+
+            UnityEngine.Random.state = randomState;
+            Assert.AreEqual(6, normalDamage[0].DamageAmount);
+            Assert.Greater(criticalDamage[0].DamageAmount, 12);
+            Assert.LessOrEqual(criticalDamage[0].DamageAmount, 22);
+            UnityEngine.Object.DestroyImmediate(logObject);
+        }
+
+        [Test]
         public void AmmoAndReloadStateAreEnforced()
         {
             GameObject creature = new GameObject("archer");
@@ -100,6 +282,42 @@ namespace TestsCombat
             Assert.IsTrue(component.ReloadWeapon(sling));
             Assert.IsTrue(component.IsWeaponLoaded(sling));
             UnityEngine.Object.DestroyImmediate(creature);
+        }
+
+        [Test]
+        public void CreatureJsonImportsRangedWeaponBonusAmmoAndReload()
+        {
+            GameObject goblin = CreatureJsonConverter.CreateFromFile("DataFiles/pathfinder-monster-core/goblin-warrior");
+            Assert.IsNotNull(goblin);
+            CreatureComponent component = goblin.GetComponent<CreatureComponent>();
+            EquipmentWeapon shortbow = component.weapons.FirstOrDefault(weapon => weapon.name == "Shortbow");
+
+            Assert.IsNotNull(shortbow);
+            Assert.AreEqual(60, shortbow.range);
+            Assert.AreEqual("0", shortbow.reload);
+            Assert.AreEqual("arrows", shortbow.ammo);
+            Assert.AreEqual(10, component.GetAmmoQuantity("arrows"));
+            Assert.AreEqual(7, component.GetAttackBonusForWeapon(shortbow));
+
+            UnityEngine.Object.DestroyImmediate(goblin);
+        }
+
+        [Test]
+        public void WeaponStrikeAdderAutomaticAddsRangedAndReloadActionsWithoutDuplicates()
+        {
+            GameObject kobold = CreatureJsonConverter.CreateFromFile("DataFiles/pathfinder-monster-core/kobold-warrior");
+            Assert.IsNotNull(kobold);
+            kobold.AddComponent<TestActionController>();
+
+            StrikeWeapon.WeaponStrikeAdderAutomatic(kobold);
+            StrikeWeapon.WeaponStrikeAdderAutomatic(kobold);
+
+            List<EntityAction> actions = kobold.GetComponent<ActionController>().GetActions();
+            Assert.AreEqual(1, actions.OfType<StrikeWeapon>().Count(action => action.ActionName == "Sling"));
+            Assert.AreEqual(1, actions.Count(action => action.ActionName == "Reload Sling"));
+            Assert.AreEqual(20, kobold.GetComponent<CreatureComponent>().GetAmmoQuantity("sling-bullets"));
+
+            UnityEngine.Object.DestroyImmediate(kobold);
         }
 
         [Test]
@@ -125,6 +343,17 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(creature);
         }
 
+        [Test]
+        public void RageDamageIgnoresProjectileStrikeWithoutMeleeFlatDamage()
+        {
+            // PF2e source for Rage applying additional damage only to melee Strikes: https://2e.aonprd.com/Actions.aspx?ID=2802
+            Strike projectileStrike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
+            Rage rage = new Rage(1);
+
+            Assert.DoesNotThrow(() => rage.AddRageDamage(projectileStrike));
+            Assert.AreEqual(0, projectileStrike.FlatDamages.Count);
+        }
+
         private static Tile[,] BuildTiles(int width, int height)
         {
             Tile[,] tiles = new Tile[width, height];
@@ -134,6 +363,37 @@ namespace TestsCombat
                     tiles[x, z] = new Tile();
             }
             return tiles;
+        }
+
+        private static TestCombatLog InstallTestCombatLog(GameObject logObject)
+        {
+            TestCombatLog log = logObject.AddComponent<TestCombatLog>();
+            FieldInfo field = typeof(SingletonMonoBehaviour<CombatLogInterface>).GetField("Instance", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(field);
+            field.SetValue(null, log);
+            return log;
+        }
+
+        private class TestActionController : ActionController
+        {
+            public override void EndTurn() { }
+        }
+
+        private class TestCombatLog : CombatLogInterface
+        {
+            public readonly List<string> Messages = new();
+
+            public override void DevMode() { }
+            public override void ReleaseMode() { }
+            public override void AddWhiteList(string tag) { }
+            public override void AddBlackList(string tag) { }
+            public override void DevLog(string msg) => Messages.Add(msg);
+            public override void DevLog(string msg, string tag) => Messages.Add(msg);
+            public override void DevLog(string msg, List<string> tags) => Messages.Add(msg);
+            public override void Log(string msg) => Messages.Add(msg);
+            public override void Log(string msg, string tag) => Messages.Add(msg);
+            public override void Log(string msg, List<string> tags) => Messages.Add(msg);
+            public override List<string> GetMessages() => new(Messages);
         }
     }
 }

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -1,0 +1,139 @@
+using System;
+using Game.Creature;
+using Game.Strikes;
+using GridPrivate;
+using GridPublic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestsCombat
+{
+    public class Pf2eRangedStrikeTests
+    {
+        [Test]
+        public void NaturalTwentyAndOneAdjustDegreeByOneStep()
+        {
+            D20Result naturalTwenty = D20.Evaluate(20, -20, 25);
+            D20Result naturalOne = D20.Evaluate(1, 30, 20);
+
+            Assert.AreEqual(DegreeOfSuccess.Fail, naturalTwenty.degree);
+            Assert.AreEqual(DegreeOfSuccess.Success, naturalOne.degree);
+        }
+
+        [Test]
+        public void GridDistanceUsesAlternatingDiagonalCosts()
+        {
+            Assert.AreEqual(5, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(1, 0, 1)));
+            Assert.AreEqual(15, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(2, 0, 2)));
+            Assert.AreEqual(30, StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.zero, new Vector3Int(4, 0, 4)));
+        }
+
+        [Test]
+        public void RangedIncrementPenaltyCapsAtSixIncrements()
+        {
+            Assert.AreEqual(0, StrikeTargeting.CalculateRangePenalty(60, 60));
+            Assert.AreEqual(-2, StrikeTargeting.CalculateRangePenalty(65, 60));
+            Assert.AreEqual(-10, StrikeTargeting.CalculateRangePenalty(360, 60));
+            Assert.Throws<ArgumentOutOfRangeException>(() => StrikeTargeting.CalculateRangePenalty(365, 60));
+        }
+
+        [Test]
+        public void SolidWallBlocksLineOfEffect()
+        {
+            Tile[,] tiles = BuildTiles(5, 1);
+            tiles[2, 0] = null;
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.transform.position = new Vector3(0, 0, 0);
+            target.transform.position = new Vector3(4, 0, 0);
+
+            StrikeTargetResult result = StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = true,
+                RangeIncrementFeet = 60
+            });
+
+            Assert.IsNull(result);
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void PartialWallGivesStandardCover()
+        {
+            Tile[,] tiles = BuildTiles(3, 2);
+            tiles[1, 0] = null;
+            GameObject attacker = new GameObject("attacker");
+            GameObject target = new GameObject("target");
+            attacker.transform.position = new Vector3(0, 0, 0);
+            target.transform.position = new Vector3(2, 0, 1);
+
+            StrikeTargetResult result = StrikeTargeting.Evaluate(attacker, target, tiles, new StrikeTargetRequest
+            {
+                IsRanged = true,
+                RangeIncrementFeet = 60
+            });
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StrikeCover.Standard, result.Cover);
+            Assert.AreEqual(2, result.CoverAcBonus);
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void AmmoAndReloadStateAreEnforced()
+        {
+            GameObject creature = new GameObject("archer");
+            CreatureComponent component = creature.AddComponent<CreatureComponent>();
+            EquipmentWeapon sling = new EquipmentWeapon { name = "Sling", range = 50, reload = "1", ammo = "sling-bullets", damage = new Dice(1, 6, "bludgeoning") };
+
+            component.SetAmmoQuantity("Sling Bullets", 2);
+
+            Assert.IsTrue(component.HasAmmoFor(sling));
+            Assert.IsTrue(component.IsWeaponLoaded(sling));
+            Assert.IsTrue(component.ConsumeAmmoFor(sling));
+            Assert.AreEqual(1, component.GetAmmoQuantity("sling-bullets"));
+
+            component.MarkWeaponFired(sling);
+            Assert.IsFalse(component.IsWeaponLoaded(sling));
+            Assert.IsTrue(component.ReloadWeapon(sling));
+            Assert.IsTrue(component.IsWeaponLoaded(sling));
+            UnityEngine.Object.DestroyImmediate(creature);
+        }
+
+        [Test]
+        public void ProjectileRangedWeaponDoesNotAddMeleeFlatDamage()
+        {
+            GameObject creature = new GameObject("archer");
+            CreatureComponent component = creature.AddComponent<CreatureComponent>();
+            component.damageBonus = 4;
+            EquipmentWeapon shortbow = new EquipmentWeapon
+            {
+                name = "Shortbow",
+                range = 60,
+                reload = "0",
+                ammo = "arrows",
+                damage = new Dice(1, 6, "piercing"),
+                traits = new System.Collections.Generic.List<string> { "deadly-d10" }
+            };
+
+            StrikeWeapon action = new StrikeWeapon(1, shortbow, creature);
+
+            Assert.AreEqual(0, action.GetStrike().FlatDamages.Count);
+            Assert.AreEqual(3.5f, action.GetStrike().GetAvgDmg());
+            UnityEngine.Object.DestroyImmediate(creature);
+        }
+
+        private static Tile[,] BuildTiles(int width, int height)
+        {
+            Tile[,] tiles = new Tile[width, height];
+            for (int x = 0; x < width; x++)
+            {
+                for (int z = 0; z < height; z++)
+                    tiles[x, z] = new Tile();
+            }
+            return tiles;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs.meta
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86298d12d39d42918f6f9f989559c0c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs
@@ -1,0 +1,97 @@
+using System.Collections;
+using Game.Creature;
+using Game.Strikes;
+using GridPrivate;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestsState
+{
+    public class RangedStrikeAiTests : PlayModeBase
+    {
+        [UnityTest]
+        public IEnumerator EnemyCanChooseLegalRangedStrike()
+        {
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+
+            GameObject target = null;
+            foreach (GameObject combatant in CombatManagerInterface.GetInstance().GetCombatants())
+            {
+                if (target == null && combatant.GetComponent<PlayerActionController>() != null)
+                    target = combatant;
+            }
+
+            Assert.IsNotNull(target, "Expected a player target in UnitTestingScene.");
+
+            GameObject enemy = new GameObject("ranged-ai-test-enemy");
+            enemy.SetActive(false);
+            Team enemyTeam = enemy.AddComponent<Team>();
+            enemyTeam.Name = "Ranged AI Test Enemies";
+            enemy.AddComponent<CreatureComponent>();
+            enemy.AddComponent<MindlessController>();
+            TeamRules rules = TeamRules.GetInstance();
+            if (!rules.Contains(enemyTeam.Name))
+            {
+                rules.AddHostileTeam(enemyTeam.Name);
+                rules.OneWayFriendly(enemyTeam.Name, enemyTeam.Name);
+            }
+            enemy.SetActive(true);
+
+            PlaceOnClearLine(tiles, enemy, target);
+
+            CreatureComponent enemyCreature = enemy.GetComponent<CreatureComponent>();
+            EquipmentWeapon shortbow = new EquipmentWeapon
+            {
+                name = "Shortbow",
+                range = 60,
+                reload = "0",
+                ammo = "arrows",
+                damage = new Dice(1, 6, "piercing"),
+                traits = new System.Collections.Generic.List<string> { "deadly-d10" }
+            };
+            enemyCreature.SetAmmoQuantity("arrows", 1);
+            enemy.GetComponent<ActionController>().AddAction(new StrikeWeapon(1, shortbow, enemy));
+
+            MindlessController controller = enemy.GetComponent<MindlessController>();
+            controller.StartTurn();
+            controller.StopAllCoroutines();
+            EntityAction selected = controller.MindlessDecision();
+
+            Assert.IsInstanceOf<StrikeWeapon>(selected);
+            Assert.AreEqual("Shortbow", selected.ActionName);
+        }
+
+        private static void PlaceOnClearLine(Tile[,] tiles, GameObject enemy, GameObject target)
+        {
+            for (int z = 0; z < tiles.GetLength(1); z++)
+            {
+                for (int x = 0; x < tiles.GetLength(0) - 4; x++)
+                {
+                    bool clear = true;
+                    for (int offset = 0; offset <= 4; offset++)
+                    {
+                        if (tiles[x + offset, z] == null)
+                        {
+                            clear = false;
+                            break;
+                        }
+                    }
+
+                    if (!clear)
+                        continue;
+
+                    enemy.transform.position = new Vector3(x, 0, z);
+                    target.transform.position = new Vector3(x + 4, 0, z);
+                    return;
+                }
+            }
+
+            Assert.Fail("Could not find a clear line for ranged Strike AI test.");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs
@@ -1,10 +1,12 @@
 using System.Collections;
+using System.Collections.Generic;
 using Game.Creature;
 using Game.Strikes;
 using GridPrivate;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.UIElements;
 
 namespace TestsState
 {
@@ -18,44 +20,9 @@ namespace TestsState
             GridBase grid = Object.FindFirstObjectByType<GridBase>();
             Assert.IsNotNull(grid);
             Tile[,] tiles = grid.GetTiles();
-
-            GameObject target = null;
-            foreach (GameObject combatant in CombatManagerInterface.GetInstance().GetCombatants())
-            {
-                if (target == null && combatant.GetComponent<PlayerActionController>() != null)
-                    target = combatant;
-            }
-
-            Assert.IsNotNull(target, "Expected a player target in UnitTestingScene.");
-
-            GameObject enemy = new GameObject("ranged-ai-test-enemy");
-            enemy.SetActive(false);
-            Team enemyTeam = enemy.AddComponent<Team>();
-            enemyTeam.Name = "Ranged AI Test Enemies";
-            enemy.AddComponent<CreatureComponent>();
-            enemy.AddComponent<MindlessController>();
-            TeamRules rules = TeamRules.GetInstance();
-            if (!rules.Contains(enemyTeam.Name))
-            {
-                rules.AddHostileTeam(enemyTeam.Name);
-                rules.OneWayFriendly(enemyTeam.Name, enemyTeam.Name);
-            }
-            enemy.SetActive(true);
-
+            GameObject target = FindPlayerTarget();
+            GameObject enemy = CreateRangedEnemy("ranged-ai-test-enemy", CreateShortbow(), 1, 7);
             PlaceOnClearLine(tiles, enemy, target);
-
-            CreatureComponent enemyCreature = enemy.GetComponent<CreatureComponent>();
-            EquipmentWeapon shortbow = new EquipmentWeapon
-            {
-                name = "Shortbow",
-                range = 60,
-                reload = "0",
-                ammo = "arrows",
-                damage = new Dice(1, 6, "piercing"),
-                traits = new System.Collections.Generic.List<string> { "deadly-d10" }
-            };
-            enemyCreature.SetAmmoQuantity("arrows", 1);
-            enemy.GetComponent<ActionController>().AddAction(new StrikeWeapon(1, shortbow, enemy));
 
             MindlessController controller = enemy.GetComponent<MindlessController>();
             controller.StartTurn();
@@ -66,16 +33,286 @@ namespace TestsState
             Assert.AreEqual("Shortbow", selected.ActionName);
         }
 
-        private static void PlaceOnClearLine(Tile[,] tiles, GameObject enemy, GameObject target)
+        [UnityTest]
+        public IEnumerator EnemyExecutesLegalRangedStrikeConsumesAmmoAndDamagesTarget()
+        {
+            // PF2e source for Strike as a one-action ranged attack: https://2e.aonprd.com/Rules.aspx?ID=2343
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+            GameObject target = FindPlayerTarget();
+            GameObject enemy = CreateRangedEnemy("ranged-ai-execute-test-enemy", CreateShortbow(), 1, 100);
+            PlaceOnClearLine(tiles, enemy, target);
+            Vector3 startingPosition = enemy.transform.position;
+
+            MindlessController controller = enemy.GetComponent<MindlessController>();
+            controller.StartTurn();
+            controller.StopAllCoroutines();
+            EntityAction selected = controller.MindlessDecision();
+            Assert.IsInstanceOf<StrikeWeapon>(selected);
+            CreatureComponent selectedTargetCreature = PrepareDurableTarget(controller.BestTarget);
+
+            UnityEngine.Random.State randomState = UnityEngine.Random.state;
+            UnityEngine.Random.InitState(7602);
+            controller.TakeAction(selected);
+            yield return WaitUntilWithTimeout(timeout, () => !controller.IsTakingAction);
+            UnityEngine.Random.state = randomState;
+
+            Assert.AreEqual(startingPosition, enemy.transform.position, "Ranged AI should not move when it can Strike from its current cell.");
+            Assert.AreEqual(2u, controller.ActionPoints);
+            Assert.AreEqual(1u, controller.StrikePenalty);
+            Assert.AreEqual(0, enemy.GetComponent<CreatureComponent>().GetAmmoQuantity("arrows"));
+            Assert.Less(selectedTargetCreature.hp, 100);
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerRangedStrikeButtonExecutesAndConsumesAmmo()
+        {
+            // PF2e source for Strike as a one-action ranged attack: https://2e.aonprd.com/Rules.aspx?ID=2343
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+            GameObject player = null;
+            yield return WaitForCurrentPlayerTurn(value => player = value);
+            GameObject target = FindHostileTarget(player);
+            CreatureComponent targetCreature = PrepareDurableTarget(target);
+            SetupRangedAction(player, CreateShortbow(), 1, 100);
+            PlaceOnClearLine(tiles, player, target);
+            OnNextTurn.Invoke(player);
+
+            Button shortbowButton = null;
+            yield return WaitUntilWithTimeout(timeout, () =>
+            {
+                shortbowButton = root.Q<Button>("ShortbowButton");
+                return shortbowButton != null;
+            });
+            Assert.IsNotNull(shortbowButton, "Shortbow action button was not created for the player.");
+
+            PushButton(shortbowButton);
+            yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateStrike);
+            Assert.IsTrue(grid.Fsm.CurrentState is StateStrike);
+
+            Vector3Int targetCell = Vector3Int.RoundToInt(target.transform.position);
+            OnHover.Invoke(new List<Vector3Int> { targetCell });
+
+            ActionController controller = player.GetComponent<ActionController>();
+            UnityEngine.Random.State randomState = UnityEngine.Random.state;
+            UnityEngine.Random.InitState(7603);
+            grid.Fsm.CurrentState.Leftclick();
+            yield return WaitUntilWithTimeout(timeout, () => !controller.IsTakingAction && grid.Fsm.CurrentState is StateIdle);
+            UnityEngine.Random.state = randomState;
+
+            Assert.IsTrue(grid.Fsm.CurrentState is StateIdle);
+            Assert.AreEqual(2u, controller.ActionPoints);
+            Assert.AreEqual(1u, controller.StrikePenalty);
+            Assert.AreEqual(0, player.GetComponent<CreatureComponent>().GetAmmoQuantity("arrows"));
+            Assert.Less(targetCreature.hp, 100);
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerRangedStrikeBlockedByWallDoesNotConsumeActionOrAmmo()
+        {
+            // PF2e source for cover and blocked line of effect: https://2e.aonprd.com/Rules.aspx?ID=2372
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+            GameObject player = null;
+            yield return WaitForCurrentPlayerTurn(value => player = value);
+            GameObject target = FindHostileTarget(player);
+            CreatureComponent targetCreature = PrepareDurableTarget(target);
+            SetupRangedAction(player, CreateShortbow(), 1, 100);
+            FindEmptyStraightLine(tiles, 5, out Vector3Int playerCell, out Vector3Int targetCell);
+            MoveCombatant(tiles, player, playerCell);
+            MoveCombatant(tiles, target, targetCell);
+            tiles[playerCell.x + 2, playerCell.z] = null;
+            OnNextTurn.Invoke(player);
+
+            Button shortbowButton = null;
+            yield return WaitUntilWithTimeout(timeout, () =>
+            {
+                shortbowButton = root.Q<Button>("ShortbowButton");
+                return shortbowButton != null;
+            });
+            Assert.IsNotNull(shortbowButton, "Shortbow action button was not created for the player.");
+
+            PushButton(shortbowButton);
+            yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateStrike);
+            OnHover.Invoke(new List<Vector3Int> { targetCell });
+            grid.Fsm.CurrentState.Leftclick();
+            yield return null;
+
+            ActionController controller = player.GetComponent<ActionController>();
+            Assert.IsTrue(grid.Fsm.CurrentState is StateStrike, "Blocked line of effect should leave targeting active.");
+            Assert.AreEqual(3u, controller.ActionPoints);
+            Assert.AreEqual(0u, controller.StrikePenalty);
+            Assert.AreEqual(1, player.GetComponent<CreatureComponent>().GetAmmoQuantity("arrows"));
+            Assert.AreEqual(100, targetCreature.hp);
+        }
+
+        [UnityTest]
+        public IEnumerator ReloadActionRestoresLoadedStateAndCostsActionPoint()
+        {
+            // Reload cost is driven by imported weapon data; the action consumes that many action points.
+            yield return base.Setup();
+
+            GameObject player = null;
+            yield return WaitForCurrentPlayerTurn(value => player = value);
+            ActionController controller = player.GetComponent<ActionController>();
+            CreatureComponent creature = player.GetComponent<CreatureComponent>();
+            EquipmentWeapon sling = CreateSling();
+            creature.SetAmmoQuantity("sling-bullets", 2);
+            creature.MarkWeaponFired(sling);
+            Assert.IsFalse(creature.IsWeaponLoaded(sling));
+
+            controller.StartTurn();
+            uint startingActionPoints = controller.ActionPoints;
+            ReloadWeaponAction reload = new ReloadWeaponAction(1, sling);
+            controller.TakeAction(reload);
+            yield return null;
+
+            Assert.IsTrue(creature.IsWeaponLoaded(sling));
+            Assert.AreEqual(startingActionPoints - reload.ActionCost, controller.ActionPoints);
+            Assert.IsFalse(controller.IsTakingAction);
+        }
+
+        private IEnumerator WaitForCurrentPlayerTurn(System.Action<GameObject> assign)
+        {
+            GameObject current = null;
+            yield return WaitUntilWithTimeout(timeout, () =>
+            {
+                try
+                {
+                    current = CombatManagerInterface.GetInstance().WhosTurn();
+                }
+                catch (System.NullReferenceException)
+                {
+                    current = null;
+                }
+
+                return current != null && current.GetComponent<PlayerActionController>() != null;
+            });
+
+            Assert.IsNotNull(current, "Expected an active player turn in UnitTestingScene.");
+            assign(current);
+        }
+
+        private static GameObject FindPlayerTarget()
+        {
+            foreach (GameObject combatant in CombatManagerInterface.GetInstance().GetCombatants())
+            {
+                if (combatant.GetComponent<PlayerActionController>() != null)
+                    return combatant;
+            }
+
+            Assert.Fail("Expected a player target in UnitTestingScene.");
+            return null;
+        }
+
+        private static GameObject FindHostileTarget(GameObject actor)
+        {
+            string actorTeam = actor.GetComponent<Team>().Name;
+            foreach (GameObject combatant in CombatManagerInterface.GetInstance().GetCombatants())
+            {
+                if (combatant == actor)
+                    continue;
+
+                Team team = combatant.GetComponent<Team>();
+                if (team != null && !TeamRules.GetInstance().IsFriendly(actorTeam, team.Name))
+                    return combatant;
+            }
+
+            Assert.Fail("Expected a hostile target in UnitTestingScene.");
+            return null;
+        }
+
+        private static GameObject CreateRangedEnemy(string name, EquipmentWeapon weapon, int ammo, int attackBonus)
+        {
+            GameObject enemy = new GameObject(name);
+            enemy.SetActive(false);
+            Team enemyTeam = enemy.AddComponent<Team>();
+            enemyTeam.Name = "Ranged AI Test Enemies";
+            CreatureComponent enemyCreature = enemy.AddComponent<CreatureComponent>();
+            enemyCreature.attackBonus = attackBonus;
+            enemy.AddComponent<MindlessController>();
+            TeamRules rules = TeamRules.GetInstance();
+            if (!rules.Contains(enemyTeam.Name))
+            {
+                rules.AddHostileTeam(enemyTeam.Name);
+                rules.OneWayFriendly(enemyTeam.Name, enemyTeam.Name);
+            }
+            enemy.SetActive(true);
+            SetupRangedAction(enemy, weapon, ammo, attackBonus);
+            return enemy;
+        }
+
+        private static void SetupRangedAction(GameObject actor, EquipmentWeapon weapon, int ammo, int attackBonus)
+        {
+            CreatureComponent creature = actor.GetComponent<CreatureComponent>();
+            creature.attackBonus = attackBonus;
+            creature.SetAmmoQuantity(weapon.ammo, ammo);
+            actor.GetComponent<ActionController>().AddAction(new StrikeWeapon(1, weapon, actor));
+        }
+
+        private static CreatureComponent PrepareDurableTarget(GameObject target)
+        {
+            Assert.IsNotNull(target);
+            CreatureComponent creature = target.GetComponent<CreatureComponent>();
+            creature.maxHp = 100;
+            creature.hp = 100;
+            creature.ac = 1;
+            return creature;
+        }
+
+        private static EquipmentWeapon CreateShortbow()
+        {
+            return new EquipmentWeapon
+            {
+                name = "Shortbow",
+                range = 60,
+                reload = "0",
+                ammo = "arrows",
+                damage = new Dice(1, 6, "piercing"),
+                traits = new List<string> { "deadly-d10" }
+            };
+        }
+
+        private static EquipmentWeapon CreateSling()
+        {
+            return new EquipmentWeapon
+            {
+                name = "Sling",
+                range = 50,
+                reload = "1",
+                ammo = "sling-bullets",
+                damage = new Dice(1, 6, "bludgeoning"),
+                traits = new List<string> { "propulsive" }
+            };
+        }
+
+        private static void PlaceOnClearLine(Tile[,] tiles, GameObject attacker, GameObject target)
+        {
+            FindEmptyStraightLine(tiles, 5, out Vector3Int attackerCell, out Vector3Int targetCell);
+            MoveCombatant(tiles, attacker, attackerCell);
+            MoveCombatant(tiles, target, targetCell);
+        }
+
+        private static void FindEmptyStraightLine(Tile[,] tiles, int length, out Vector3Int start, out Vector3Int target)
         {
             for (int z = 0; z < tiles.GetLength(1); z++)
             {
-                for (int x = 0; x < tiles.GetLength(0) - 4; x++)
+                for (int x = 0; x <= tiles.GetLength(0) - length; x++)
                 {
                     bool clear = true;
-                    for (int offset = 0; offset <= 4; offset++)
+                    for (int offset = 0; offset < length; offset++)
                     {
-                        if (tiles[x + offset, z] == null)
+                        Tile tile = tiles[x + offset, z];
+                        if (tile == null || tile.Occupants.Count > 0)
                         {
                             clear = false;
                             break;
@@ -85,13 +322,29 @@ namespace TestsState
                     if (!clear)
                         continue;
 
-                    enemy.transform.position = new Vector3(x, 0, z);
-                    target.transform.position = new Vector3(x + 4, 0, z);
+                    start = new Vector3Int(x, 0, z);
+                    target = new Vector3Int(x + length - 1, 0, z);
                     return;
                 }
             }
 
-            Assert.Fail("Could not find a clear line for ranged Strike AI test.");
+            Assert.Fail("Could not find a clear line in UnitTestingScene.");
+            start = Vector3Int.zero;
+            target = Vector3Int.zero;
+        }
+
+        private static void MoveCombatant(Tile[,] tiles, GameObject combatant, Vector3Int cell)
+        {
+            for (int z = 0; z < tiles.GetLength(1); z++)
+            {
+                for (int x = 0; x < tiles.GetLength(0); x++)
+                    tiles[x, z]?.Occupants.Remove(combatant);
+            }
+
+            Assert.IsNotNull(tiles[cell.x, cell.z]);
+            combatant.transform.position = new Vector3(cell.x, cell.y, cell.z);
+            if (!tiles[cell.x, cell.z].Occupants.Contains(combatant))
+                tiles[cell.x, cell.z].Occupants.Add(combatant);
         }
     }
 }

--- a/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs.meta
+++ b/Assets/Tests/PlayMode/TestsState/RangedStrikeAiTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f39e424fc27483d82ede49a55bf9cb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #76.

## Summary
- Add Strike targeting requests/results with PF2e grid distance, range increments, line of effect, and cover.
- Add ranged weapon Strike actions, action-specific attack bonuses, ammo/reload state, ranged damage handling, and deadly-d10 critical damage.
- Update AI to choose legal ranged Strikes before moving adjacent.

## Tests
- Unity EditMode: 8/8 passed.
- Unity PlayMode: 25/25 passed.