### PR TITLE
Add github workflow skill

### DIFF
--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: github-workflow
+description: Work with GitHub issues, pull requests, PR descriptions, issue comments, inline PR review comments, review-comment replies, and gists through safer Python wrappers around the gh CLI. Use when Codex needs to create or update issues, post or edit comments, reply to PR review comments, update PR bodies, fetch comments, or upload temporary review assets while avoiding PowerShell quoting, JSON, and Hashtable string-conversion problems.
+---
+
+# GitHub Workflow
+
+Use this skill for GitHub operations where multiline text, JSON payloads, review-thread replies, or PowerShell quoting could corrupt the request. Prefer the bundled Python scripts over direct `gh` calls for comments, PR bodies, issue bodies, and review replies.
+
+## Rules
+
+- Use markdown body files for all comment, issue, and PR body text. Do not pass multiline bodies inline through PowerShell.
+- Run mutating commands with `--dry-run` first unless the user explicitly asks for the write and the payload is already reviewed.
+- Keep authentication delegated to `gh`; these scripts call `gh api` and do not manage tokens.
+- Distinguish comment types:
+  - Issue comments and PR conversation comments use `/repos/{owner}/{repo}/issues/{number}/comments`.
+  - Inline PR review comments use `/repos/{owner}/{repo}/pulls/{pull_number}/comments`.
+  - Replies to inline review comments use `/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
+  - Editing inline review comments uses `/repos/{owner}/{repo}/pulls/comments/{comment_id}`.
+- Use `gh-issue-capture` as well when the task is to create a durable follow-up issue that should follow this repo's issue schema.
+
+## Scripts
+
+All scripts live in `scripts/` and accept `--repo owner/name`. They print GitHub API output for live calls and a structured plan for `--dry-run` calls.
+
+### Issues
+
+```powershell
+python .agents/skills/github-workflow/scripts/gh_issue.py create --repo silvertreestudios/sdmay26-02 --title "[Area] Title" --body-file C:\tmp\issue.md --label "type: bug" --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py update --repo silvertreestudios/sdmay26-02 --issue 76 --body-file C:\tmp\issue.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py comment --repo silvertreestudios/sdmay26-02 --issue 76 --body-file C:\tmp\comment.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py list-comments --repo silvertreestudios/sdmay26-02 --issue 76
+```
+
+### Pull Requests
+
+```powershell
+python .agents/skills/github-workflow/scripts/gh_pr.py update-body --repo silvertreestudios/sdmay26-02 --pr 123 --body-file C:\tmp\pr-body.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_pr.py comment --repo silvertreestudios/sdmay26-02 --pr 123 --body-file C:\tmp\comment.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_pr.py list-comments --repo silvertreestudios/sdmay26-02 --pr 123
+```
+
+### Inline PR Review Comments
+
+```powershell
+python .agents/skills/github-workflow/scripts/gh_review_comments.py list --repo silvertreestudios/sdmay26-02 --pr 123
+python .agents/skills/github-workflow/scripts/gh_review_comments.py reply --repo silvertreestudios/sdmay26-02 --pr 123 --comment-id 456789 --body-file C:\tmp\reply.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_review_comments.py update --repo silvertreestudios/sdmay26-02 --comment-id 456789 --body-file C:\tmp\reply.md --dry-run
+```
+
+### Gists
+
+Use gists for temporary review artifacts that do not belong in the PR branch. Prefer committed files or PR screenshots when the artifact is part of the work product.
+
+```powershell
+python .agents/skills/github-workflow/scripts/gh_gist.py create --description "PR 123 screenshots" --file C:\tmp\screen.png --dry-run
+```
+
+## Verification
+
+When changing this skill, run:
+
+```powershell
+python C:\Users\Josh\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents/skills/github-workflow
+python -c "from pathlib import Path; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in Path('.agents/skills/github-workflow/scripts').glob('*.py')]"
+python .agents/skills/github-workflow/scripts/gh_issue.py --help
+python .agents/skills/github-workflow/scripts/gh_pr.py --help
+python .agents/skills/github-workflow/scripts/gh_review_comments.py --help
+python .agents/skills/github-workflow/scripts/gh_gist.py --help
+```

--- a/.agents/skills/github-workflow/agents/openai.yaml
+++ b/.agents/skills/github-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Workflow"
+  short_description: "Safer gh workflows for issues and PRs"
+  default_prompt: "Use $github-workflow to handle GitHub issue, PR, review comment, or gist operations safely."

--- a/.agents/skills/github-workflow/scripts/gh_common.py
+++ b/.agents/skills/github-workflow/scripts/gh_common.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2022-11-28"
+
+
+def add_repo_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", required=True, help="Repository in owner/name form.")
+
+
+def add_body_file_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--body-file",
+        required=True,
+        help="Path to a UTF-8 markdown/text file. Use '-' to read from stdin.",
+    )
+
+
+def add_dry_run_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned request without calling GitHub.")
+
+
+def parse_repo(repo: str) -> tuple[str, str]:
+    parts = repo.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise SystemExit("--repo must be in owner/name form")
+    return parts[0], parts[1]
+
+
+def repo_path(repo: str) -> str:
+    owner, name = parse_repo(repo)
+    return f"/repos/{owner}/{name}"
+
+
+def read_body(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def require_gh() -> None:
+    if shutil.which("gh") is None:
+        raise SystemExit("GitHub CLI 'gh' was not found on PATH")
+
+
+def print_plan(method: str, endpoint: str, payload: dict[str, Any] | None, paginate: bool = False) -> int:
+    plan = {
+        "dry_run": True,
+        "method": method,
+        "endpoint": endpoint,
+        "paginate": paginate,
+        "payload": payload,
+    }
+    print(json.dumps(plan, indent=2, ensure_ascii=False))
+    return 0
+
+
+def gh_api(
+    endpoint: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+    paginate: bool = False,
+    dry_run: bool = False,
+) -> int:
+    method = method.upper()
+    if dry_run:
+        return print_plan(method, endpoint, payload, paginate)
+
+    require_gh()
+    args = [
+        "gh",
+        "api",
+        endpoint,
+        "--method",
+        method,
+        "--header",
+        "Accept: application/vnd.github+json",
+        "--header",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+    ]
+    if paginate:
+        args.append("--paginate")
+
+    stdin = None
+    if payload is not None:
+        args.extend(["--input", "-"])
+        stdin = json.dumps(payload, ensure_ascii=False)
+
+    completed = subprocess.run(args, input=stdin, text=True, check=False)
+    return completed.returncode
+
+
+def gh_command(args: list[str], *, dry_run: bool = False) -> int:
+    if dry_run:
+        print(json.dumps({"dry_run": True, "command": args}, indent=2, ensure_ascii=False))
+        return 0
+
+    require_gh()
+    completed = subprocess.run(args, text=True, check=False)
+    return completed.returncode

--- a/.agents/skills/github-workflow/scripts/gh_gist.py
+++ b/.agents/skills/github-workflow/scripts/gh_gist.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from gh_common import add_dry_run_argument, gh_command
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create GitHub gists with gh while keeping arguments predictable.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="Create a secret gist by default.")
+    create.add_argument("--description", default="", help="Gist description.")
+    create.add_argument("--file", action="append", required=True, help="File to upload; may be repeated.")
+    create.add_argument("--public", action="store_true", help="Create a public gist. Default is secret.")
+    add_dry_run_argument(create)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    if args.command == "create":
+        files = [str(Path(path)) for path in args.file]
+        missing = [path for path in files if not Path(path).is_file()]
+        if missing:
+            raise SystemExit(f"Missing gist file(s): {', '.join(missing)}")
+
+        command = ["gh", "gist", "create", *files]
+        if args.description:
+            command.extend(["--desc", args.description])
+        if args.public:
+            command.append("--public")
+        return gh_command(command, dry_run=args.dry_run)
+
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/github-workflow/scripts/gh_issue.py
+++ b/.agents/skills/github-workflow/scripts/gh_issue.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+
+from gh_common import add_body_file_argument, add_dry_run_argument, add_repo_argument, gh_api, read_body, repo_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safe GitHub issue operations through gh api.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="Create a GitHub issue.")
+    add_repo_argument(create)
+    create.add_argument("--title", required=True)
+    add_body_file_argument(create)
+    create.add_argument("--label", action="append", default=[], help="Label to apply; may be repeated.")
+    create.add_argument("--assignee", action="append", default=[], help="Assignee login; may be repeated.")
+    add_dry_run_argument(create)
+
+    update = subparsers.add_parser("update", help="Update a GitHub issue.")
+    add_repo_argument(update)
+    update.add_argument("--issue", required=True, type=int)
+    update.add_argument("--title")
+    update.add_argument("--body-file")
+    update.add_argument("--state", choices=["open", "closed"])
+    update.add_argument("--label", action="append", default=[], help="Replace labels with this list; may be repeated.")
+    add_dry_run_argument(update)
+
+    comment = subparsers.add_parser("comment", help="Post a comment on an issue or PR conversation.")
+    add_repo_argument(comment)
+    comment.add_argument("--issue", required=True, type=int)
+    add_body_file_argument(comment)
+    add_dry_run_argument(comment)
+
+    list_comments = subparsers.add_parser("list-comments", help="List comments on an issue or PR conversation.")
+    add_repo_argument(list_comments)
+    list_comments.add_argument("--issue", required=True, type=int)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    base = repo_path(args.repo)
+
+    if args.command == "create":
+        payload = {"title": args.title, "body": read_body(args.body_file)}
+        if args.label:
+            payload["labels"] = args.label
+        if args.assignee:
+            payload["assignees"] = args.assignee
+        return gh_api(f"{base}/issues", method="POST", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "update":
+        payload = {}
+        if args.title is not None:
+            payload["title"] = args.title
+        if args.body_file is not None:
+            payload["body"] = read_body(args.body_file)
+        if args.state is not None:
+            payload["state"] = args.state
+        if args.label:
+            payload["labels"] = args.label
+        if not payload:
+            raise SystemExit("update requires at least one of --title, --body-file, --state, or --label")
+        return gh_api(f"{base}/issues/{args.issue}", method="PATCH", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "comment":
+        payload = {"body": read_body(args.body_file)}
+        return gh_api(f"{base}/issues/{args.issue}/comments", method="POST", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "list-comments":
+        return gh_api(f"{base}/issues/{args.issue}/comments", paginate=True)
+
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/github-workflow/scripts/gh_pr.py
+++ b/.agents/skills/github-workflow/scripts/gh_pr.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+
+from gh_common import add_body_file_argument, add_dry_run_argument, add_repo_argument, gh_api, read_body, repo_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safe GitHub pull request operations through gh api.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    get = subparsers.add_parser("get", help="Get PR metadata.")
+    add_repo_argument(get)
+    get.add_argument("--pr", required=True, type=int)
+
+    update_body = subparsers.add_parser("update-body", help="Replace a pull request description/body.")
+    add_repo_argument(update_body)
+    update_body.add_argument("--pr", required=True, type=int)
+    add_body_file_argument(update_body)
+    add_dry_run_argument(update_body)
+
+    comment = subparsers.add_parser("comment", help="Post a PR conversation comment.")
+    add_repo_argument(comment)
+    comment.add_argument("--pr", required=True, type=int)
+    add_body_file_argument(comment)
+    add_dry_run_argument(comment)
+
+    list_comments = subparsers.add_parser("list-comments", help="List PR conversation comments, not inline review comments.")
+    add_repo_argument(list_comments)
+    list_comments.add_argument("--pr", required=True, type=int)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    base = repo_path(args.repo)
+
+    if args.command == "get":
+        return gh_api(f"{base}/pulls/{args.pr}")
+
+    if args.command == "update-body":
+        payload = {"body": read_body(args.body_file)}
+        return gh_api(f"{base}/pulls/{args.pr}", method="PATCH", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "comment":
+        payload = {"body": read_body(args.body_file)}
+        return gh_api(f"{base}/issues/{args.pr}/comments", method="POST", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "list-comments":
+        return gh_api(f"{base}/issues/{args.pr}/comments", paginate=True)
+
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/github-workflow/scripts/gh_review_comments.py
+++ b/.agents/skills/github-workflow/scripts/gh_review_comments.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+
+from gh_common import add_body_file_argument, add_dry_run_argument, add_repo_argument, gh_api, read_body, repo_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safe GitHub inline PR review comment operations through gh api.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List inline review comments on a PR.")
+    add_repo_argument(list_parser)
+    list_parser.add_argument("--pr", required=True, type=int)
+
+    get = subparsers.add_parser("get", help="Get one inline review comment by comment id.")
+    add_repo_argument(get)
+    get.add_argument("--comment-id", required=True, type=int)
+
+    reply = subparsers.add_parser("reply", help="Reply to a top-level inline review comment.")
+    add_repo_argument(reply)
+    reply.add_argument("--pr", required=True, type=int)
+    reply.add_argument("--comment-id", required=True, type=int)
+    add_body_file_argument(reply)
+    add_dry_run_argument(reply)
+
+    update = subparsers.add_parser("update", help="Edit an existing inline review comment or reply.")
+    add_repo_argument(update)
+    update.add_argument("--comment-id", required=True, type=int)
+    add_body_file_argument(update)
+    add_dry_run_argument(update)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    base = repo_path(args.repo)
+
+    if args.command == "list":
+        return gh_api(f"{base}/pulls/{args.pr}/comments", paginate=True)
+
+    if args.command == "get":
+        return gh_api(f"{base}/pulls/comments/{args.comment_id}")
+
+    if args.command == "reply":
+        payload = {"body": read_body(args.body_file)}
+        endpoint = f"{base}/pulls/{args.pr}/comments/{args.comment_id}/replies"
+        return gh_api(endpoint, method="POST", payload=payload, dry_run=args.dry_run)
+
+    if args.command == "update":
+        payload = {"body": read_body(args.body_file)}
+        return gh_api(f"{base}/pulls/comments/{args.comment_id}", method="PATCH", payload=payload, dry_run=args.dry_run)
+
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a `github-workflow` Codex skill for safer GitHub issue, PR, review-comment, and gist workflows.
- Add Python wrappers around `gh api` that pass JSON through stdin and comment/description bodies through files or stdin.
- Document endpoint distinctions for PR conversation comments vs inline PR review comments and replies.

## Verification
- `quick_validate.py .agents/skills/github-workflow`
- Python syntax compilation for all bundled scripts
- Script `--help` checks for issue, PR, review-comment, and gist helpers
- Dry-run payload checks for issue creation, PR body update, review-comment reply, and gist creation
- Live read-only issue comment listing through the wrapper

## Live PR Script Verification
- PR opened from `github-workflow-skill` to `main`: #82.
- PR body updated by `gh_pr.py update-body`.
- PR conversation comment posted by `gh_pr.py comment`: issue comment `4905372848`.
- PR issue-endpoint comment posted by `gh_issue.py comment`: issue comment `4905372824`.
- Inline review comment listed by `gh_review_comments.py list`: review comment `3537614782`.
- Inline review comment updated by `gh_review_comments.py update`: review comment `3537614782`.
- Inline review comment reply posted by `gh_review_comments.py reply`: review comment `3537618784`, replying to `3537614782`.
- `gh_gist.py create` was verified with dry-run only; no persistent gist was created for this PR test.
