### PR TITLE
Implement data-driven PF2e barbarian rule pipeline

### DIFF
--- a/Assets/Resources/DataFiles/effects.meta
+++ b/Assets/Resources/DataFiles/effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c68a18923bb057f4989d36491416f30f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json
+++ b/Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json
@@ -1,0 +1,44 @@
+{
+    "_id": "MaepXeSHiMoWDm7u",
+    "img": "icons/skills/wounds/injury-pain-body-orange.webp",
+    "name": "Effect: Rage Temporary Hit Points Immunity",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Rage]</p>\n<p>You can't gain temporary Hit Points from using the Rage action.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.system.rageTempHP",
+                "phase": "beforeDerived",
+                "value": 0
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json.meta
+++ b/Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 458d7de2ac73a234593874cac322e0a3
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/effects/effect-rage.json
+++ b/Assets/Resources/DataFiles/effects/effect-rage.json
@@ -1,0 +1,68 @@
+{
+    "_id": "z3uyCMBddrPK5umr",
+    "img": "icons/skills/wounds/injury-face-impact-orange.webp",
+    "name": "Effect: Rage",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Rage]</p>\n<p>You gain a number of temporary Hit Points equal to your level plus your Constitution modifier.</p>\n<p>You deal additional damage on melee Strikes. This additional damage is halved if your weapon or unarmed attack is agile.</p>\n<p>When you stop raging, you lose any remaining temporary Hit Points from Rage, and can't gain temporary Hit Points from using the Rage action again for 1 minute.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.system.rageTempHP",
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.system.rageTempHP",
+                "phase": "beforeDerived",
+                "predicate": [
+                    {
+                        "nor": [
+                            "self:type:familiar",
+                            "self:type:hazard",
+                            "self:type:vehicle"
+                        ]
+                    }
+                ],
+                "value": "@actor.level + @actor.abilities.con.mod"
+            },
+            {
+                "key": "TempHP",
+                "value": "@actor.flags.system.rageTempHP"
+            },
+            {
+                "key": "RollOption",
+                "option": "rage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/Assets/Resources/DataFiles/effects/effect-rage.json.meta
+++ b/Assets/Resources/DataFiles/effects/effect-rage.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a23f9c50a79f34e4ca8be892bd94c752
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Actions/AbilityActions/Rage.cs
+++ b/Assets/Scripts/Combat/Actions/AbilityActions/Rage.cs
@@ -1,116 +1,72 @@
-using Game.Creature;
-using Game.Strikes;
-using System.Collections.Generic;
+using Game.Creature.Rules;
 using System.Collections;
 using UnityEngine;
-using Unity.VisualScripting;
-using System.Diagnostics.Tracing;
-using System;
-//using System.Diagnostics;
 
-namespace Game.AbilityActions{
-
-// TODO change to single frame entity action?
-[System.Serializable]
-public class Rage : MultiFrameEntityAction
+namespace Game.AbilityActions
 {
-    // Done by Ryan Meyer 04/07/2026
-    public override string ActionName => "Rage";
-    List<string> Traits = new List<string> {"barbarian", "concentrate", "emotion", "mental"};
-    int rageBonus = 2;
-    
-    public Rage(uint cost) : base(cost)
+    /// <summary>
+    /// Unity action wrapper for Rage; rules live in RageRule and this class only bridges action flow to Unity components.
+    /// </summary>
+    [System.Serializable]
+    public class Rage : MultiFrameEntityAction
     {
-        // apply abilities that alter rage?
-    }
+        public override string ActionName => "Rage";
 
-    public void UseRage(GameObject g)
-    {
-        Debug.Log(g + " is attempting to use Rage");
-        if (RageAllowed(g)){
-            // Check for rage modifying abilities
-            if (g.GetComponent<CreatureComponent>().passives.Contains("Fury-Instinct")) rageBonus = 3;
-            // Apply THP from rage
-            AddRageTHP(g);
-            // Add listener to trigger bonus rage damage
-            OnStrikeEvent.AddListener((Tuple<Strike, GameObject> tuple) => { if (tuple.Item2 == g) { AddRageDamage(tuple.Item1); }});
-            MFInvoke(g);
+        /// <summary>
+        /// Creates a Rage action with the action point cost supplied by the action system.
+        /// </summary>
+        /// <param name="cost">The number of action points Rage spends when successfully used.</param>
+        public Rage(uint cost) : base(cost)
+        {
         }
-    }
 
-    public bool RageAllowed(GameObject g)
-    {
-        // Check for conditions that would prevent raging, and return false if any are present
-        bool allowed =true;
-        if (g.GetComponent<Conditions>().Contains("Fatigued")){
-            allowed = false;
-            Debug.Log(g + " cannot Rage while Fatigued");
-        }
-        if (g.GetComponent<Conditions>().Contains("Raging")){ // TODO Update to look for an actual sign of rage
-            allowed = false;
-            Debug.Log(g + " cannot Rage while Raging");
-        }
-        if(g.GetComponent<CreatureComponent>().equippedArmor != null && g.GetComponent<CreatureComponent>().equippedArmor.category == "heavy")
+        /// <summary>
+        /// Attempts to start Rage for an actor by evaluating the pure rule and applying its generic Unity side effects.
+        /// </summary>
+        /// <param name="actor">The Unity actor attempting to Rage.</param>
+        /// <returns>True when Rage was applied.</returns>
+        public bool UseRage(GameObject actor)
         {
-            allowed = false;
-            Debug.Log(g + " cannot Rage while wearing heavy armor");
-        }
-        return allowed;
-    }
-
-    public void AddRageTHP(GameObject g)
-    {
-        ActionController ac = g.GetComponent<ActionController>();
-        CreatureComponent cc = g.GetComponent<CreatureComponent>();
-        
-        if (cc.tempHp > 0)
-        {
-            // TODO if creature already has THP, UI prompt to ask if they want to accept rage THP
-        }
-        // Add THP, if rage hasn't ended with 1 min == 10 turns
-        if (true)
-        {
-            int tempHP = cc.level;
-            tempHP += cc.conMod;
-            cc.GainTempHp(tempHP);
-            if (ac)
+            Debug.Log(actor + " is attempting to use Rage");
+            RageRuleResult result = RageRule.Apply(new RageRequest
             {
-                Debug.Log(g + " used Rage");
-                PayCost(ac);
-                ac.IsTakingAction = false;
-            }
+                Creature = UnityCreatureRulesAdapter.From(actor),
+                ActionCost = ActionCost
+            });
+            UnityRuleEffectApplier.Apply(actor, result.Effects);
+            if (!result.Applied)
+                Debug.Log(actor + " cannot Rage");
+            return result.Applied;
         }
-    }
 
-
-    public void AddRageDamage(Strike action)
-    {
-        // TODO make rageBonus not hardcoded
-        // int rageBonus = 2;
-        Debug.Log("Adding Rage damage to strike");
-        if (action == null || action.FlatDamages == null || action.FlatDamages.Count == 0)
-            return;
-
-        if (action.getTraits().Contains("agile") || action.getTraits().Contains("unarmed"))
+        /// <summary>
+        /// Checks whether the actor can currently Rage without mutating Unity or prepared rule state.
+        /// </summary>
+        /// <param name="actor">The Unity actor being checked.</param>
+        /// <returns>True when the actor satisfies the Rage rule prerequisites.</returns>
+        public bool RageAllowed(GameObject actor)
         {
-            DamageValue dmg = action.FlatDamages[0];
-            dmg.DamageAmount = rageBonus/2;
-            action.FlatDamages.Add(dmg);  
+            return RageRule.CanApply(new RageRequest
+            {
+                Creature = UnityCreatureRulesAdapter.From(actor),
+                ActionCost = ActionCost
+            });
         }
-        else
+
+        /// <summary>
+        /// Ends Rage for an actor and applies cleanup effects returned by the pure Rage rule.
+        /// </summary>
+        /// <param name="actor">The Unity actor whose Rage should end.</param>
+        public void EndRage(GameObject actor)
         {
-            //Debug.Log("Rage damage not applicable to this action");
-            DamageValue dmg = action.FlatDamages[0];
-            dmg.DamageAmount = rageBonus;
-            action.FlatDamages.Add(dmg);  
+            RageRuleResult result = RageRule.End(UnityCreatureRulesAdapter.From(actor));
+            UnityRuleEffectApplier.Apply(actor, result.Effects);
+        }
+
+        protected override IEnumerator MFInvoke(GameObject actor)
+        {
+            UseRage(actor);
+            yield break;
         }
     }
-
-    protected override IEnumerator MFInvoke(GameObject g)
-    {
-        ActionController ac = g.GetComponent<ActionController>();
-        yield break;
-    }
-}
-
 }

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Game.Creature;
+using Game.Creature.Rules;
 using System;
 using GridPublic;
 
@@ -42,6 +43,7 @@ public class Strike
         evaluated.To = to_go;
         evaluated.TargetingResult = targetingResult;
 
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(from_go.GetComponent<CreatureComponent>(), evaluated);
         OnStrikeEvent.Invoke(new(evaluated, from_go));
         evaluated.DamageEvaluate();
     }

--- a/Assets/Scripts/Combat/CombatManager.cs
+++ b/Assets/Scripts/Combat/CombatManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.Events;
 using Game.Creature;
+using Game.Creature.Rules;
 
 public class CombatManager : CombatManagerInterface
 {
@@ -74,6 +75,7 @@ public class CombatManager : CombatManagerInterface
     public override void StartCombat()
     {
         RollInitiative();
+        Pf2eRulesEngine.ApplyCombatStartRules(Combatants);
         OnCombatStart.Invoke();
         //Debug.Log("Start Combat.");
 
@@ -137,6 +139,7 @@ public class CombatManager : CombatManagerInterface
         if (teams.Count < 2)
         {
             Debug.Log("Team " + teams[0] + " wins!");
+            Pf2eRulesEngine.EndEncounter(Combatants);
             OnCombatEnd.Invoke(teams[0]);// Signal end
             if (teams[0].ToLower() == "players")
             {

--- a/Assets/Scripts/Combat/Team.cs
+++ b/Assets/Scripts/Combat/Team.cs
@@ -8,6 +8,9 @@ public class Team : MonoBehaviour
 
     private void Awake()
     {
+        if (string.IsNullOrWhiteSpace(Name))
+            return;
+
         TeamRules tr = TeamRules.GetInstance();
         if(!tr.Contains(Name)) 
         {

--- a/Assets/Scripts/Creature/Conditions/Conditions.cs
+++ b/Assets/Scripts/Creature/Conditions/Conditions.cs
@@ -2,11 +2,17 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// A container for all the conditions that are applied to a target
+/// Stores active conditions by source so rules can query condition names without coupling to condition UI or effects.
 /// </summary>
 public class Conditions : MonoBehaviour, IConditionTarget
 {
     protected Dictionary<string, List<ConditionSource>> AppliedConditions = new();
+
+    /// <summary>
+    /// Adds a condition from a specific source, preserving multiple sources for the same condition.
+    /// </summary>
+    /// <param name="condition">The condition name to add.</param>
+    /// <param name="source">The source responsible for applying the condition.</param>
     public void Add(string condition, ConditionSource source)
     {
         List<ConditionSource> sources;
@@ -16,17 +22,42 @@ public class Conditions : MonoBehaviour, IConditionTarget
             sources.Add(source);
     }
 
+    /// <summary>
+    /// Checks whether a condition is present from a specific source.
+    /// </summary>
+    /// <param name="condition">The condition name to check.</param>
+    /// <param name="source">The source that must be present.</param>
+    /// <returns>True when that source currently applies the condition.</returns>
     public bool Contains(string condition, ConditionSource source)
     {
         List<ConditionSource> sources;
         return AppliedConditions.TryGetValue(condition, out sources) && sources.Contains(source);
     }
 
+    /// <summary>
+    /// Checks whether a condition is present from any source.
+    /// </summary>
+    /// <param name="condition">The condition name to check.</param>
+    /// <returns>True when the condition currently exists.</returns>
     public bool Contains(string condition)
     {
         return AppliedConditions.TryGetValue(condition, out _);
     }
 
+    /// <summary>
+    /// Returns a snapshot of active condition names for Unity-free rule evaluation.
+    /// </summary>
+    /// <returns>The active condition names without their source details.</returns>
+    public IReadOnlyCollection<string> GetConditionNames()
+    {
+        return new List<string>(AppliedConditions.Keys);
+    }
+
+    /// <summary>
+    /// Removes one source from a condition and clears the condition when no sources remain.
+    /// </summary>
+    /// <param name="condition">The condition name to remove.</param>
+    /// <param name="source">The source being removed.</param>
     public void Remove(string condition, ConditionSource source)
     {
         List<ConditionSource> sources;
@@ -38,6 +69,13 @@ public class Conditions : MonoBehaviour, IConditionTarget
         }
     }
 
+    /// <summary>
+    /// Replaces one sourced condition with another while preserving source-aware condition ownership.
+    /// </summary>
+    /// <param name="oldCondition">The condition name to remove.</param>
+    /// <param name="oldSource">The source to remove from the old condition.</param>
+    /// <param name="newCondition">The condition name to add.</param>
+    /// <param name="newSource">The source applying the new condition.</param>
     public void Change(string oldCondition, ConditionSource oldSource, string newCondition, ConditionSource newSource)
     {
         Remove(oldCondition, oldSource);

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using Game.Strikes;
 using GridPublic;
+using Game.Creature.Rules;
+using System;
 
 namespace Game.Creature
 {
@@ -18,7 +20,9 @@ namespace Game.Creature
     [System.Serializable] public struct AmmoCount { public string ammoName; public int quantity; }
 
 
-    // Extension as a Unity MonoBehaviour
+    /// <summary>
+    /// Unity creature component that owns mutable gameplay state and exposes narrow state snapshots for PF2e rules.
+    /// </summary>
     public class CreatureComponent : MonoBehaviour 
     {
 
@@ -249,11 +253,15 @@ namespace Game.Creature
         public string size { get; set; }
         public List<string> languages { get; set; } = new List<string>();
         public List<string> senses { get; set; } = new List<string>();
+        public CharacterBuild Build { get; set; }
+        public PreparedCharacter Prepared { get; set; }
 
         // expose serialized backing fields via properties used by code
         public List<SkillValue> skills { get => _skills; set => _skills = value ?? new List<SkillValue>(); }
         public string description { get => _description; set => _description = value; }
 
+        private readonly Dictionary<string, int> _sourceTempHp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _tempHpImmunities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         void Awake()
         {
@@ -262,15 +270,8 @@ namespace Game.Creature
         void Start()
         {
             // Initialization code here
-            // Apply passive abilities
-            foreach (var a in passives)
-            {
-                var ability = DefinedAbilities.TryGet(a);
-                if (ability != null)
-                    ability.Apply(this.gameObject);
-                else
-                    Debug.LogWarning($"Ability '{a}' not found for {name}");
-            }
+            if (Prepared == null && Build != null)
+                Prepared = Pf2eCharacterPreparer.Prepare(this, Build);
 
             // Add initial strike actions
             if(this.gameObject.GetComponent<ActionController>() != null){
@@ -365,6 +366,7 @@ namespace Game.Creature
             {
                 int used = Mathf.Min(_tempHp, remaining);
                 _tempHp -= used;
+                ConsumeSourceTempHp(used);
                 remaining -= used;
             }
             // apply HP loss
@@ -377,7 +379,9 @@ namespace Game.Creature
         public void TakeDamage(uint amount)
         {
             // consume temp HP first
+            int tempBeforeDamage = _tempHp;
             _tempHp -= (int)amount;
+            ConsumeSourceTempHp(Mathf.Min(tempBeforeDamage, (int)amount));
             if (_tempHp < 0)
             {
                 _hp += _tempHp;
@@ -423,6 +427,81 @@ namespace Game.Creature
         public void GainTempHp(int tempHpAmount)
         {
             GainTempHp(tempHpAmount, false);
+        }
+
+        /// <summary>
+        /// Grants temporary Hit Points tracked by a stable source so rule cleanup can remove only its own grant.
+        /// </summary>
+        /// <param name="source">The source key associated with the temporary Hit Points.</param>
+        /// <param name="tempHpAmount">The amount of temporary Hit Points to grant.</param>
+        public void GainSourceTempHp(string source, int tempHpAmount)
+        {
+            if (string.IsNullOrWhiteSpace(source) || tempHpAmount <= 0)
+                return;
+
+            RemoveSourceTempHp(source);
+            _sourceTempHp[source] = tempHpAmount;
+            if (tempHpAmount > _tempHp)
+                _tempHp = tempHpAmount;
+        }
+
+        /// <summary>
+        /// Removes temporary Hit Points previously granted by a specific source.
+        /// </summary>
+        /// <param name="source">The source key to remove.</param>
+        public void RemoveSourceTempHp(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source) || !_sourceTempHp.TryGetValue(source, out int amount))
+                return;
+
+            _sourceTempHp.Remove(source);
+            _tempHp = Mathf.Max(0, _tempHp - amount);
+        }
+
+        /// <summary>
+        /// Records that a source cannot grant temporary Hit Points again until game flow resets the immunity set.
+        /// </summary>
+        /// <param name="source">The source key to mark immune.</param>
+        public void AddTempHpImmunity(string source)
+        {
+            if (!string.IsNullOrWhiteSpace(source))
+                _tempHpImmunities.Add(source);
+        }
+
+        /// <summary>
+        /// Checks whether a source is currently blocked from granting temporary Hit Points.
+        /// </summary>
+        /// <param name="source">The source key to check.</param>
+        /// <returns>True when the source has temporary Hit Point immunity.</returns>
+        public bool HasTempHpImmunity(string source)
+        {
+            return !string.IsNullOrWhiteSpace(source) && _tempHpImmunities.Contains(source);
+        }
+
+        /// <summary>
+        /// Returns a snapshot of temporary Hit Point immunity sources for Unity-free rule evaluation.
+        /// </summary>
+        /// <returns>The active source keys with temporary Hit Point immunity.</returns>
+        public IReadOnlyCollection<string> GetTempHpImmunitySources()
+        {
+            return new List<string>(_tempHpImmunities);
+        }
+
+        private void ConsumeSourceTempHp(int amount)
+        {
+            if (amount <= 0 || _sourceTempHp.Count == 0)
+                return;
+
+            foreach (string source in new List<string>(_sourceTempHp.Keys))
+            {
+                int consumed = Mathf.Min(amount, _sourceTempHp[source]);
+                _sourceTempHp[source] -= consumed;
+                amount -= consumed;
+                if (_sourceTempHp[source] <= 0)
+                    _sourceTempHp.Remove(source);
+                if (amount <= 0)
+                    return;
+            }
         }
 
         public int GetInitiative()

--- a/Assets/Scripts/Creature/CreatureJsonConverter.cs
+++ b/Assets/Scripts/Creature/CreatureJsonConverter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Game.Strikes;
+using Game.Creature.Rules;
 // using System.Diagnostics;
 
 namespace Game.Creature
@@ -430,6 +431,9 @@ namespace Game.Creature
             GameObject go = prefab != null ? UnityEngine.Object.Instantiate(prefab) : new GameObject(dto?.name ?? "Creature");
             var comp = go.GetComponent<CreatureComponent>() ?? go.AddComponent<CreatureComponent>();
             comp.ApplyFromDto(dto);
+            comp.Build = CharacterBuild.FromCreatureJson(creatureAsset.text);
+            if (!string.IsNullOrWhiteSpace(comp.Build.ClassName))
+                comp.Prepared = Pf2eCharacterPreparer.Prepare(comp, comp.Build);
             return go;
         }
 

--- a/Assets/Scripts/Creature/Rules.meta
+++ b/Assets/Scripts/Creature/Rules.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb11cf59f56029e4e87c4bf230003948
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/CharacterBuild.cs
+++ b/Assets/Scripts/Creature/Rules/CharacterBuild.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Captures durable player build choices that select PF2e data items; runtime rule state is prepared separately from these saved choices.
+    /// </summary>
+    public sealed class CharacterBuild
+    {
+        public string ClassName;
+        public string SubclassName;
+        public string ClassFeatName;
+        public readonly Dictionary<string, string> RuleSelections = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Reads the current creature JSON shape into build choices without requiring Foundry-derived data to be rewritten.
+        /// </summary>
+        /// <param name="json">Serialized creature JSON from the existing character data pipeline.</param>
+        /// <returns>A build with any recognizable class, subclass, and feat choices populated.</returns>
+        public static CharacterBuild FromCreatureJson(string json)
+        {
+            CharacterBuild build = new();
+            if (string.IsNullOrWhiteSpace(json))
+                return build;
+
+            try
+            {
+                JObject root = JObject.Parse(json);
+                JObject firstPlayerBlock = root["playerOnlyStuff"]?.First as JObject;
+                if (firstPlayerBlock != null)
+                {
+                    build.ClassName = firstPlayerBlock.Value<string>("className");
+                    build.SubclassName = firstPlayerBlock.Value<string>("subclass");
+                    build.ClassFeatName = firstPlayerBlock.Value<string>("classFeat");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"PF2e build data could not be parsed: {ex.Message}");
+            }
+
+            return build;
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/CharacterBuild.cs.meta
+++ b/Assets/Scripts/Creature/Rules/CharacterBuild.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2f0634e31a44933b8ba6be934de28e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/CreatureRulesState.cs
+++ b/Assets/Scripts/Creature/Rules/CreatureRulesState.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Provides the Unity-free creature facts that PF2e rules need when making decisions.
+    /// </summary>
+    public sealed class CreatureRulesState
+    {
+        public int Level { get; set; }
+        public int ConstitutionModifier { get; set; }
+        public string ArmorCategory { get; set; }
+        public PreparedCharacter Prepared { get; set; }
+        public IReadOnlyCollection<string> Conditions { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> TempHpImmunitySources { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Checks for an active condition by rules name while keeping condition storage outside rule implementations.
+        /// </summary>
+        /// <param name="condition">The PF2e condition name or slug to match.</param>
+        /// <returns>True when the condition is present on this rules snapshot.</returns>
+        public bool HasCondition(string condition)
+        {
+            return Conditions != null && Conditions.Contains(condition, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks whether a rules source is currently blocked from granting temporary Hit Points again.
+        /// </summary>
+        /// <param name="source">The stable source key used by the originating rule.</param>
+        /// <returns>True when that source has temporary Hit Point immunity.</returns>
+        public bool HasTempHpImmunity(string source)
+        {
+            return TempHpImmunitySources != null && TempHpImmunitySources.Contains(source, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/CreatureRulesState.cs.meta
+++ b/Assets/Scripts/Creature/Rules/CreatureRulesState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9b5b52714364e86abf6870f15a53191
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
@@ -1,0 +1,245 @@
+using Game.Creature;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Builds the derived PF2e rule state from character choices and verbatim-ish Foundry data items.
+    /// </summary>
+    public static class Pf2eCharacterPreparer
+    {
+        /// <summary>
+        /// Resolves build choices, grants, roll options, and supported rule elements into a prepared character snapshot.
+        /// </summary>
+        /// <param name="creature">The Unity creature receiving prepared math and derived options.</param>
+        /// <param name="build">The saved choices that select class, subclass, feats, and rule selections.</param>
+        /// <param name="catalog">Optional catalog override for tests; production uses the Resources-backed singleton.</param>
+        /// <returns>A prepared character that rules can query without reparsing item JSON.</returns>
+        public static PreparedCharacter Prepare(CreatureComponent creature, CharacterBuild build, Pf2eItemCatalog catalog = null)
+        {
+            catalog ??= Pf2eItemCatalog.Instance;
+            PreparedCharacter prepared = new(build);
+            if (creature == null)
+                return prepared;
+
+            prepared.RollOptions.Add($"self:level:{creature.level}");
+            AddArmorRollOptions(creature, prepared);
+
+            if (catalog.TryResolveByNameOrSlug(build.ClassName, out Pf2eItem classItem))
+            {
+                prepared.AddOwnedItem(classItem);
+                ApplyClassBaseMath(creature, classItem);
+                GrantClassItems(creature.level, classItem, catalog, prepared);
+            }
+
+            if (catalog.TryResolveByNameOrSlug(build.SubclassName, out Pf2eItem subclassItem))
+                prepared.AddOwnedItem(subclassItem);
+
+            if (catalog.TryResolveByNameOrSlug(build.ClassFeatName, out Pf2eItem classFeatItem))
+                prepared.AddOwnedItem(classFeatItem);
+
+            for (int i = 0; i < 4; i++)
+                ProcessGrantRules(prepared, catalog);
+
+            CollectRuleSynthetics(prepared, catalog);
+            return prepared;
+        }
+
+        /// <summary>
+        /// Returns an existing prepared snapshot or prepares one lazily for legacy call sites that only have a CreatureComponent.
+        /// </summary>
+        /// <param name="creature">The Unity creature that owns the cached prepared character.</param>
+        /// <returns>The cached or newly prepared PF2e character state.</returns>
+        public static PreparedCharacter EnsurePrepared(CreatureComponent creature)
+        {
+            if (creature.Prepared == null)
+                creature.Prepared = Prepare(creature, creature.Build ?? new CharacterBuild());
+            return creature.Prepared;
+        }
+
+        private static void ApplyClassBaseMath(CreatureComponent creature, Pf2eItem classItem)
+        {
+            JObject system = classItem.System;
+            if (system == null)
+                return;
+
+            ApplyWeaponBonus(creature, "unarmed", system.SelectToken("attacks.unarmed")?.Value<int>() ?? 0);
+            ApplyWeaponBonus(creature, "simple", system.SelectToken("attacks.simple")?.Value<int>() ?? 0);
+            ApplyWeaponBonus(creature, "martial", system.SelectToken("attacks.martial")?.Value<int>() ?? 0);
+            ApplyWeaponBonus(creature, "advanced", system.SelectToken("attacks.advanced")?.Value<int>() ?? 0);
+
+            ApplyArmorBonus(creature, "unarmored", system.SelectToken("defenses.unarmored")?.Value<int>() ?? 0);
+            ApplyArmorBonus(creature, "light", system.SelectToken("defenses.light")?.Value<int>() ?? 0);
+            ApplyArmorBonus(creature, "medium", system.SelectToken("defenses.medium")?.Value<int>() ?? 0);
+            ApplyArmorBonus(creature, "heavy", system.SelectToken("defenses.heavy")?.Value<int>() ?? 0);
+        }
+
+        private static void ApplyWeaponBonus(CreatureComponent creature, string category, int rank)
+        {
+            int index = creature.weaponBonuses.FindIndex(b => b.category == category);
+            if (index < 0)
+                creature.weaponBonuses.Add(new WeaponBonus { category = category, bonus = rank * 2 });
+            else
+                creature.weaponBonuses[index] = new WeaponBonus { category = category, bonus = rank * 2 };
+        }
+
+        private static void ApplyArmorBonus(CreatureComponent creature, string category, int rank)
+        {
+            int index = creature.armorBonuses.FindIndex(b => b.category == category);
+            if (index < 0)
+                creature.armorBonuses.Add(new ArmorBonus { category = category, bonus = rank * 2 });
+            else
+                creature.armorBonuses[index] = new ArmorBonus { category = category, bonus = rank * 2 };
+        }
+
+        private static void GrantClassItems(int level, Pf2eItem classItem, Pf2eItemCatalog catalog, PreparedCharacter prepared)
+        {
+            JObject items = classItem.System?["items"] as JObject;
+            if (items == null)
+                return;
+
+            foreach (JProperty property in items.Properties())
+            {
+                JObject grant = property.Value as JObject;
+                if (grant == null || grant.Value<int?>("level").GetValueOrDefault(1) > level)
+                    continue;
+
+                string uuid = grant.Value<string>("uuid");
+                string name = grant.Value<string>("name");
+                Pf2eItem granted = catalog.Resolve(uuid) ?? catalog.Resolve(name);
+                prepared.AddOwnedItem(granted, classItem.Slug);
+            }
+        }
+
+        private static void ProcessGrantRules(PreparedCharacter prepared, Pf2eItemCatalog catalog)
+        {
+            foreach (OwnedPf2eItem owned in prepared.OwnedItems.ToArray())
+            {
+                foreach (JObject rule in owned.Item.Rules)
+                {
+                    string key = rule.Value<string>("key");
+                    if (key == "ChoiceSet" || key == "GrantItem")
+                        ProcessRule(rule, owned.Item, prepared, catalog);
+                }
+            }
+        }
+
+        private static void CollectRuleSynthetics(PreparedCharacter prepared, Pf2eItemCatalog catalog)
+        {
+            prepared.Modifiers.Clear();
+            prepared.Adjustments.Clear();
+            prepared.ItemAlterations.Clear();
+            prepared.UnsupportedRuleKeys.Clear();
+
+            foreach (OwnedPf2eItem owned in prepared.OwnedItems.ToArray())
+            {
+                foreach (JObject rule in owned.Item.Rules)
+                {
+                    string key = rule.Value<string>("key");
+                    if (key != "ChoiceSet" && key != "GrantItem")
+                        ProcessRule(rule, owned.Item, prepared, catalog);
+                }
+            }
+        }
+
+        private static void ProcessRule(JObject rule, Pf2eItem source, PreparedCharacter prepared, Pf2eItemCatalog catalog)
+        {
+            string key = rule.Value<string>("key");
+            if (string.IsNullOrWhiteSpace(key))
+                return;
+
+            bool predicateMatches = Pf2ePredicate.Evaluate(rule["predicate"], prepared);
+
+            switch (key)
+            {
+                case "ChoiceSet":
+                    if (predicateMatches)
+                        ApplyChoiceSet(rule, prepared, catalog);
+                    break;
+                case "GrantItem":
+                    if (predicateMatches)
+                        ApplyGrantItem(rule, source, prepared, catalog);
+                    break;
+                case "FlatModifier":
+                    prepared.Modifiers.Add(new RuleModifier
+                    {
+                        Selector = rule.Value<string>("selector"),
+                        Slug = rule.Value<string>("slug"),
+                        Value = rule.Value<int?>("value") ?? 0,
+                        Predicate = rule["predicate"]?.DeepClone()
+                    });
+                    break;
+                case "AdjustModifier":
+                    prepared.Adjustments.Add(new RuleAdjustment
+                    {
+                        Selector = rule.Value<string>("selector"),
+                        Slug = rule.Value<string>("slug"),
+                        Mode = rule.Value<string>("mode"),
+                        Value = rule.Value<float?>("value") ?? 0,
+                        Priority = rule.Value<int?>("priority") ?? 0,
+                        Predicate = rule["predicate"]?.DeepClone()
+                    });
+                    break;
+                case "ItemAlteration":
+                    prepared.ItemAlterations.Add(new ItemAlterationRule
+                    {
+                        ItemType = rule.Value<string>("itemType"),
+                        Mode = rule.Value<string>("mode"),
+                        Property = rule.Value<string>("property"),
+                        Value = rule.Value<string>("value"),
+                        Predicate = rule["predicate"]?.DeepClone()
+                    });
+                    break;
+                case "RollOption":
+                    if (!predicateMatches)
+                        break;
+                    string option = rule.Value<string>("option");
+                    if (!string.IsNullOrWhiteSpace(option))
+                        prepared.RollOptions.Add(option);
+                    break;
+                case "TempHP":
+                case "Resistance":
+                    break;
+                default:
+                    if (!prepared.UnsupportedRuleKeys.Contains(key))
+                        prepared.UnsupportedRuleKeys.Add(key);
+                    break;
+            }
+        }
+        private static void ApplyChoiceSet(JObject rule, PreparedCharacter prepared, Pf2eItemCatalog catalog)
+        {
+            string flag = rule.Value<string>("flag");
+            if (string.IsNullOrWhiteSpace(flag) || prepared.Build.RuleSelections.ContainsKey(flag))
+                return;
+
+            Pf2eItem selected = catalog.Resolve(prepared.Build.ClassFeatName);
+            if (selected != null)
+                prepared.Build.RuleSelections[flag] = $"Compendium.pf2e.feats-srd.Item.{selected.Name}";
+        }
+
+        private static void ApplyGrantItem(JObject rule, Pf2eItem source, PreparedCharacter prepared, Pf2eItemCatalog catalog)
+        {
+            string uuid = rule.Value<string>("uuid");
+            if (string.IsNullOrWhiteSpace(uuid))
+                return;
+
+            if (uuid.StartsWith("{item|flags.pf2e.rulesSelections.", StringComparison.OrdinalIgnoreCase))
+            {
+                string flag = uuid.Replace("{item|flags.pf2e.rulesSelections.", string.Empty).TrimEnd('}');
+                prepared.Build.RuleSelections.TryGetValue(flag, out uuid);
+            }
+
+            Pf2eItem granted = catalog.Resolve(uuid);
+            prepared.AddOwnedItem(granted, source.Slug);
+        }
+
+        private static void AddArmorRollOptions(CreatureComponent creature, PreparedCharacter prepared)
+        {
+            string category = creature.equippedArmor?.category;
+            if (!string.IsNullOrWhiteSpace(category))
+                prepared.RollOptions.Add($"armor:category:{category}");
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad912e3e62274eacb935e8461718f2e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/Pf2eItem.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eItem.cs
@@ -1,0 +1,75 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Wraps one PF2e data item while preserving the original JSON as the rule-element source of truth.
+    /// </summary>
+    public sealed class Pf2eItem
+    {
+        public string Name { get; private set; }
+        public string Slug { get; private set; }
+        public string Type { get; private set; }
+        public string ResourceName { get; private set; }
+        public string Source { get; private set; }
+        public JObject Json { get; private set; }
+        public JObject System => Json["system"] as JObject;
+
+        public IEnumerable<JObject> Rules
+        {
+            get
+            {
+                JArray rules = System?["rules"] as JArray;
+                if (rules == null)
+                    yield break;
+
+                foreach (JToken rule in rules)
+                    if (rule is JObject obj)
+                        yield return obj;
+            }
+        }
+
+        /// <summary>
+        /// Parses a Resources text asset into a catalog item without mutating the upstream-style JSON shape.
+        /// </summary>
+        /// <param name="resourceName">The Unity Resources asset name used as a fallback lookup alias.</param>
+        /// <param name="json">The raw PF2e item JSON.</param>
+        /// <param name="item">The parsed catalog item when parsing succeeds.</param>
+        /// <returns>True when the item has the minimum name and type data required by the rules pipeline.</returns>
+        public static bool TryParse(string resourceName, string json, out Pf2eItem item)
+        {
+            item = null;
+            if (string.IsNullOrWhiteSpace(json))
+                return false;
+
+            try
+            {
+                JObject root = JObject.Parse(json);
+                string name = root.Value<string>("name");
+                string type = root.Value<string>("type");
+                if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(type))
+                    return false;
+
+                string slug = root.SelectToken("system.slug")?.Value<string>();
+                item = new Pf2eItem
+                {
+                    Name = name,
+                    Slug = string.IsNullOrWhiteSpace(slug) ? Pf2eSlug.FromName(name) : slug,
+                    Type = type,
+                    ResourceName = resourceName,
+                    Source = root.Value<string>("Source") ?? root.SelectToken("system.publication.title")?.Value<string>() ?? string.Empty,
+                    Json = root
+                };
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"PF2e catalog skipped malformed item '{resourceName}': {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2eItem.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2eItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74e9c2f88186460db4528bc96488463e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/Pf2eItemCatalog.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eItemCatalog.cs
@@ -1,0 +1,140 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Indexes PF2e data items loaded from Resources so rules can resolve names, slugs, and Foundry UUID-style references.
+    /// </summary>
+    public sealed class Pf2eItemCatalog
+    {
+        private readonly Dictionary<string, Pf2eItem> bySlug = new();
+        private readonly Dictionary<string, Pf2eItem> byName = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Pf2eItem> byUuid = new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<Pf2eItem> items = new();
+        private static Pf2eItemCatalog instance;
+
+        public IReadOnlyList<Pf2eItem> Items => items;
+
+        public static Pf2eItemCatalog Instance => instance ??= LoadFromResources();
+
+        /// <summary>
+        /// Clears the Resources-backed singleton so tests can rebuild the catalog from controlled data.
+        /// </summary>
+        public static void ResetForTests()
+        {
+            instance = null;
+        }
+
+        /// <summary>
+        /// Loads all parseable PF2e JSON files under Resources/DataFiles into a lookup catalog.
+        /// </summary>
+        /// <returns>A catalog containing every valid PF2e item found in Resources.</returns>
+        public static Pf2eItemCatalog LoadFromResources()
+        {
+            Pf2eItemCatalog catalog = new();
+            TextAsset[] assets = Resources.LoadAll<TextAsset>("DataFiles");
+            foreach (TextAsset asset in assets)
+            {
+                if (Pf2eItem.TryParse(asset.name, asset.text, out Pf2eItem item))
+                    catalog.Add(item);
+            }
+            return catalog;
+        }
+
+        /// <summary>
+        /// Adds an item to every supported lookup index while preserving the first item for duplicate aliases.
+        /// </summary>
+        /// <param name="item">The parsed PF2e item to index.</param>
+        public void Add(Pf2eItem item)
+        {
+            if (item == null)
+                return;
+
+            items.Add(item);
+            Index(bySlug, item.Slug, item);
+            Index(byName, item.Name, item);
+            Index(byName, item.ResourceName, item);
+
+            foreach (string uuid in GenerateUuidAliases(item))
+                Index(byUuid, uuid, item);
+        }
+
+        /// <summary>
+        /// Resolves a Foundry UUID, item name, resource name, or slug into a catalog item.
+        /// </summary>
+        /// <param name="reference">The reference value found in data or supplied by gameplay code.</param>
+        /// <returns>The matching item, or null when the catalog cannot resolve it.</returns>
+        public Pf2eItem Resolve(string reference)
+        {
+            if (string.IsNullOrWhiteSpace(reference))
+                return null;
+
+            string trimmed = reference.Trim();
+            if (byUuid.TryGetValue(trimmed, out Pf2eItem item))
+                return item;
+
+            string nameFromUuid = ExtractUuidItemName(trimmed);
+            if (!string.IsNullOrWhiteSpace(nameFromUuid) && TryResolveByNameOrSlug(nameFromUuid, out item))
+                return item;
+
+            return TryResolveByNameOrSlug(trimmed, out item) ? item : null;
+        }
+
+        /// <summary>
+        /// Resolves a human-readable item name or slug without requiring callers to know which form they have.
+        /// </summary>
+        /// <param name="value">The item name, resource name, or slug.</param>
+        /// <param name="item">The resolved item when one exists.</param>
+        /// <returns>True when the value resolves to a catalog item.</returns>
+        public bool TryResolveByNameOrSlug(string value, out Pf2eItem item)
+        {
+            item = null;
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            if (byName.TryGetValue(value, out item))
+                return true;
+
+            string slug = Pf2eSlug.FromName(value);
+            return bySlug.TryGetValue(slug, out item);
+        }
+
+        private static void Index(Dictionary<string, Pf2eItem> dictionary, string key, Pf2eItem item)
+        {
+            if (!string.IsNullOrWhiteSpace(key) && !dictionary.ContainsKey(key))
+                dictionary.Add(key, item);
+        }
+
+        private static IEnumerable<string> GenerateUuidAliases(Pf2eItem item)
+        {
+            string sourceId = item.Json.SelectToken("flags.core.sourceId")?.Value<string>()
+                ?? item.Json.SelectToken("flags.pf2e.sourceId")?.Value<string>()
+                ?? item.Json.SelectToken("system.source.value")?.Value<string>();
+            if (!string.IsNullOrWhiteSpace(sourceId))
+                yield return sourceId;
+
+            string[] commonPacks =
+            {
+                "classes",
+                "classfeatures",
+                "actionspf2e",
+                "feat-effects",
+                "feats-srd",
+                "conditionitems"
+            };
+
+            foreach (string pack in commonPacks)
+                yield return $"Compendium.pf2e.{pack}.Item.{item.Name}";
+        }
+
+        private static string ExtractUuidItemName(string reference)
+        {
+            const string marker = ".Item.";
+            int index = reference.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            return index < 0 ? null : reference.Substring(index + marker.Length);
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2eItemCatalog.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2eItemCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c427a06007d4468ac5bd51434f08ab5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/Pf2ePredicate.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2ePredicate.cs
@@ -1,0 +1,94 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Evaluates the supported subset of Foundry PF2e predicates against prepared roll options and item options.
+    /// </summary>
+    public static class Pf2ePredicate
+    {
+        /// <summary>
+        /// Determines whether a predicate matches the current prepared character and transient item context.
+        /// </summary>
+        /// <param name="predicate">The predicate token from a PF2e rule element.</param>
+        /// <param name="prepared">The prepared character supplying roll options and numeric rule facts.</param>
+        /// <param name="itemOptions">Optional item-scoped options such as traits for a Strike or item alteration.</param>
+        /// <returns>True when the predicate is empty or all supported clauses match.</returns>
+        public static bool Evaluate(JToken predicate, PreparedCharacter prepared, IEnumerable<string> itemOptions = null)
+        {
+            if (predicate == null || predicate.Type == JTokenType.Null)
+                return true;
+
+            if (predicate is JArray array)
+                return array.All(entry => Evaluate(entry, prepared, itemOptions));
+
+            if (predicate.Type == JTokenType.String)
+                return EvaluateAtomic(predicate.Value<string>(), prepared, itemOptions);
+
+            if (predicate is JObject obj)
+            {
+                if (obj.TryGetValue("and", out JToken andToken))
+                    return (andToken as JArray)?.All(entry => Evaluate(entry, prepared, itemOptions)) ?? Evaluate(andToken, prepared, itemOptions);
+                if (obj.TryGetValue("or", out JToken orToken))
+                    return (orToken as JArray)?.Any(entry => Evaluate(entry, prepared, itemOptions)) ?? Evaluate(orToken, prepared, itemOptions);
+                if (obj.TryGetValue("not", out JToken notToken))
+                    return !Evaluate(notToken, prepared, itemOptions);
+                if (obj.TryGetValue("gte", out JToken gteToken))
+                    return EvaluateGte(gteToken as JArray, prepared);
+            }
+
+            return false;
+        }
+
+        private static bool EvaluateAtomic(string option, PreparedCharacter prepared, IEnumerable<string> itemOptions)
+        {
+            if (string.IsNullOrWhiteSpace(option))
+                return true;
+
+            if (option.StartsWith("skill:", StringComparison.OrdinalIgnoreCase) && option.EndsWith(":rank", StringComparison.OrdinalIgnoreCase))
+                return GetNumeric(option, prepared) > 0;
+
+            if (option.StartsWith("skill:", StringComparison.OrdinalIgnoreCase) && option.Contains(":rank:", StringComparison.OrdinalIgnoreCase))
+            {
+                string[] parts = option.Split(':');
+                return parts.Length == 4 && int.TryParse(parts[3], out int rank) && GetNumeric($"skill:{parts[1]}:rank", prepared) >= rank;
+            }
+
+            if (itemOptions != null && itemOptions.Contains(option, StringComparer.OrdinalIgnoreCase))
+                return true;
+
+            return prepared?.RollOptions.Contains(option) ?? false;
+        }
+
+        private static bool EvaluateGte(JArray gte, PreparedCharacter prepared)
+        {
+            if (gte == null || gte.Count != 2)
+                return false;
+
+            int left = GetNumeric(gte[0].Value<string>(), prepared);
+            int right = gte[1].Value<int>();
+            return left >= right;
+        }
+
+        private static int GetNumeric(string path, PreparedCharacter prepared)
+        {
+            if (string.Equals(path, "self:level", StringComparison.OrdinalIgnoreCase))
+            {
+                string levelOption = prepared.RollOptions.FirstOrDefault(option => option.StartsWith("self:level:", StringComparison.OrdinalIgnoreCase));
+                if (levelOption != null && int.TryParse(levelOption.Substring("self:level:".Length), out int level))
+                    return level;
+            }
+
+            if (path != null && path.StartsWith("skill:", StringComparison.OrdinalIgnoreCase) && path.EndsWith(":rank", StringComparison.OrdinalIgnoreCase))
+            {
+                string skill = path.Substring("skill:".Length, path.Length - "skill:".Length - ":rank".Length);
+                return prepared.SkillRanks.TryGetValue(skill, out int rank) ? rank : 0;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2ePredicate.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2ePredicate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0914e3dc77044f1a6097647355db902
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
@@ -1,0 +1,140 @@
+using Game.AbilityActions;
+using Game.Creature;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Runtime facade for shared PF2e rule hooks that are not owned by a single action implementation.
+    /// </summary>
+    public static class Pf2eRulesEngine
+    {
+        /// <summary>
+        /// Applies prepared strike-damage modifiers and adjustments to a Strike before damage is resolved.
+        /// </summary>
+        /// <param name="attacker">The creature making the Strike and owning the prepared rule state.</param>
+        /// <param name="strike">The Strike being modified by matching PF2e rule elements.</param>
+        public static void ApplyStrikeDamageModifiers(CreatureComponent attacker, Strike strike)
+        {
+            PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(attacker);
+            List<string> itemOptions = BuildStrikeItemOptions(strike);
+            List<RuleModifier> modifiers = prepared.Modifiers
+                .Where(m => string.Equals(m.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(m => Pf2ePredicate.Evaluate(m.Predicate, prepared, itemOptions))
+                .GroupBy(m => m.Slug, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.Last())
+                .ToList();
+
+            foreach (RuleAdjustment adjustment in prepared.Adjustments
+                .Where(a => string.Equals(a.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(a => Pf2ePredicate.Evaluate(a.Predicate, prepared, itemOptions))
+                .OrderBy(a => a.Priority))
+            {
+                RuleModifier modifier = modifiers.LastOrDefault(m => string.Equals(m.Slug, adjustment.Slug, StringComparison.OrdinalIgnoreCase));
+                if (modifier == null)
+                    continue;
+
+                if (string.Equals(adjustment.Mode, "upgrade", StringComparison.OrdinalIgnoreCase))
+                    modifier.Value = Math.Max(modifier.Value, Mathf.RoundToInt(adjustment.Value));
+                else if (string.Equals(adjustment.Mode, "multiply", StringComparison.OrdinalIgnoreCase))
+                    modifier.Value = Mathf.FloorToInt(modifier.Value * adjustment.Value);
+            }
+
+            foreach (RuleModifier modifier in modifiers)
+            {
+                if (modifier.Value == 0)
+                    continue;
+
+                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
+                strike.FlatDamages.Add(new DamageValue(damageType, modifier.Value));
+            }
+        }
+
+        /// <summary>
+        /// Runs encounter-cleanup rule hooks for each combatant; action-specific details stay in their own rule classes.
+        /// </summary>
+        /// <param name="combatants">The combatants leaving encounter state.</param>
+        public static void EndEncounter(IEnumerable<ActionController> combatants)
+        {
+            if (combatants == null)
+                return;
+
+            foreach (ActionController controller in combatants)
+                new Rage(0).EndRage(controller?.gameObject);
+        }
+
+        /// <summary>
+        /// Applies combat-start rule hooks such as auto-starting Rage for matching prepared character options.
+        /// </summary>
+        /// <param name="combatants">The combatants entering encounter state.</param>
+        public static void ApplyCombatStartRules(IEnumerable<ActionController> combatants)
+        {
+            if (combatants == null)
+                return;
+
+            foreach (ActionController controller in combatants)
+            {
+                CreatureComponent creature = controller?.GetComponent<CreatureComponent>();
+                if (creature == null)
+                    continue;
+
+                PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(creature);
+                if (prepared.HasOwnedItem("quick-tempered"))
+                    new Rage(0).UseRage(controller.gameObject);
+            }
+        }
+
+        /// <summary>
+        /// Applies supported PF2e item trait alteration rules without modifying the item data itself.
+        /// </summary>
+        /// <param name="prepared">The prepared character whose item alteration rules are evaluated.</param>
+        /// <param name="itemType">The PF2e item type being altered.</param>
+        /// <param name="itemSlug">The slug of the item being altered.</param>
+        /// <param name="existingTraits">The traits already present on the item.</param>
+        /// <returns>A new trait list containing existing traits plus any matching additions.</returns>
+        public static List<string> GetAlteredTraits(PreparedCharacter prepared, string itemType, string itemSlug, IEnumerable<string> existingTraits)
+        {
+            List<string> traits = new(existingTraits ?? Enumerable.Empty<string>());
+            if (prepared == null)
+                return traits;
+
+            List<string> itemOptions = traits.Select(trait => $"item:trait:{trait}").ToList();
+            itemOptions.Add($"item:slug:{itemSlug}");
+
+            foreach (ItemAlterationRule alteration in prepared.ItemAlterations)
+            {
+                if (!string.Equals(alteration.ItemType, itemType, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!string.Equals(alteration.Property, "traits", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!string.Equals(alteration.Mode, "add", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!Pf2ePredicate.Evaluate(alteration.Predicate, prepared, itemOptions))
+                    continue;
+                if (!traits.Contains(alteration.Value))
+                    traits.Add(alteration.Value);
+            }
+
+            return traits;
+        }
+
+        private static List<string> BuildStrikeItemOptions(Strike strike)
+        {
+            List<string> options = new();
+            foreach (string trait in strike.Traits ?? new List<string>())
+                options.Add($"item:trait:{trait}");
+
+            if (strike.Traits != null && strike.Traits.Contains("thrown"))
+                options.Add("item:thrown");
+            if (strike.Traits != null && strike.Traits.Contains("ranged"))
+                options.Add("item:ranged");
+            if (strike.Traits != null && strike.Traits.Contains("unarmed"))
+                options.Add("item:category:unarmed");
+
+            return options;
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58037f10f8d32724c9b565c26bc3de1b

--- a/Assets/Scripts/Creature/Rules/Pf2eSlug.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eSlug.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Normalizes display names into PF2e-style slugs for lookups when data omits an explicit slug.
+    /// </summary>
+    public static class Pf2eSlug
+    {
+        /// <summary>
+        /// Converts a name to a lowercase hyphenated slug compatible with the project catalog indexes.
+        /// </summary>
+        /// <param name="value">The human-readable PF2e item name.</param>
+        /// <returns>A normalized slug, or an empty string for blank input.</returns>
+        public static string FromName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            string lower = value.Trim().ToLowerInvariant();
+            char[] chars = lower.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray();
+            string slug = new string(chars);
+            while (slug.Contains("--"))
+                slug = slug.Replace("--", "-");
+            return slug.Trim('-');
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/Pf2eSlug.cs.meta
+++ b/Assets/Scripts/Creature/Rules/Pf2eSlug.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b612f331e28485181c51c3dfad96324
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
+++ b/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
@@ -1,0 +1,204 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Holds derived PF2e rule state for a creature after build choices and data item rules have been prepared.
+    /// </summary>
+    public sealed class PreparedCharacter
+    {
+        public CharacterBuild Build { get; }
+        public List<OwnedPf2eItem> OwnedItems { get; } = new();
+        public HashSet<string> RollOptions { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public List<RuleModifier> Modifiers { get; } = new();
+        public List<RuleAdjustment> Adjustments { get; } = new();
+        public List<ItemAlterationRule> ItemAlterations { get; } = new();
+        public List<ActivePf2eEffect> ActiveEffects { get; } = new();
+        public Dictionary<string, int> SkillRanks { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public List<string> UnsupportedRuleKeys { get; } = new();
+
+        /// <summary>
+        /// Creates prepared state around saved build choices while leaving all derivation to the preparer.
+        /// </summary>
+        /// <param name="build">The durable character build choices that seed preparation.</param>
+        public PreparedCharacter(CharacterBuild build)
+        {
+            Build = build ?? new CharacterBuild();
+        }
+
+        /// <summary>
+        /// Adds a PF2e item once and records its roll options so later predicates can match it.
+        /// </summary>
+        /// <param name="item">The catalog item to add.</param>
+        /// <param name="grantedBy">Optional slug of the item or rule that granted this item.</param>
+        /// <returns>True when the item was newly added.</returns>
+        public bool AddOwnedItem(Pf2eItem item, string grantedBy = null)
+        {
+            if (item == null || OwnedItems.Any(owned => owned.Item.Slug == item.Slug))
+                return false;
+
+            OwnedItems.Add(new OwnedPf2eItem(item, grantedBy));
+            AddRollOptionsForItem(item);
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the character owns an item by slug.
+        /// </summary>
+        /// <param name="slug">The item slug to match.</param>
+        /// <returns>True when an owned item has the supplied slug.</returns>
+        public bool HasOwnedItem(string slug)
+        {
+            return OwnedItems.Any(item => string.Equals(item.Item.Slug, slug, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Checks whether an effect is currently active by either its effect slug or source slug.
+        /// </summary>
+        /// <param name="slug">The active effect slug or source slug to match.</param>
+        /// <returns>True when the prepared character currently has that effect.</returns>
+        public bool HasActiveEffect(string slug)
+        {
+            return ActiveEffects.Any(effect =>
+                string.Equals(effect.Slug, slug, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(effect.SourceSlug, slug, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Records an active effect and exposes the Foundry-style effect roll options used by predicates.
+        /// </summary>
+        /// <param name="item">The effect item from the catalog, when one can be resolved.</param>
+        /// <param name="sourceSlug">The stable source slug used by the rule that activated the effect.</param>
+        /// <returns>The existing or newly created active effect entry.</returns>
+        public ActivePf2eEffect AddActiveEffect(Pf2eItem item, string sourceSlug)
+        {
+            string slug = string.IsNullOrWhiteSpace(sourceSlug) ? item?.Slug : sourceSlug;
+            ActivePf2eEffect existing = ActiveEffects.FirstOrDefault(effect =>
+                string.Equals(effect.Slug, slug, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(effect.SourceSlug, slug, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+                return existing;
+
+            ActivePf2eEffect active = new(item?.Name ?? slug, slug, item?.Slug ?? slug);
+            ActiveEffects.Add(active);
+            RollOptions.Add($"self:effect:{slug}");
+            if (item != null)
+                RollOptions.Add($"self:effect:{item.Slug}");
+            return active;
+        }
+
+        /// <summary>
+        /// Removes active effect state and the roll options that came from it.
+        /// </summary>
+        /// <param name="slug">The effect slug or source slug to remove.</param>
+        public void RemoveActiveEffect(string slug)
+        {
+            foreach (ActivePf2eEffect effect in ActiveEffects.Where(effect =>
+                string.Equals(effect.Slug, slug, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(effect.SourceSlug, slug, StringComparison.OrdinalIgnoreCase)).ToArray())
+            {
+                RollOptions.Remove($"self:effect:{effect.Slug}");
+                RollOptions.Remove($"self:effect:{effect.SourceSlug}");
+                ActiveEffects.Remove(effect);
+            }
+        }
+
+        private void AddRollOptionsForItem(Pf2eItem item)
+        {
+            if (item.Type == "class")
+                RollOptions.Add($"class:{item.Slug}");
+
+            if (item.Type == "feat")
+                RollOptions.Add($"feat:{item.Slug}");
+
+            string category = item.System?.SelectToken("category")?.Value<string>();
+            if (item.Type == "feat" && string.Equals(category, "classfeature", StringComparison.OrdinalIgnoreCase))
+                RollOptions.Add($"feature:{item.Slug}");
+
+            if (item.Type == "action")
+                RollOptions.Add($"action:{item.Slug}");
+        }
+    }
+
+    /// <summary>
+    /// Records a prepared item and the optional source that granted it so future rules can reason about provenance.
+    /// </summary>
+    public sealed class OwnedPf2eItem
+    {
+        public Pf2eItem Item { get; }
+        public string GrantedBy { get; }
+
+        /// <summary>
+        /// Creates a prepared ownership record for a PF2e item.
+        /// </summary>
+        /// <param name="item">The owned PF2e catalog item.</param>
+        /// <param name="grantedBy">The slug of the item or rule that granted it, when known.</param>
+        public OwnedPf2eItem(Pf2eItem item, string grantedBy)
+        {
+            Item = item;
+            GrantedBy = grantedBy;
+        }
+    }
+
+    /// <summary>
+    /// Tracks an active PF2e effect in prepared state without requiring Unity components to know its source JSON.
+    /// </summary>
+    public sealed class ActivePf2eEffect
+    {
+        public string Name { get; }
+        public string Slug { get; }
+        public string SourceSlug { get; }
+
+        /// <summary>
+        /// Creates an active effect entry with both runtime and source identifiers.
+        /// </summary>
+        /// <param name="name">The display name of the active effect.</param>
+        /// <param name="slug">The runtime effect slug used for rule checks.</param>
+        /// <param name="sourceSlug">The source item slug used for cleanup and predicate options.</param>
+        public ActivePf2eEffect(string name, string slug, string sourceSlug)
+        {
+            Name = name;
+            Slug = slug;
+            SourceSlug = sourceSlug;
+        }
+    }
+
+    /// <summary>
+    /// Represents a supported FlatModifier rule element after item preparation.
+    /// </summary>
+    public sealed class RuleModifier
+    {
+        public string Selector;
+        public string Slug;
+        public int Value;
+        public JToken Predicate;
+    }
+
+    /// <summary>
+    /// Represents a supported AdjustModifier rule element that can alter a prepared modifier by selector and slug.
+    /// </summary>
+    public sealed class RuleAdjustment
+    {
+        public string Selector;
+        public string Slug;
+        public string Mode;
+        public float Value;
+        public int Priority;
+        public JToken Predicate;
+    }
+
+    /// <summary>
+    /// Represents a supported ItemAlteration rule element while keeping upstream item JSON unchanged.
+    /// </summary>
+    public sealed class ItemAlterationRule
+    {
+        public string ItemType;
+        public string Mode;
+        public string Property;
+        public string Value;
+        public JToken Predicate;
+    }
+}

--- a/Assets/Scripts/Creature/Rules/PreparedCharacter.cs.meta
+++ b/Assets/Scripts/Creature/Rules/PreparedCharacter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02d06fcaef8b47558daf289c197cb8f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/RageRule.cs
+++ b/Assets/Scripts/Creature/Rules/RageRule.cs
@@ -1,0 +1,149 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Supplies all Unity-free inputs needed to decide whether Rage can start and which side effects should result.
+    /// </summary>
+    public sealed class RageRequest
+    {
+        public CreatureRulesState Creature { get; set; }
+        public uint ActionCost { get; set; }
+        public Pf2eItemCatalog Catalog { get; set; }
+    }
+
+    /// <summary>
+    /// Describes the outcome of evaluating Rage, separating PF2e rule decisions from Unity-side mutation.
+    /// </summary>
+    public sealed class RageRuleResult
+    {
+        public bool Applied { get; }
+        public string FailureReason { get; }
+        public IReadOnlyList<RuleEffect> Effects { get; }
+
+        private RageRuleResult(bool applied, string failureReason, IReadOnlyList<RuleEffect> effects)
+        {
+            Applied = applied;
+            FailureReason = failureReason;
+            Effects = effects ?? Array.Empty<RuleEffect>();
+        }
+
+        /// <summary>
+        /// Creates a successful Rage result with the generic side effects that the Unity layer should apply.
+        /// </summary>
+        /// <param name="effects">The ordered side effects produced by the rule.</param>
+        /// <returns>A successful rule result.</returns>
+        public static RageRuleResult Success(IReadOnlyList<RuleEffect> effects)
+        {
+            return new RageRuleResult(true, null, effects);
+        }
+
+        /// <summary>
+        /// Creates a blocked Rage result with a diagnostic reason and no side effects.
+        /// </summary>
+        /// <param name="reason">The rules reason Rage could not be applied.</param>
+        /// <returns>A blocked rule result.</returns>
+        public static RageRuleResult Blocked(string reason)
+        {
+            return new RageRuleResult(false, reason, Array.Empty<RuleEffect>());
+        }
+    }
+
+    /// <summary>
+    /// Owns PF2e Rage behavior while remaining independent of GameObject, MonoBehaviour, and UI state.
+    /// </summary>
+    public static class RageRule
+    {
+        private const string RageSource = "rage";
+        private const string RageTempHpImmunitySource = "rage-temp-hp-immunity";
+
+        /// <summary>
+        /// Checks Rage eligibility using prepared rule state and current creature facts.
+        /// </summary>
+        /// <param name="request">The Unity-free Rage inputs.</param>
+        /// <returns>True when Rage can currently be applied.</returns>
+        public static bool CanApply(RageRequest request)
+        {
+            return GetBlockReason(request) == null;
+        }
+
+        /// <summary>
+        /// Applies the Rage rule to prepared state and returns generic side effects for the host layer to perform.
+        /// </summary>
+        /// <param name="request">The Unity-free Rage inputs.</param>
+        /// <returns>The rule result, including any side effects needed to reflect successful Rage in Unity.</returns>
+        public static RageRuleResult Apply(RageRequest request)
+        {
+            string blockReason = GetBlockReason(request);
+            if (blockReason != null)
+                return RageRuleResult.Blocked(blockReason);
+
+            CreatureRulesState creature = request.Creature;
+            PreparedCharacter prepared = creature.Prepared;
+            Pf2eItemCatalog catalog = request.Catalog ?? Pf2eItemCatalog.Instance;
+            Pf2eItem rageAction = catalog.Resolve("Rage");
+            string effectUuid = rageAction?.System?.SelectToken("selfEffect.uuid")?.Value<string>();
+            Pf2eItem rageEffect = catalog.Resolve(effectUuid) ?? catalog.Resolve("Effect: Rage");
+            prepared.AddActiveEffect(rageEffect, RageSource);
+
+            List<RuleEffect> effects = new()
+            {
+                RuleEffect.SpendActions(request.ActionCost),
+                RuleEffect.SetTakingActionFalse()
+            };
+
+            int tempHp = Math.Max(0, creature.Level + creature.ConstitutionModifier);
+            if (!creature.HasTempHpImmunity(RageSource) && tempHp > 0)
+                effects.Add(RuleEffect.GainSourceTempHp(RageSource, tempHp));
+
+            return RageRuleResult.Success(effects);
+        }
+
+        /// <summary>
+        /// Ends active Rage in prepared state and emits cleanup effects, including temporary Hit Point immunity.
+        /// </summary>
+        /// <param name="creature">The Unity-free creature facts and prepared state.</param>
+        /// <param name="catalog">Optional catalog override for resolving the immunity effect in tests.</param>
+        /// <returns>A rule result containing cleanup effects, or a blocked result when the creature is not raging.</returns>
+        public static RageRuleResult End(CreatureRulesState creature, Pf2eItemCatalog catalog = null)
+        {
+            if (creature?.Prepared == null || !creature.Prepared.HasActiveEffect(RageSource))
+                return RageRuleResult.Blocked("Creature is not raging.");
+
+            creature.Prepared.RemoveActiveEffect(RageSource);
+            catalog ??= Pf2eItemCatalog.Instance;
+            Pf2eItem immunity = catalog.Resolve("Effect: Rage Temporary Hit Points Immunity");
+            creature.Prepared.AddActiveEffect(immunity, RageTempHpImmunitySource);
+
+            return RageRuleResult.Success(new List<RuleEffect>
+            {
+                RuleEffect.RemoveSourceTempHp(RageSource),
+                RuleEffect.AddTempHpImmunity(RageSource)
+            });
+        }
+
+        private static string GetBlockReason(RageRequest request)
+        {
+            CreatureRulesState creature = request?.Creature;
+            if (creature?.Prepared == null)
+                return "Creature is not prepared for PF2e rules.";
+
+            if (creature.Prepared.HasActiveEffect(RageSource))
+                return "Creature is already raging.";
+
+            if (creature.HasCondition("Fatigued"))
+                return "Creature is fatigued.";
+
+            if (creature.HasCondition("Encumbered"))
+                return "Creature is encumbered.";
+
+            if (string.Equals(creature.ArmorCategory, "heavy", StringComparison.OrdinalIgnoreCase)
+                && !creature.Prepared.RollOptions.Contains("feat:invulnerable-rager"))
+                return "Creature is wearing heavy armor.";
+
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/RageRule.cs.meta
+++ b/Assets/Scripts/Creature/Rules/RageRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d981f41451e45f79e0bb118a0607d9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/RuleEffect.cs
+++ b/Assets/Scripts/Creature/Rules/RuleEffect.cs
@@ -1,0 +1,83 @@
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Identifies generic host-side effects emitted by Unity-free rules; keep this vocabulary concrete and reusable.
+    /// </summary>
+    public enum RuleEffectType
+    {
+        SpendActions,
+        SetTakingActionFalse,
+        GainSourceTempHp,
+        RemoveSourceTempHp,
+        AddTempHpImmunity
+    }
+
+    /// <summary>
+    /// Represents one generic side effect that a rule wants the Unity layer to apply.
+    /// </summary>
+    public sealed class RuleEffect
+    {
+        public RuleEffectType Type { get; }
+        public string Source { get; }
+        public int Amount { get; }
+        public uint ActionCost { get; }
+
+        private RuleEffect(RuleEffectType type, string source = null, int amount = 0, uint actionCost = 0)
+        {
+            Type = type;
+            Source = source;
+            Amount = amount;
+            ActionCost = actionCost;
+        }
+
+        /// <summary>
+        /// Creates an effect that spends action points from the acting Unity controller.
+        /// </summary>
+        /// <param name="actionCost">The number of action points to spend.</param>
+        /// <returns>A generic action-spend effect.</returns>
+        public static RuleEffect SpendActions(uint actionCost)
+        {
+            return new RuleEffect(RuleEffectType.SpendActions, actionCost: actionCost);
+        }
+
+        /// <summary>
+        /// Creates an effect that clears the Unity action-in-progress flag after a rule resolves.
+        /// </summary>
+        /// <returns>A generic action-state cleanup effect.</returns>
+        public static RuleEffect SetTakingActionFalse()
+        {
+            return new RuleEffect(RuleEffectType.SetTakingActionFalse);
+        }
+
+        /// <summary>
+        /// Creates an effect that grants temporary Hit Points associated with a stable rule source.
+        /// </summary>
+        /// <param name="source">The source key used for later removal or immunity checks.</param>
+        /// <param name="amount">The amount of temporary Hit Points to grant.</param>
+        /// <returns>A generic source-tracked temporary Hit Point effect.</returns>
+        public static RuleEffect GainSourceTempHp(string source, int amount)
+        {
+            return new RuleEffect(RuleEffectType.GainSourceTempHp, source, amount);
+        }
+
+        /// <summary>
+        /// Creates an effect that removes temporary Hit Points associated with a stable rule source.
+        /// </summary>
+        /// <param name="source">The source key to remove.</param>
+        /// <returns>A generic source-tracked temporary Hit Point removal effect.</returns>
+        public static RuleEffect RemoveSourceTempHp(string source)
+        {
+            return new RuleEffect(RuleEffectType.RemoveSourceTempHp, source);
+        }
+
+        /// <summary>
+        /// Creates an effect that prevents a source from granting temporary Hit Points again until reset by game flow.
+        /// </summary>
+        /// <param name="source">The source key that should become temporarily immune.</param>
+        /// <returns>A generic temporary Hit Point immunity effect.</returns>
+        public static RuleEffect AddTempHpImmunity(string source)
+        {
+            return new RuleEffect(RuleEffectType.AddTempHpImmunity, source);
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/RuleEffect.cs.meta
+++ b/Assets/Scripts/Creature/Rules/RuleEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bd84d2a90fe4bdfad781261a14a2e65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/UnityCreatureRulesAdapter.cs
+++ b/Assets/Scripts/Creature/Rules/UnityCreatureRulesAdapter.cs
@@ -1,0 +1,40 @@
+using Game.Creature;
+using System;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Extracts Unity component state into Unity-free rule state; it should not apply rule results or contain action logic.
+    /// </summary>
+    public static class UnityCreatureRulesAdapter
+    {
+        /// <summary>
+        /// Builds a rules snapshot from an actor GameObject for use by pure PF2e rule classes.
+        /// </summary>
+        /// <param name="actor">The Unity actor whose creature, conditions, and prepared data should be read.</param>
+        /// <returns>A Unity-free creature rules state, or an empty state when the actor is missing required components.</returns>
+        public static CreatureRulesState From(GameObject actor)
+        {
+            if (actor == null)
+                return new CreatureRulesState();
+
+            CreatureComponent creature = actor.GetComponent<CreatureComponent>();
+            if (creature == null)
+                return new CreatureRulesState();
+
+            Conditions conditions = actor.GetComponent<Conditions>();
+            PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(creature);
+
+            return new CreatureRulesState
+            {
+                Level = creature.level,
+                ConstitutionModifier = creature.conMod,
+                ArmorCategory = creature.equippedArmor?.category,
+                Prepared = prepared,
+                Conditions = conditions?.GetConditionNames() ?? Array.Empty<string>(),
+                TempHpImmunitySources = creature.GetTempHpImmunitySources()
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/UnityCreatureRulesAdapter.cs.meta
+++ b/Assets/Scripts/Creature/Rules/UnityCreatureRulesAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7d7ee55c2ab47e4af3cb3da61d52362
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/Rules/UnityRuleEffectApplier.cs
+++ b/Assets/Scripts/Creature/Rules/UnityRuleEffectApplier.cs
@@ -1,0 +1,53 @@
+using Game.Creature;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Creature.Rules
+{
+    /// <summary>
+    /// Applies generic rule effects back to Unity components without knowing which PF2e rule produced them.
+    /// </summary>
+    public static class UnityRuleEffectApplier
+    {
+        /// <summary>
+        /// Applies an ordered list of generic effects to an actor GameObject.
+        /// </summary>
+        /// <param name="actor">The Unity actor receiving the side effects.</param>
+        /// <param name="effects">The generic effects emitted by a Unity-free rule.</param>
+        public static void Apply(GameObject actor, IEnumerable<RuleEffect> effects)
+        {
+            if (actor == null || effects == null)
+                return;
+
+            CreatureComponent creature = actor.GetComponent<CreatureComponent>();
+            ActionController actionController = actor.GetComponent<ActionController>();
+
+            foreach (RuleEffect effect in effects)
+            {
+                if (effect == null)
+                    continue;
+
+                switch (effect.Type)
+                {
+                    case RuleEffectType.SpendActions:
+                        if (actionController != null)
+                            actionController.ActionPoints -= effect.ActionCost;
+                        break;
+                    case RuleEffectType.SetTakingActionFalse:
+                        if (actionController != null)
+                            actionController.IsTakingAction = false;
+                        break;
+                    case RuleEffectType.GainSourceTempHp:
+                        creature?.GainSourceTempHp(effect.Source, effect.Amount);
+                        break;
+                    case RuleEffectType.RemoveSourceTempHp:
+                        creature?.RemoveSourceTempHp(effect.Source);
+                        break;
+                    case RuleEffectType.AddTempHpImmunity:
+                        creature?.AddTempHpImmunity(effect.Source);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Creature/Rules/UnityRuleEffectApplier.cs.meta
+++ b/Assets/Scripts/Creature/Rules/UnityRuleEffectApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5beef49f6644f789c905fd4d138145d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Game.AbilityActions;
 using Game.Creature;
+using Game.Creature.Rules;
 using Game.Strikes;
 using GridPrivate;
 using GridPublic;
@@ -347,11 +348,33 @@ namespace TestsCombat
         public void RageDamageIgnoresProjectileStrikeWithoutMeleeFlatDamage()
         {
             // PF2e source for Rage applying additional damage only to melee Strikes: https://2e.aonprd.com/Actions.aspx?ID=2802
-            Strike projectileStrike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
-            Rage rage = new Rage(1);
+            GameObject creatureObject = new GameObject("raging archer");
+            try
+            {
+                CreatureComponent creature = creatureObject.AddComponent<CreatureComponent>();
+                creatureObject.AddComponent<Conditions>();
+                creature.level = 1;
+                creature.conMod = 1;
+                creature.Build = new CharacterBuild
+                {
+                    ClassName = "Barbarian",
+                    SubclassName = "Fury Instinct",
+                    ClassFeatName = "Raging Intimidation"
+                };
+                creature.Prepared = Pf2eCharacterPreparer.Prepare(creature, creature.Build);
+                Assert.IsTrue(new Rage(0).UseRage(creatureObject));
 
-            Assert.DoesNotThrow(() => rage.AddRageDamage(projectileStrike));
-            Assert.AreEqual(0, projectileStrike.FlatDamages.Count);
+                Strike projectileStrike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
+                projectileStrike.Traits.Add("ranged");
+
+                Assert.DoesNotThrow(() => Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, projectileStrike));
+                Assert.AreEqual(0, projectileStrike.FlatDamages.Count);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(creatureObject);
+                Pf2eItemCatalog.ResetForTests();
+            }
         }
 
         private static Tile[,] BuildTiles(int width, int height)

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs
@@ -1,0 +1,210 @@
+using Game.AbilityActions;
+using Game.Creature;
+using Game.Creature.Rules;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class Pf2eRulesTests
+{
+    private readonly List<GameObject> created = new();
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (GameObject go in created)
+            if (go != null)
+                Object.DestroyImmediate(go);
+        created.Clear();
+        Pf2eItemCatalog.ResetForTests();
+    }
+
+    [Test]
+    public void CatalogResolvesFoundryStyleReferences()
+    {
+        Pf2eItemCatalog catalog = Pf2eItemCatalog.Instance;
+
+        Assert.That(catalog.Resolve("Compendium.pf2e.classes.Item.Barbarian")?.Slug, Is.EqualTo("barbarian"));
+        Assert.That(catalog.Resolve("Compendium.pf2e.actionspf2e.Item.Rage")?.Slug, Is.EqualTo("rage"));
+        Assert.That(catalog.Resolve("Compendium.pf2e.feat-effects.Item.Effect: Rage")?.Slug, Is.EqualTo("effect-rage"));
+        Assert.That(catalog.Resolve("Raging Intimidation")?.Slug, Is.EqualTo("raging-intimidation"));
+    }
+
+    [Test]
+    public void TorgrimPreparesBarbarianFeaturesFromBuildData()
+    {
+        GameObject torgrim = CreatureJsonConverter.CreateFromFile("DataFiles/playerCharacters/Torgrim");
+        created.Add(torgrim);
+        CreatureComponent creature = torgrim.GetComponent<CreatureComponent>();
+
+        Assert.That(creature.Build.ClassName, Is.EqualTo("Barbarian"));
+        Assert.That(creature.Build.SubclassName, Is.EqualTo("Fury Instinct"));
+        Assert.That(creature.Prepared.HasOwnedItem("barbarian"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("quick-tempered"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("rage"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("fury-instinct"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("raging-intimidation"), Is.True);
+        Assert.That(creature.Prepared.Build.RuleSelections["furyInstinct"], Does.Contain("Raging Intimidation"));
+    }
+
+    [Test]
+    public void PredicateSupportsAtomicCompoundAndNumericChecks()
+    {
+        PreparedCharacter prepared = new(new CharacterBuild());
+        prepared.RollOptions.Add("class:barbarian");
+        prepared.RollOptions.Add("self:effect:rage");
+        prepared.RollOptions.Add("self:level:7");
+        prepared.SkillRanks["intimidation"] = 4;
+
+        Assert.That(Pf2ePredicate.Evaluate(JToken.Parse("[\"class:barbarian\", {\"not\": \"item:ranged\"}]"), prepared), Is.True);
+        Assert.That(Pf2ePredicate.Evaluate(JToken.Parse("[{\"or\": [\"item:ranged\", \"self:effect:rage\"]}]"), prepared), Is.True);
+        Assert.That(Pf2ePredicate.Evaluate(JToken.Parse("[{\"gte\": [\"self:level\", 7]}, {\"gte\": [\"skill:intimidation:rank\", 4]}]"), prepared), Is.True);
+        Assert.That(Pf2ePredicate.Evaluate(JToken.Parse("[{\"and\": [\"class:barbarian\", {\"not\": \"item:ranged\"}]}]"), prepared), Is.True);
+    }
+
+    [Test]
+    public void RageRuleAppliesActiveEffectAndEmitsTempHpEffects()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+        CreatureRulesState state = UnityCreatureRulesAdapter.From(creature.gameObject);
+
+        RageRuleResult result = RageRule.Apply(new RageRequest { Creature = state, ActionCost = 0 });
+
+        Assert.That(result.Applied, Is.True);
+        Assert.That(creature.Prepared.HasActiveEffect("effect-rage"), Is.True);
+        Assert.That(creature.Prepared.RollOptions.Contains("self:effect:effect-rage"), Is.True);
+        Assert.That(result.Effects.Any(e => e.Type == RuleEffectType.GainSourceTempHp && e.Source == "rage" && e.Amount == 2), Is.True);
+    }
+
+    [Test]
+    public void RageRuleBlocksInvalidRageStates()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+
+        Assert.That(RageRule.CanApply(new RageRequest
+        {
+            Creature = new CreatureRulesState
+            {
+                Prepared = creature.Prepared,
+                Conditions = new[] { "Fatigued" }
+            }
+        }), Is.False);
+
+        Assert.That(RageRule.CanApply(new RageRequest
+        {
+            Creature = new CreatureRulesState
+            {
+                Prepared = creature.Prepared,
+                Conditions = new[] { "Encumbered" }
+            }
+        }), Is.False);
+
+        Assert.That(RageRule.CanApply(new RageRequest
+        {
+            Creature = new CreatureRulesState
+            {
+                Prepared = creature.Prepared,
+                ArmorCategory = "heavy"
+            }
+        }), Is.False);
+    }
+
+    [Test]
+    public void RageRuleEndRemovesActiveEffectAndEmitsCleanupEffects()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+        RageRule.Apply(new RageRequest { Creature = UnityCreatureRulesAdapter.From(creature.gameObject), ActionCost = 0 });
+
+        RageRuleResult end = RageRule.End(UnityCreatureRulesAdapter.From(creature.gameObject));
+
+        Assert.That(end.Applied, Is.True);
+        Assert.That(creature.Prepared.HasActiveEffect("effect-rage"), Is.False);
+        Assert.That(creature.Prepared.HasActiveEffect("rage-temp-hp-immunity"), Is.True);
+        Assert.That(end.Effects.Any(e => e.Type == RuleEffectType.RemoveSourceTempHp && e.Source == "rage"), Is.True);
+        Assert.That(end.Effects.Any(e => e.Type == RuleEffectType.AddTempHpImmunity && e.Source == "rage"), Is.True);
+    }
+
+    [Test]
+    public void RageUnityActionAppliesRuleEffectsToUnityComponents()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+        TestActionController actionController = creature.gameObject.AddComponent<TestActionController>();
+        actionController.ActionPoints = 3;
+        actionController.IsTakingAction = true;
+
+        Rage rage = new(1);
+        Assert.That(rage.UseRage(creature.gameObject), Is.True);
+
+        Assert.That(creature.tempHp, Is.EqualTo(2));
+        Assert.That(actionController.ActionPoints, Is.EqualTo(2));
+        Assert.That(actionController.IsTakingAction, Is.False);
+
+        rage.EndRage(creature.gameObject);
+        Assert.That(creature.tempHp, Is.EqualTo(0));
+        Assert.That(creature.HasTempHpImmunity("rage"), Is.True);
+
+        Assert.That(rage.UseRage(creature.gameObject), Is.True);
+        Assert.That(creature.tempHp, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RageDamageUsesRuleModifiersAndFuryInstinctAdjustments()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+        Assert.That(new Rage(0).UseRage(creature.gameObject), Is.True);
+
+        Strike greataxe = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, greataxe);
+        Assert.That(greataxe.FlatDamages.Last().DamageAmount, Is.EqualTo(3));
+
+        Strike agile = new(new List<Dice> { new Dice(1, 4, "Bludgeoning") }, new List<DamageValue> { new DamageValue("Bludgeoning", 4) });
+        agile.Traits.Add("agile");
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, agile);
+        Assert.That(agile.FlatDamages.Last().DamageAmount, Is.EqualTo(1));
+
+        new Rage(0).EndRage(creature.gameObject);
+        Strike notRaging = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, notRaging);
+        Assert.That(notRaging.FlatDamages.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void RagingIntimidationItemAlterationAddsRageTraitOnlyWhileRaging()
+    {
+        CreatureComponent creature = CreatePreparedBarbarian();
+
+        List<string> beforeRage = Pf2eRulesEngine.GetAlteredTraits(creature.Prepared, "action", "demoralize", new List<string>());
+        Assert.That(beforeRage, Does.Not.Contain("rage"));
+
+        Assert.That(new Rage(0).UseRage(creature.gameObject), Is.True);
+        List<string> duringRage = Pf2eRulesEngine.GetAlteredTraits(creature.Prepared, "action", "demoralize", new List<string>());
+        Assert.That(duringRage, Does.Contain("rage"));
+    }
+
+    private CreatureComponent CreatePreparedBarbarian()
+    {
+        GameObject go = new("Prepared Barbarian");
+        created.Add(go);
+        CreatureComponent creature = go.AddComponent<CreatureComponent>();
+        go.AddComponent<Conditions>();
+        creature.level = 1;
+        creature.conMod = 1;
+        creature.Build = new CharacterBuild
+        {
+            ClassName = "Barbarian",
+            SubclassName = "Fury Instinct",
+            ClassFeatName = "Raging Intimidation"
+        };
+        creature.Prepared = Pf2eCharacterPreparer.Prepare(creature, creature.Build);
+        return creature;
+    }
+
+    private sealed class TestActionController : ActionController
+    {
+        public override void EndTurn()
+        {
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs.meta
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf8352a2074a2a04d984cc678930ec74

--- a/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs
@@ -1,0 +1,95 @@
+using Game.Creature;
+using Game.Creature.Rules;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class Pf2eBarbarianSmokeTests
+{
+    private readonly List<GameObject> created = new();
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (GameObject go in created)
+            if (go != null)
+                Object.Destroy(go);
+        created.Clear();
+        OnCombatStart.RemoveAllListeners();
+        OnCombatEnd.RemoveAllListeners();
+        OnNextTurn.RemoveAllListeners();
+        Pf2eItemCatalog.ResetForTests();
+    }
+
+    [UnityTest]
+    public IEnumerator TorgrimQuickTemperedRagesAtCombatStart()
+    {
+        GameObject teamRulesGo = Create("TeamRules");
+        teamRulesGo.AddComponent<TeamRules>();
+        GameObject logGo = Create("TestCombatLog");
+        logGo.AddComponent<TestCombatLog>();
+        GameObject managerGo = Create("CombatManager");
+        CombatManager manager = managerGo.AddComponent<CombatManager>();
+
+        GameObject torgrim = CreatureJsonConverter.CreateFromFile("DataFiles/playerCharacters/Torgrim");
+        created.Add(torgrim);
+        torgrim.AddComponent<Conditions>();
+        torgrim.AddComponent<TestActionController>();
+        Team torgrimTeam = torgrim.AddComponent<Team>();
+        torgrimTeam.Name = "Players";
+
+        GameObject enemy = Create("Enemy");
+        CreatureComponent enemyCreature = enemy.AddComponent<CreatureComponent>();
+        enemyCreature.name = "Enemy";
+        enemyCreature.level = 1;
+        enemyCreature.hp = 10;
+        enemyCreature.maxHp = 10;
+        enemy.AddComponent<Conditions>();
+        enemy.AddComponent<TestActionController>();
+        Team enemyTeam = enemy.AddComponent<Team>();
+        enemyTeam.Name = "Enemies";
+
+        manager.AddCombatant(torgrim.GetComponent<ActionController>());
+        manager.AddCombatant(enemy.GetComponent<ActionController>());
+        manager.StartCombat();
+        yield return null;
+
+        CreatureComponent torgrimCreature = torgrim.GetComponent<CreatureComponent>();
+        Assert.That(torgrimCreature.Prepared.HasOwnedItem("quick-tempered"), Is.True);
+        Assert.That(torgrimCreature.Prepared.HasActiveEffect("rage"), Is.True);
+        Assert.That(torgrimCreature.tempHp, Is.EqualTo(torgrimCreature.level + torgrimCreature.conMod));
+    }
+
+    private GameObject Create(string name)
+    {
+        GameObject go = new(name);
+        created.Add(go);
+        return go;
+    }
+
+    private sealed class TestActionController : ActionController
+    {
+        public override void EndTurn()
+        {
+        }
+    }
+
+    private sealed class TestCombatLog : CombatLogInterface
+    {
+        private readonly List<string> messages = new();
+
+        public override void DevMode() { }
+        public override void ReleaseMode() { }
+        public override void AddWhiteList(string tag) { }
+        public override void AddBlackList(string tag) { }
+        public override void Log(string msg) => messages.Add(msg);
+        public override void DevLog(string msg) => messages.Add(msg);
+        public override void DevLog(string msg, string tag) => messages.Add(msg);
+        public override void DevLog(string msg, List<string> tags) => messages.Add(msg);
+        public override void Log(string msg, string tag) => messages.Add(msg);
+        public override void Log(string msg, List<string> tags) => messages.Add(msg);
+        public override List<string> GetMessages() => new(messages);
+    }
+}

--- a/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs.meta
+++ b/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f56c4592b78f0d48b9a00b7dbbd94e5

--- a/Docs/PF2E_RULE_PIPELINE.md
+++ b/Docs/PF2E_RULE_PIPELINE.md
@@ -1,0 +1,46 @@
+# PF2e Class and Rule Preparation
+
+Imported PF2e item JSON under `Assets/Resources/DataFiles` is treated as source data. Keep FoundryVTT PF2e files verbatim where practical so future imports can diff and refresh them cleanly. Unity-owned data belongs outside imported item JSON: saved character choices live in `CharacterBuild`, runtime state lives in `PreparedCharacter`, and provenance/import notes live in docs or sidecar files outside `Resources`.
+
+## Preparation Flow
+
+Player creature JSON is still loaded into `CreatureComponent` for the existing combat fields. When `playerOnlyStuff` contains a class build, the loader also creates a `CharacterBuild` and prepares a `PreparedCharacter`:
+
+1. Reset prepared state.
+2. Resolve the selected class from `DataFiles/classes`.
+3. Apply class base math from the class item.
+4. Grant class items from `system.items` up to the creature level.
+5. Add selected subclass and class feat items from saved build choices.
+6. Resolve `ChoiceSet` and `GrantItem` rules into owned items.
+7. Collect typed rule synthetics for combat evaluation.
+
+Legacy `passives` callbacks remain only for creatures without a player build, so monster imports are not broken by the player-class pipeline.
+
+## Supported Rule Elements
+
+The first implementation supports the subset needed for level-1 barbarian behavior:
+
+- `FlatModifier` for selector-based numeric bonuses such as Rage damage.
+- `AdjustModifier` for slug-targeted upgrades and multipliers such as Fury Instinct and agile Rage damage.
+- `ChoiceSet` for persisted build selections.
+- `GrantItem` for adding owned items while preserving the granting item slug.
+- `ItemAlteration` for conditional trait changes such as Raging Intimidation adding `rage`.
+- `RollOption` for feature/effect flags.
+- `TempHP` through source-tracked Rage temp HP runtime state.
+- `Resistance` is accepted as schema data but not applied to damage yet.
+
+Unsupported rule keys are collected on `PreparedCharacter.UnsupportedRuleKeys` and ignored rather than removed from source JSON.
+
+## Predicates
+
+Predicates support atomic roll options, `and`, `or`, `not`, and numeric `gte`. The implemented atoms cover current barbarian data, including class, feat, feature, effect, item trait, ranged/thrown, armor category, and skill-rank checks.
+
+## Barbarian V1
+
+Rage applies active effect state and source-tracked temporary HP. Strike damage is evaluated from prepared rule modifiers instead of static `OnStrikeEvent` listeners. Quick-Tempered runs from combat-start timing after initiative is rolled. Fury Instinct defaults Torgrim's bonus level-1 barbarian feat selection to Raging Intimidation when saved build data does not override it.
+
+## Tests
+
+Rules changes should prefer deterministic EditMode tests for catalog resolution, preparation, predicates, rule grants, active effects, temp HP, and damage modifiers. Use PlayMode smoke tests for scene/combat timing such as Quick-Tempered.
+
+Run Unity tests with the project Unity version and do not pass `-quit`.

--- a/Docs/foundry-pf2e-import-manifest.json
+++ b/Docs/foundry-pf2e-import-manifest.json
@@ -1,0 +1,15 @@
+{
+  "source": "foundryvtt/pf2e",
+  "ref": "v14-dev",
+  "policy": "Imported PF2e item JSON should remain verbatim where practical. Unity-specific build choices, runtime state, and resource-path mappings live in code or sidecar files rather than in imported JSON.",
+  "imports": [
+    {
+      "localPath": "Assets/Resources/DataFiles/effects/effect-rage.json",
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feat-effects/effect-rage.json"
+    },
+    {
+      "localPath": "Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json",
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feat-effects/effect-rage-temporary-hit-points-immunity.json"
+    }
+  ]
+}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.feature.development": "1.0.2",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.test-framework": "1.5.1",
     "com.unity.timeline": "1.8.9",
     "com.unity.ugui": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -93,7 +93,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.2.1",
-      "depth": 1,
+      "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
## Summary
- Adds a Foundry-shaped PF2e item catalog and prepared character/rule pipeline for player class builds.
- Reworks barbarian Rage, Fury Instinct, Raging Intimidation, and Quick-Tempered through prepared rule data instead of passive callbacks/static strike listeners.
- Imports verbatim Foundry PF2e Rage effect JSON files and documents data ownership/provenance expectations.

## Tests
- EditMode: 7 passed, 0 failed
- PlayMode: 25 passed, 0 failed

## Visual Evidence
No screenshots attached. This PR changes rules code, JSON data, tests, and docs only; it does not change scenes, prefabs, UI, materials, models, VFX, animation, or art assets.

Closes #78