### PR TITLE
Add PF2e typed modifier stacking

### DIFF
--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Game.Creature;
+using Game.Rules;
 using System;
 using GridPublic;
 
@@ -56,19 +57,24 @@ public class Strike
         int coverBonus = TargetingResult?.CoverAcBonus ?? 0;
 
         int attackBonus = AttackModifierOverride ?? from.attackBonus;
-        int targetAc = to.ac + coverBonus;
-        int totalModifier = attackBonus - mapPenalty + rangePenalty;
+        Pf2eModifierResolution attackResolution = from.ResolveAttackRoll(AttackModifierOverride, BuildStrikeAttackModifiers(mapPenalty, rangePenalty));
+        Pf2eModifierResolution baseAcResolution = to.ResolveArmorClass();
+        Pf2eModifierResolution targetAcResolution = to.ResolveArmorClass(BuildStrikeAcModifiers(coverBonus));
+        int targetAc = targetAcResolution.Total;
+        int totalModifier = attackResolution.Total;
 
         D20Result attackRoll = D20.Roll(totalModifier, targetAc);
 
         string log = "Attack:\n  AC: " + targetAc;
         if (coverBonus != 0)
-            log += " (" + to.ac + " + " + coverBonus + " cover)";
+            log += " (" + baseAcResolution.Total + " + " + coverBonus + " cover)";
         log += "\n  Attack Roll: " + attackRoll.total
             + " (" + attackRoll.roll + " + " + attackBonus + " - " + mapPenalty;
         if (rangePenalty != 0)
             log += " " + rangePenalty;
         log += ")\n  Result: " + attackRoll.degree;
+        log += "\n  Attack Modifiers: " + FormatResolution(attackResolution);
+        log += "\n  AC Modifiers: " + FormatResolution(targetAcResolution);
 
         if (attackRoll.degree == DegreeOfSuccess.Success || attackRoll.degree == DegreeOfSuccess.CriticalSuccess)
         {
@@ -87,6 +93,41 @@ public class Strike
             log += "\nAttack Missed!";
             CombatLog.GetInstance().Log(log);
         }
+    }
+
+    private static IEnumerable<Pf2eModifier> BuildStrikeAttackModifiers(int mapPenalty, int rangePenalty)
+    {
+        if (mapPenalty != 0)
+            yield return new Pf2eModifier(-mapPenalty, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll, Pf2eRuleReferences.MultipleAttackPenalty);
+        if (rangePenalty != 0)
+            yield return new Pf2eModifier(rangePenalty, Pf2eModifierType.Untyped, "Range penalty", Pf2eStatistic.AttackRoll, Pf2eRuleReferences.RangePenalty);
+    }
+
+    private static IEnumerable<Pf2eModifier> BuildStrikeAcModifiers(int coverBonus)
+    {
+        if (coverBonus != 0)
+            yield return new Pf2eModifier(coverBonus, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.Cover);
+    }
+
+    private static string FormatResolution(Pf2eModifierResolution resolution)
+    {
+        return "total " + resolution.Total + "; applied [" + FormatModifiers(resolution.AppliedModifiers) + "]; suppressed [" + FormatModifiers(resolution.SuppressedModifiers) + "]";
+    }
+
+    private static string FormatModifiers(IReadOnlyList<Pf2eModifier> modifiers)
+    {
+        if (modifiers == null || modifiers.Count == 0)
+            return "none";
+
+        List<string> parts = new();
+        foreach (Pf2eModifier modifier in modifiers)
+            parts.Add(modifier.Source + " " + FormatSigned(modifier.Value) + " " + modifier.Type);
+        return string.Join(", ", parts);
+    }
+
+    private static string FormatSigned(int value)
+    {
+        return value >= 0 ? "+" + value : value.ToString();
     }
 
     private int CalculateMultipleAttackPenalty(uint strikePenaltyCount)

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -98,15 +98,18 @@ public class Strike
     private static IEnumerable<Pf2eModifier> BuildStrikeAttackModifiers(int mapPenalty, int rangePenalty)
     {
         if (mapPenalty != 0)
-            yield return new Pf2eModifier(-mapPenalty, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll, Pf2eRuleReferences.MultipleAttackPenalty);
+            // Multiple attack penalty source: https://2e.aonprd.com/Rules.aspx?ID=2288
+            yield return new Pf2eModifier(-mapPenalty, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll);
         if (rangePenalty != 0)
-            yield return new Pf2eModifier(rangePenalty, Pf2eModifierType.Untyped, "Range penalty", Pf2eStatistic.AttackRoll, Pf2eRuleReferences.RangePenalty);
+            // Range penalty source: https://2e.aonprd.com/Rules.aspx?ID=2288
+            yield return new Pf2eModifier(rangePenalty, Pf2eModifierType.Untyped, "Range penalty", Pf2eStatistic.AttackRoll);
     }
 
     private static IEnumerable<Pf2eModifier> BuildStrikeAcModifiers(int coverBonus)
     {
         if (coverBonus != 0)
-            yield return new Pf2eModifier(coverBonus, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.Cover);
+            // Cover source: https://2e.aonprd.com/Rules.aspx?ID=2372
+            yield return new Pf2eModifier(coverBonus, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass);
     }
 
     private static string FormatResolution(Pf2eModifierResolution resolution)

--- a/Assets/Scripts/Creature/Conditions/Conditions.cs
+++ b/Assets/Scripts/Creature/Conditions/Conditions.cs
@@ -7,8 +7,14 @@ using UnityEngine;
 public class Conditions : MonoBehaviour, IConditionTarget
 {
     protected Dictionary<string, List<ConditionSource>> AppliedConditions = new();
+
+    public IReadOnlyCollection<string> ActiveConditionNames => AppliedConditions.Keys;
+
     public void Add(string condition, ConditionSource source)
     {
+        if (string.IsNullOrWhiteSpace(condition))
+            return;
+
         List<ConditionSource> sources;
         if(!AppliedConditions.TryGetValue(condition, out sources))
             AppliedConditions.Add(condition, new List<ConditionSource>() { source });

--- a/Assets/Scripts/Creature/Conditions/Conditions.cs
+++ b/Assets/Scripts/Creature/Conditions/Conditions.cs
@@ -3,12 +3,15 @@ using Game.Rules;
 using UnityEngine;
 
 /// <summary>
-/// A container for all the conditions that are applied to a target
+/// Tracks condition sources on a creature and exposes condition-derived PF2e modifiers as a provider.
 /// </summary>
 public class Conditions : MonoBehaviour, IConditionTarget, IPf2eModifierProvider
 {
     protected Dictionary<string, List<ConditionSource>> AppliedConditions = new();
 
+    /// <summary>
+    /// Active condition names used by UI and condition modifier mapping; source details remain internal to this component.
+    /// </summary>
     public IReadOnlyCollection<string> ActiveConditionNames => AppliedConditions.Keys;
 
     public void Add(string condition, ConditionSource source)
@@ -51,12 +54,21 @@ public class Conditions : MonoBehaviour, IConditionTarget, IPf2eModifierProvider
         Add(newCondition, newSource);
     }
 
+    /// <summary>
+    /// Provides rule-derived modifiers from active conditions without requiring CreatureComponent to know condition details.
+    /// </summary>
+    /// <param name="statistic">The statistic currently being resolved.</param>
+    /// <returns>Condition modifiers for the requested statistic.</returns>
     public IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic)
     {
         return ConditionModifierRules.GetModifiers(ActiveConditionNames, statistic);
     }
 }
 
+/// <summary>
+/// Maps active condition names to PF2e modifiers while keeping condition-specific math outside CreatureComponent.
+/// Add new condition modifiers here only when the condition itself directly changes a supported statistic.
+/// </summary>
 public static class ConditionModifierRules
 {
     private static readonly Dictionary<string, Pf2eModifier[]> ModifiersByCondition = new()
@@ -66,6 +78,12 @@ public static class ConditionModifierRules
         { NormalizeConditionKey("flat-footed"), new[] { new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass) } }
     };
 
+    /// <summary>
+    /// Converts active condition names into de-duplicated modifiers for the requested statistic.
+    /// </summary>
+    /// <param name="activeConditions">Condition names currently applied to a creature.</param>
+    /// <param name="statistic">The statistic currently being resolved.</param>
+    /// <returns>Condition modifiers that apply to the requested statistic.</returns>
     public static IEnumerable<Pf2eModifier> GetModifiers(IEnumerable<string> activeConditions, Pf2eStatistic statistic)
     {
         if (activeConditions == null)

--- a/Assets/Scripts/Creature/Conditions/Conditions.cs
+++ b/Assets/Scripts/Creature/Conditions/Conditions.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using Game.Rules;
 using UnityEngine;
 
 /// <summary>
 /// A container for all the conditions that are applied to a target
 /// </summary>
-public class Conditions : MonoBehaviour, IConditionTarget
+public class Conditions : MonoBehaviour, IConditionTarget, IPf2eModifierProvider
 {
     protected Dictionary<string, List<ConditionSource>> AppliedConditions = new();
 
@@ -48,5 +49,46 @@ public class Conditions : MonoBehaviour, IConditionTarget
     {
         Remove(oldCondition, oldSource);
         Add(newCondition, newSource);
+    }
+
+    public IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic)
+    {
+        return ConditionModifierRules.GetModifiers(ActiveConditionNames, statistic);
+    }
+}
+
+public static class ConditionModifierRules
+{
+    private static readonly Dictionary<string, Pf2eModifier[]> ModifiersByCondition = new()
+    {
+        // Off-Guard/Flat-Footed: circumstance penalty to AC. Source: https://2e.aonprd.com/Conditions.aspx?ID=58
+        { NormalizeConditionKey("off-guard"), new[] { new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass) } },
+        { NormalizeConditionKey("flat-footed"), new[] { new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass) } }
+    };
+
+    public static IEnumerable<Pf2eModifier> GetModifiers(IEnumerable<string> activeConditions, Pf2eStatistic statistic)
+    {
+        if (activeConditions == null)
+            yield break;
+
+        HashSet<string> emittedSources = new();
+        foreach (string activeCondition in activeConditions)
+        {
+            if (!ModifiersByCondition.TryGetValue(NormalizeConditionKey(activeCondition), out Pf2eModifier[] modifiers))
+                continue;
+
+            foreach (Pf2eModifier modifier in modifiers)
+            {
+                if (modifier.TargetStatistic != statistic || !emittedSources.Add(modifier.Source + modifier.TargetStatistic))
+                    continue;
+
+                yield return modifier;
+            }
+        }
+    }
+
+    private static string NormalizeConditionKey(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToLowerInvariant().Replace(" ", string.Empty).Replace("-", string.Empty);
     }
 }

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -1,7 +1,9 @@
 using Game.Creature;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Game.Strikes;
+using Game.Rules;
 using GridPublic;
 
 namespace Game.Creature
@@ -43,6 +45,7 @@ namespace Game.Creature
         [SerializeField] private List<ArmorBonus> _armorBonuses = new List<ArmorBonus>();
         [SerializeField] private List<DamageValue> _weaknesses = new List<DamageValue>();
         [SerializeField] private List<DamageValue> _resistances = new List<DamageValue>();
+        private readonly List<Pf2eModifier> _modifiers = new();
 
         // Ability modifiers
         [Header("Ability Modifiers")]
@@ -104,6 +107,7 @@ namespace Game.Creature
         public List<ArmorBonus> armorBonuses { get => _armorBonuses; set => _armorBonuses = value ?? new List<ArmorBonus>(); }
         public List<DamageValue> weaknesses { get => _weaknesses; set => _weaknesses = value; }
         public List<DamageValue> resistances { get => _resistances; set => _resistances = value; }
+        public IReadOnlyList<Pf2eModifier> modifiers => _modifiers;
 
         public int strMod { get => _strMod; set => _strMod = value; }
         public int dexMod { get => _dexMod; set => _dexMod = value; }
@@ -149,6 +153,176 @@ namespace Game.Creature
                 }
             }
             return attackBonus;
+        }
+
+
+        public void AddModifier(Pf2eModifier modifier)
+        {
+            _modifiers.Add(modifier);
+        }
+
+        public void RemoveModifiersFromSource(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+                return;
+
+            _modifiers.RemoveAll(modifier => string.Equals(modifier.Source, source, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public void ClearModifiers()
+        {
+            _modifiers.Clear();
+        }
+
+        public Pf2eModifierResolution ResolveAttackRoll(int? baseAttackOverride = null, IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            List<Pf2eModifier> modifiers = new()
+            {
+                new Pf2eModifier(baseAttackOverride ?? attackBonus, Pf2eModifierType.Untyped, baseAttackOverride.HasValue ? "Attack modifier override" : "Attack bonus", Pf2eStatistic.AttackRoll)
+            };
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.AttackRoll);
+        }
+
+        public Pf2eModifierResolution ResolveAttackRollForWeapon(EquipmentWeapon weapon, IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            return ResolveAttackRoll(GetAttackBonusForWeapon(weapon), additionalModifiers);
+        }
+
+        public Pf2eModifierResolution ResolveArmorClass(IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            List<Pf2eModifier> modifiers = BuildBaseArmorClassModifiers();
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddConditionModifiers(modifiers, Pf2eStatistic.ArmorClass);
+            return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.ArmorClass);
+        }
+
+        public Pf2eModifierResolution ResolveFortitudeSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            return ResolveSave(fortitudeSave, "Fortitude save", Pf2eStatistic.FortitudeSave, additionalModifiers);
+        }
+
+        public Pf2eModifierResolution ResolveReflexSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            return ResolveSave(reflexSave, "Reflex save", Pf2eStatistic.ReflexSave, additionalModifiers);
+        }
+
+        public Pf2eModifierResolution ResolveWillSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            return ResolveSave(willSave, "Will save", Pf2eStatistic.WillSave, additionalModifiers);
+        }
+
+        public Pf2eModifierResolution ResolveSkillCheck(string skillName, IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            List<Pf2eModifier> modifiers = new()
+            {
+                new Pf2eModifier(GetBaseSkillMod(skillName, 0), Pf2eModifierType.Untyped, string.IsNullOrWhiteSpace(skillName) ? "Skill modifier" : skillName.Trim() + " skill", Pf2eStatistic.SkillCheck)
+            };
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.SkillCheck);
+        }
+
+        public Pf2eModifierResolution ResolveInitiative(IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            int baseInitiative = Mathf.Max(initiative, GetBaseSkillMod("perception", 0));
+            List<Pf2eModifier> modifiers = new()
+            {
+                new Pf2eModifier(baseInitiative, Pf2eModifierType.Untyped, "Initiative", Pf2eStatistic.Initiative)
+            };
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.Initiative);
+        }
+
+        public Pf2eModifierResolution ResolveDifficultyClass(int baseDc, IEnumerable<Pf2eModifier> additionalModifiers = null)
+        {
+            List<Pf2eModifier> modifiers = new()
+            {
+                new Pf2eModifier(baseDc, Pf2eModifierType.Untyped, "Base DC", Pf2eStatistic.DifficultyClass)
+            };
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.DifficultyClass);
+        }
+
+        private Pf2eModifierResolution ResolveSave(int baseSave, string source, Pf2eStatistic statistic, IEnumerable<Pf2eModifier> additionalModifiers)
+        {
+            List<Pf2eModifier> modifiers = new()
+            {
+                new Pf2eModifier(baseSave, Pf2eModifierType.Untyped, source, statistic),
+                new Pf2eModifier(allSaves, Pf2eModifierType.Untyped, "All saves", statistic)
+            };
+            AddRuntimeModifiers(modifiers, additionalModifiers);
+            return Pf2eModifierResolver.Resolve(modifiers, statistic);
+        }
+
+        private void AddRuntimeModifiers(List<Pf2eModifier> modifiers, IEnumerable<Pf2eModifier> additionalModifiers)
+        {
+            if (_modifiers != null)
+                modifiers.AddRange(_modifiers);
+            if (additionalModifiers != null)
+                modifiers.AddRange(additionalModifiers);
+        }
+
+        private List<Pf2eModifier> BuildBaseArmorClassModifiers()
+        {
+            if (_equippedArmor != null && !string.IsNullOrWhiteSpace(_equippedArmor.name))
+            {
+                return new List<Pf2eModifier>
+                {
+                    new Pf2eModifier(10, Pf2eModifierType.Untyped, "Base AC", Pf2eStatistic.ArmorClass),
+                    new Pf2eModifier(Mathf.Min(dexMod, _equippedArmor.dexCap), Pf2eModifierType.Untyped, "Dexterity modifier", Pf2eStatistic.ArmorClass),
+                    new Pf2eModifier(GetArmorProficiencyBonus(_equippedArmor.category), Pf2eModifierType.Untyped, _equippedArmor.category + " armor proficiency", Pf2eStatistic.ArmorClass),
+                    new Pf2eModifier(_equippedArmor.acBonus, Pf2eModifierType.Item, _equippedArmor.name, Pf2eStatistic.ArmorClass)
+                };
+            }
+
+            return new List<Pf2eModifier>
+            {
+                new Pf2eModifier(ac, Pf2eModifierType.Untyped, "Armor Class", Pf2eStatistic.ArmorClass)
+            };
+        }
+
+        private int GetArmorProficiencyBonus(string category)
+        {
+            if (armorBonuses == null || string.IsNullOrWhiteSpace(category))
+                return 0;
+
+            foreach (ArmorBonus armorBonus in armorBonuses)
+            {
+                if (string.Equals(armorBonus.category, category, StringComparison.OrdinalIgnoreCase))
+                    return armorBonus.bonus;
+            }
+            return 0;
+        }
+
+        private void AddConditionModifiers(List<Pf2eModifier> modifiers, Pf2eStatistic statistic)
+        {
+            if (statistic == Pf2eStatistic.ArmorClass && HasActiveCondition("off-guard", "flat-footed"))
+            {
+                modifiers.Add(new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.OffGuard));
+            }
+        }
+
+        private bool HasActiveCondition(params string[] conditionNames)
+        {
+            Conditions conditions = GetComponent<Conditions>();
+            if (conditions == null)
+                return false;
+
+            foreach (string activeCondition in conditions.ActiveConditionNames)
+            {
+                string activeKey = NormalizeConditionKey(activeCondition);
+                foreach (string conditionName in conditionNames)
+                {
+                    if (activeKey == NormalizeConditionKey(conditionName))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        private static string NormalizeConditionKey(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToLowerInvariant().Replace(" ", string.Empty).Replace("-", string.Empty);
         }
 
         public int GetAmmoQuantity(string ammoName)
@@ -292,6 +466,12 @@ namespace Game.Creature
         public int GetSkillMod(string skillName, int defaultValue = 0)
         {
             if (string.IsNullOrWhiteSpace(skillName)) return defaultValue;
+            return ResolveSkillCheck(skillName).Total;
+        }
+
+        private int GetBaseSkillMod(string skillName, int defaultValue = 0)
+        {
+            if (string.IsNullOrWhiteSpace(skillName)) return defaultValue;
             string key = skillName.Trim();
 
             // Check explicit proficient skill entries first
@@ -427,8 +607,7 @@ namespace Game.Creature
 
         public int GetInitiative()
         {
-            // initiative is populated by perception by default, this should account for modifications to perception as well as initiative-specific bonuses
-            return Mathf.Max(initiative, GetSkillMod("perception", 0));
+            return ResolveInitiative().Total;
         }
 
 
@@ -491,21 +670,13 @@ namespace Game.Creature
 
         public void CalculateAC()
         {
-            // If armor is equipped
-            if (_equippedArmor != null && !string.IsNullOrWhiteSpace(_equippedArmor.name))
+            if (_equippedArmor == null || string.IsNullOrWhiteSpace(_equippedArmor.name))
             {
-                // Add Dex modifier up to the armor's dex cap
-                _ac = 10 + _equippedArmor.acBonus + Mathf.Min(dexMod, _equippedArmor.dexCap);
-                int armorBonus = armorBonuses.Find(b => b.category == _equippedArmor.category).bonus; // Add armor bonuses based on equipped armor group
-                _ac += armorBonus;
-                // Debug.Log($"Calculated "+ name +" AC with armor: 10 + " + _equippedArmor.acBonus +" (armor bonus) + min(" + dexMod +" (dex mod) + " + _equippedArmor.dexCap +" (dex cap)) + " + armorBonus +" (armor proficiency bonus for " + _equippedArmor.category + " armor) = " + _ac);
-                // Debug.Log($" _equippedArmor.group: {_equippedArmor.category}, armorBonuses: {string.Join(", ", armorBonuses.ConvertAll(b => $"{b.category}: {b.bonus}"))}");
-            }else{
-                // Unarmored AC calculation
-                // TODO: modify to include natural armor or other bonuses
-                _ac = 10 + dexMod + armorBonuses.Find(b => b.category == "unarmored").bonus; 
-                //_ac += armorBonuses.Find(b => b.category == "unarmored").bonus; // Add unarmored bonus if applicable
+                _ac = 10 + dexMod + GetArmorProficiencyBonus("unarmored");
+                return;
             }
+
+            _ac = Pf2eModifierResolver.Resolve(BuildBaseArmorClassModifiers(), Pf2eStatistic.ArmorClass).Total;
         }
     }
 }

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -154,6 +154,13 @@ namespace Game.Creature
         }
 
 
+        /// <summary>
+        /// Resolves an attack roll modifier using the creature's base attack value plus providers and roll-specific modifiers.
+        /// CreatureComponent coordinates the calculation but individual rule sources should contribute through IPf2eModifierProvider.
+        /// </summary>
+        /// <param name="baseAttackOverride">Optional imported weapon/action attack total to use instead of attackBonus.</param>
+        /// <param name="additionalModifiers">One-roll modifiers from the immediate action context, such as MAP or range.</param>
+        /// <returns>The resolved attack modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveAttackRoll(int? baseAttackOverride = null, IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = new()
@@ -164,11 +171,23 @@ namespace Game.Creature
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.AttackRoll);
         }
 
+        /// <summary>
+        /// Resolves an attack roll for a specific weapon, preserving imported weapon action bonuses as the base attack total.
+        /// </summary>
+        /// <param name="weapon">The weapon whose imported attack bonus should be used when available.</param>
+        /// <param name="additionalModifiers">One-roll modifiers from the immediate action context.</param>
+        /// <returns>The resolved attack modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveAttackRollForWeapon(EquipmentWeapon weapon, IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             return ResolveAttackRoll(GetAttackBonusForWeapon(weapon), additionalModifiers);
         }
 
+        /// <summary>
+        /// Resolves Armor Class from base creature or equipped armor data plus providers and context modifiers.
+        /// Armor item bonuses are modeled as item modifiers so they stack according to PF2e rules.
+        /// </summary>
+        /// <param name="additionalModifiers">One-roll modifiers from the immediate context, such as cover.</param>
+        /// <returns>The resolved AC value and stacking details.</returns>
         public Pf2eModifierResolution ResolveArmorClass(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = BuildBaseArmorClassModifiers();
@@ -176,21 +195,42 @@ namespace Game.Creature
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.ArmorClass);
         }
 
+        /// <summary>
+        /// Resolves the creature's Fortitude save with all-save bonuses, providers, and context modifiers.
+        /// </summary>
+        /// <param name="additionalModifiers">One-roll or effect-specific modifiers for this save.</param>
+        /// <returns>The resolved Fortitude modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveFortitudeSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             return ResolveSave(fortitudeSave, "Fortitude save", Pf2eStatistic.FortitudeSave, additionalModifiers);
         }
 
+        /// <summary>
+        /// Resolves the creature's Reflex save with all-save bonuses, providers, and context modifiers.
+        /// </summary>
+        /// <param name="additionalModifiers">One-roll or effect-specific modifiers for this save.</param>
+        /// <returns>The resolved Reflex modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveReflexSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             return ResolveSave(reflexSave, "Reflex save", Pf2eStatistic.ReflexSave, additionalModifiers);
         }
 
+        /// <summary>
+        /// Resolves the creature's Will save with all-save bonuses, providers, and context modifiers.
+        /// </summary>
+        /// <param name="additionalModifiers">One-roll or effect-specific modifiers for this save.</param>
+        /// <returns>The resolved Will modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveWillSave(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             return ResolveSave(willSave, "Will save", Pf2eStatistic.WillSave, additionalModifiers);
         }
 
+        /// <summary>
+        /// Resolves a skill check from imported skill data or its fallback ability modifier plus providers and context modifiers.
+        /// </summary>
+        /// <param name="skillName">The skill name to resolve.</param>
+        /// <param name="additionalModifiers">One-roll or effect-specific modifiers for this skill check.</param>
+        /// <returns>The resolved skill modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveSkillCheck(string skillName, IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = new()
@@ -201,6 +241,11 @@ namespace Game.Creature
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.SkillCheck);
         }
 
+        /// <summary>
+        /// Resolves initiative using the better of imported initiative or Perception, then applies providers and context modifiers.
+        /// </summary>
+        /// <param name="additionalModifiers">Encounter-start or effect-specific modifiers for initiative.</param>
+        /// <returns>The resolved initiative modifier and stacking details.</returns>
         public Pf2eModifierResolution ResolveInitiative(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             int baseInitiative = Mathf.Max(initiative, GetBaseSkillMod("perception", 0));
@@ -212,6 +257,12 @@ namespace Game.Creature
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.Initiative);
         }
 
+        /// <summary>
+        /// Resolves a DC from its caller-supplied base value plus providers and context modifiers.
+        /// </summary>
+        /// <param name="baseDc">The unmodified DC supplied by the action, spell, or other rule source.</param>
+        /// <param name="additionalModifiers">Effect-specific modifiers for this DC.</param>
+        /// <returns>The resolved DC and stacking details.</returns>
         public Pf2eModifierResolution ResolveDifficultyClass(int baseDc, IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = new()
@@ -414,9 +465,19 @@ namespace Game.Creature
             // Per-frame logic here
         }
 
-        // helper: get skill mod by name (case-insensitive). If the skill is present in the serialized
-        // skills list we return that value. Otherwise we return the associated ability modifier.
+        /// <summary>
+        /// Resolves a skill modifier by name using the shared PF2e modifier pipeline.
+        /// </summary>
+        /// <param name="skillName">The skill name to resolve.</param>
+        /// <returns>The resolved skill modifier, or 0 for blank skill names.</returns>
         public int GetSkillMod(string skillName) { return GetSkillMod(skillName, 0);}
+
+        /// <summary>
+        /// Resolves a skill modifier by name, returning a fallback value when no skill name is provided.
+        /// </summary>
+        /// <param name="skillName">The skill name to resolve.</param>
+        /// <param name="defaultValue">The value returned when the skill name is blank.</param>
+        /// <returns>The resolved skill modifier or the supplied fallback.</returns>
         public int GetSkillMod(string skillName, int defaultValue = 0)
         {
             if (string.IsNullOrWhiteSpace(skillName)) return defaultValue;

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -45,7 +45,6 @@ namespace Game.Creature
         [SerializeField] private List<ArmorBonus> _armorBonuses = new List<ArmorBonus>();
         [SerializeField] private List<DamageValue> _weaknesses = new List<DamageValue>();
         [SerializeField] private List<DamageValue> _resistances = new List<DamageValue>();
-        private readonly List<Pf2eModifier> _modifiers = new();
 
         // Ability modifiers
         [Header("Ability Modifiers")]
@@ -107,7 +106,6 @@ namespace Game.Creature
         public List<ArmorBonus> armorBonuses { get => _armorBonuses; set => _armorBonuses = value ?? new List<ArmorBonus>(); }
         public List<DamageValue> weaknesses { get => _weaknesses; set => _weaknesses = value; }
         public List<DamageValue> resistances { get => _resistances; set => _resistances = value; }
-        public IReadOnlyList<Pf2eModifier> modifiers => _modifiers;
 
         public int strMod { get => _strMod; set => _strMod = value; }
         public int dexMod { get => _dexMod; set => _dexMod = value; }
@@ -156,31 +154,13 @@ namespace Game.Creature
         }
 
 
-        public void AddModifier(Pf2eModifier modifier)
-        {
-            _modifiers.Add(modifier);
-        }
-
-        public void RemoveModifiersFromSource(string source)
-        {
-            if (string.IsNullOrWhiteSpace(source))
-                return;
-
-            _modifiers.RemoveAll(modifier => string.Equals(modifier.Source, source, StringComparison.OrdinalIgnoreCase));
-        }
-
-        public void ClearModifiers()
-        {
-            _modifiers.Clear();
-        }
-
         public Pf2eModifierResolution ResolveAttackRoll(int? baseAttackOverride = null, IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = new()
             {
                 new Pf2eModifier(baseAttackOverride ?? attackBonus, Pf2eModifierType.Untyped, baseAttackOverride.HasValue ? "Attack modifier override" : "Attack bonus", Pf2eStatistic.AttackRoll)
             };
-            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddProvidedModifiers(modifiers, additionalModifiers, Pf2eStatistic.AttackRoll);
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.AttackRoll);
         }
 
@@ -192,8 +172,7 @@ namespace Game.Creature
         public Pf2eModifierResolution ResolveArmorClass(IEnumerable<Pf2eModifier> additionalModifiers = null)
         {
             List<Pf2eModifier> modifiers = BuildBaseArmorClassModifiers();
-            AddRuntimeModifiers(modifiers, additionalModifiers);
-            AddConditionModifiers(modifiers, Pf2eStatistic.ArmorClass);
+            AddProvidedModifiers(modifiers, additionalModifiers, Pf2eStatistic.ArmorClass);
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.ArmorClass);
         }
 
@@ -218,7 +197,7 @@ namespace Game.Creature
             {
                 new Pf2eModifier(GetBaseSkillMod(skillName, 0), Pf2eModifierType.Untyped, string.IsNullOrWhiteSpace(skillName) ? "Skill modifier" : skillName.Trim() + " skill", Pf2eStatistic.SkillCheck)
             };
-            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddProvidedModifiers(modifiers, additionalModifiers, Pf2eStatistic.SkillCheck);
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.SkillCheck);
         }
 
@@ -229,7 +208,7 @@ namespace Game.Creature
             {
                 new Pf2eModifier(baseInitiative, Pf2eModifierType.Untyped, "Initiative", Pf2eStatistic.Initiative)
             };
-            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddProvidedModifiers(modifiers, additionalModifiers, Pf2eStatistic.Initiative);
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.Initiative);
         }
 
@@ -239,10 +218,11 @@ namespace Game.Creature
             {
                 new Pf2eModifier(baseDc, Pf2eModifierType.Untyped, "Base DC", Pf2eStatistic.DifficultyClass)
             };
-            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddProvidedModifiers(modifiers, additionalModifiers, Pf2eStatistic.DifficultyClass);
             return Pf2eModifierResolver.Resolve(modifiers, Pf2eStatistic.DifficultyClass);
         }
 
+        // Fortitude, Reflex, and Will differ only by base value and target statistic.
         private Pf2eModifierResolution ResolveSave(int baseSave, string source, Pf2eStatistic statistic, IEnumerable<Pf2eModifier> additionalModifiers)
         {
             List<Pf2eModifier> modifiers = new()
@@ -250,16 +230,20 @@ namespace Game.Creature
                 new Pf2eModifier(baseSave, Pf2eModifierType.Untyped, source, statistic),
                 new Pf2eModifier(allSaves, Pf2eModifierType.Untyped, "All saves", statistic)
             };
-            AddRuntimeModifiers(modifiers, additionalModifiers);
+            AddProvidedModifiers(modifiers, additionalModifiers, statistic);
             return Pf2eModifierResolver.Resolve(modifiers, statistic);
         }
 
-        private void AddRuntimeModifiers(List<Pf2eModifier> modifiers, IEnumerable<Pf2eModifier> additionalModifiers)
+        private void AddProvidedModifiers(List<Pf2eModifier> modifiers, IEnumerable<Pf2eModifier> additionalModifiers, Pf2eStatistic statistic)
         {
-            if (_modifiers != null)
-                modifiers.AddRange(_modifiers);
             if (additionalModifiers != null)
                 modifiers.AddRange(additionalModifiers);
+
+            foreach (MonoBehaviour component in GetComponents<MonoBehaviour>())
+            {
+                if (component is IPf2eModifierProvider provider)
+                    modifiers.AddRange(provider.GetModifiers(statistic));
+            }
         }
 
         private List<Pf2eModifier> BuildBaseArmorClassModifiers()
@@ -271,6 +255,7 @@ namespace Game.Creature
                     new Pf2eModifier(10, Pf2eModifierType.Untyped, "Base AC", Pf2eStatistic.ArmorClass),
                     new Pf2eModifier(Mathf.Min(dexMod, _equippedArmor.dexCap), Pf2eModifierType.Untyped, "Dexterity modifier", Pf2eStatistic.ArmorClass),
                     new Pf2eModifier(GetArmorProficiencyBonus(_equippedArmor.category), Pf2eModifierType.Untyped, _equippedArmor.category + " armor proficiency", Pf2eStatistic.ArmorClass),
+                    // Armor AC bonus is an item bonus. Source: https://2e.aonprd.com/Rules.aspx?ID=2166
                     new Pf2eModifier(_equippedArmor.acBonus, Pf2eModifierType.Item, _equippedArmor.name, Pf2eStatistic.ArmorClass)
                 };
             }
@@ -292,37 +277,6 @@ namespace Game.Creature
                     return armorBonus.bonus;
             }
             return 0;
-        }
-
-        private void AddConditionModifiers(List<Pf2eModifier> modifiers, Pf2eStatistic statistic)
-        {
-            if (statistic == Pf2eStatistic.ArmorClass && HasActiveCondition("off-guard", "flat-footed"))
-            {
-                modifiers.Add(new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.OffGuard));
-            }
-        }
-
-        private bool HasActiveCondition(params string[] conditionNames)
-        {
-            Conditions conditions = GetComponent<Conditions>();
-            if (conditions == null)
-                return false;
-
-            foreach (string activeCondition in conditions.ActiveConditionNames)
-            {
-                string activeKey = NormalizeConditionKey(activeCondition);
-                foreach (string conditionName in conditionNames)
-                {
-                    if (activeKey == NormalizeConditionKey(conditionName))
-                        return true;
-                }
-            }
-            return false;
-        }
-
-        private static string NormalizeConditionKey(string value)
-        {
-            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToLowerInvariant().Replace(" ", string.Empty).Replace("-", string.Empty);
         }
 
         public int GetAmmoQuantity(string ammoName)

--- a/Assets/Scripts/Rules.meta
+++ b/Assets/Scripts/Rules.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2aea921580c0de346bd02d2135018af0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Rules/IPf2eModifierProvider.cs
+++ b/Assets/Scripts/Rules/IPf2eModifierProvider.cs
@@ -2,8 +2,17 @@ using System.Collections.Generic;
 
 namespace Game.Rules
 {
+    /// <summary>
+    /// Extension point for components that contribute PF2e modifiers without centralizing rule ownership in CreatureComponent.
+    /// </summary>
     public interface IPf2eModifierProvider
     {
+        /// <summary>
+        /// Returns modifiers from this provider that can affect the requested statistic.
+        /// Providers should keep their own source-specific state and avoid mutating the creature during resolution.
+        /// </summary>
+        /// <param name="statistic">The statistic currently being resolved.</param>
+        /// <returns>Modifiers for the requested statistic.</returns>
         IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic);
     }
 }

--- a/Assets/Scripts/Rules/IPf2eModifierProvider.cs
+++ b/Assets/Scripts/Rules/IPf2eModifierProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Game.Rules
+{
+    public interface IPf2eModifierProvider
+    {
+        IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic);
+    }
+}

--- a/Assets/Scripts/Rules/IPf2eModifierProvider.cs.meta
+++ b/Assets/Scripts/Rules/IPf2eModifierProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c993f881197b9e40bf04e1be55fedf1

--- a/Assets/Scripts/Rules/Pf2eModifierCollection.cs
+++ b/Assets/Scripts/Rules/Pf2eModifierCollection.cs
@@ -3,17 +3,32 @@ using UnityEngine;
 
 namespace Game.Rules
 {
+    /// <summary>
+    /// Simple component-backed modifier store for temporary or generic sources that do not yet have a dedicated provider.
+    /// Prefer domain-specific providers for complex systems such as feats, spells, auras, and equipment.
+    /// </summary>
     public class Pf2eModifierCollection : MonoBehaviour, IPf2eModifierProvider
     {
         private readonly List<Pf2eModifier> modifiers = new();
 
+        /// <summary>
+        /// Read-only view of stored modifiers for diagnostics, tests, and UI inspection.
+        /// </summary>
         public IReadOnlyList<Pf2eModifier> Modifiers => modifiers;
 
+        /// <summary>
+        /// Adds a modifier exactly as supplied; validation and rule interpretation belong to the source creating it.
+        /// </summary>
+        /// <param name="modifier">The modifier to expose through this provider.</param>
         public void Add(Pf2eModifier modifier)
         {
             modifiers.Add(modifier);
         }
 
+        /// <summary>
+        /// Removes all modifiers with a matching source label, ignoring blank labels to avoid accidental broad removals.
+        /// </summary>
+        /// <param name="source">The case-insensitive source label to remove.</param>
         public void RemoveFromSource(string source)
         {
             if (string.IsNullOrWhiteSpace(source))
@@ -22,11 +37,19 @@ namespace Game.Rules
             modifiers.RemoveAll(modifier => string.Equals(modifier.Source, source, System.StringComparison.OrdinalIgnoreCase));
         }
 
+        /// <summary>
+        /// Removes every modifier from this collection.
+        /// </summary>
         public void Clear()
         {
             modifiers.Clear();
         }
 
+        /// <summary>
+        /// Returns modifiers in this collection that target the requested statistic.
+        /// </summary>
+        /// <param name="statistic">The statistic currently being resolved.</param>
+        /// <returns>Stored modifiers for the requested statistic.</returns>
         public IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic)
         {
             foreach (Pf2eModifier modifier in modifiers)

--- a/Assets/Scripts/Rules/Pf2eModifierCollection.cs
+++ b/Assets/Scripts/Rules/Pf2eModifierCollection.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Rules
+{
+    public class Pf2eModifierCollection : MonoBehaviour, IPf2eModifierProvider
+    {
+        private readonly List<Pf2eModifier> modifiers = new();
+
+        public IReadOnlyList<Pf2eModifier> Modifiers => modifiers;
+
+        public void Add(Pf2eModifier modifier)
+        {
+            modifiers.Add(modifier);
+        }
+
+        public void RemoveFromSource(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+                return;
+
+            modifiers.RemoveAll(modifier => string.Equals(modifier.Source, source, System.StringComparison.OrdinalIgnoreCase));
+        }
+
+        public void Clear()
+        {
+            modifiers.Clear();
+        }
+
+        public IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic)
+        {
+            foreach (Pf2eModifier modifier in modifiers)
+            {
+                if (modifier.TargetStatistic == statistic)
+                    yield return modifier;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Rules/Pf2eModifierCollection.cs.meta
+++ b/Assets/Scripts/Rules/Pf2eModifierCollection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4fbfeec83fa76d448e0c32506edf4de

--- a/Assets/Scripts/Rules/Pf2eModifiers.cs
+++ b/Assets/Scripts/Rules/Pf2eModifiers.cs
@@ -24,30 +24,19 @@ namespace Game.Rules
         DifficultyClass
     }
 
-    public static class Pf2eRuleReferences
-    {
-        public const string ModifierStacking = "https://2e.aonprd.com/Rules.aspx?ID=2278";
-        public const string MultipleAttackPenalty = "https://2e.aonprd.com/Rules.aspx?ID=2288";
-        public const string RangePenalty = "https://2e.aonprd.com/Rules.aspx?ID=2288";
-        public const string Cover = "https://2e.aonprd.com/Rules.aspx?ID=2372";
-        public const string OffGuard = "https://2e.aonprd.com/Conditions.aspx?ID=58";
-    }
-
     public readonly struct Pf2eModifier
     {
         public int Value { get; }
         public Pf2eModifierType Type { get; }
         public string Source { get; }
         public Pf2eStatistic TargetStatistic { get; }
-        public string RulesReference { get; }
 
-        public Pf2eModifier(int value, Pf2eModifierType type, string source, Pf2eStatistic targetStatistic, string rulesReference = null)
+        public Pf2eModifier(int value, Pf2eModifierType type, string source, Pf2eStatistic targetStatistic)
         {
             Value = value;
             Type = type;
             Source = string.IsNullOrWhiteSpace(source) ? "Unknown" : source;
             TargetStatistic = targetStatistic;
-            RulesReference = rulesReference;
         }
     }
 

--- a/Assets/Scripts/Rules/Pf2eModifiers.cs
+++ b/Assets/Scripts/Rules/Pf2eModifiers.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Rules
+{
+    public enum Pf2eModifierType
+    {
+        Untyped,
+        Circumstance,
+        Item,
+        Status
+    }
+
+    public enum Pf2eStatistic
+    {
+        AttackRoll,
+        ArmorClass,
+        FortitudeSave,
+        ReflexSave,
+        WillSave,
+        SkillCheck,
+        Initiative,
+        DifficultyClass
+    }
+
+    public static class Pf2eRuleReferences
+    {
+        public const string ModifierStacking = "https://2e.aonprd.com/Rules.aspx?ID=2278";
+        public const string MultipleAttackPenalty = "https://2e.aonprd.com/Rules.aspx?ID=2288";
+        public const string RangePenalty = "https://2e.aonprd.com/Rules.aspx?ID=2288";
+        public const string Cover = "https://2e.aonprd.com/Rules.aspx?ID=2372";
+        public const string OffGuard = "https://2e.aonprd.com/Conditions.aspx?ID=58";
+    }
+
+    public readonly struct Pf2eModifier
+    {
+        public int Value { get; }
+        public Pf2eModifierType Type { get; }
+        public string Source { get; }
+        public Pf2eStatistic TargetStatistic { get; }
+        public string RulesReference { get; }
+
+        public Pf2eModifier(int value, Pf2eModifierType type, string source, Pf2eStatistic targetStatistic, string rulesReference = null)
+        {
+            Value = value;
+            Type = type;
+            Source = string.IsNullOrWhiteSpace(source) ? "Unknown" : source;
+            TargetStatistic = targetStatistic;
+            RulesReference = rulesReference;
+        }
+    }
+
+    public readonly struct Pf2eModifierResolution
+    {
+        public int Total { get; }
+        public IReadOnlyList<Pf2eModifier> AppliedModifiers { get; }
+        public IReadOnlyList<Pf2eModifier> SuppressedModifiers { get; }
+
+        public Pf2eModifierResolution(int total, IReadOnlyList<Pf2eModifier> appliedModifiers, IReadOnlyList<Pf2eModifier> suppressedModifiers)
+        {
+            Total = total;
+            AppliedModifiers = appliedModifiers ?? Array.Empty<Pf2eModifier>();
+            SuppressedModifiers = suppressedModifiers ?? Array.Empty<Pf2eModifier>();
+        }
+    }
+
+    public static class Pf2eModifierResolver
+    {
+        /// <summary>
+        /// PF2e typed modifier stacking: untyped modifiers stack; item, status, and
+        /// circumstance modifiers apply only the best bonus and worst penalty of each type.
+        /// Source: https://2e.aonprd.com/Rules.aspx?ID=2278
+        /// </summary>
+        public static Pf2eModifierResolution Resolve(IEnumerable<Pf2eModifier> modifiers, Pf2eStatistic statistic)
+        {
+            List<Pf2eModifier> relevant = modifiers?
+                .Where(modifier => modifier.TargetStatistic == statistic && modifier.Value != 0)
+                .ToList() ?? new List<Pf2eModifier>();
+            List<Pf2eModifier> applied = new();
+            List<Pf2eModifier> suppressed = new();
+
+            foreach (Pf2eModifier modifier in relevant.Where(modifier => modifier.Type == Pf2eModifierType.Untyped))
+                applied.Add(modifier);
+
+            foreach (Pf2eModifierType type in new[] { Pf2eModifierType.Circumstance, Pf2eModifierType.Item, Pf2eModifierType.Status })
+            {
+                ResolveTypedBonuses(relevant, type, applied, suppressed);
+                ResolveTypedPenalties(relevant, type, applied, suppressed);
+            }
+
+            return new Pf2eModifierResolution(applied.Sum(modifier => modifier.Value), applied, suppressed);
+        }
+
+        private static void ResolveTypedBonuses(List<Pf2eModifier> relevant, Pf2eModifierType type, List<Pf2eModifier> applied, List<Pf2eModifier> suppressed)
+        {
+            List<Pf2eModifier> bonuses = relevant
+                .Where(modifier => modifier.Type == type && modifier.Value > 0)
+                .OrderByDescending(modifier => modifier.Value)
+                .ToList();
+
+            if (bonuses.Count == 0)
+                return;
+
+            applied.Add(bonuses[0]);
+            for (int i = 1; i < bonuses.Count; i++)
+                suppressed.Add(bonuses[i]);
+        }
+
+        private static void ResolveTypedPenalties(List<Pf2eModifier> relevant, Pf2eModifierType type, List<Pf2eModifier> applied, List<Pf2eModifier> suppressed)
+        {
+            List<Pf2eModifier> penalties = relevant
+                .Where(modifier => modifier.Type == type && modifier.Value < 0)
+                .OrderBy(modifier => modifier.Value)
+                .ToList();
+
+            if (penalties.Count == 0)
+                return;
+
+            applied.Add(penalties[0]);
+            for (int i = 1; i < penalties.Count; i++)
+                suppressed.Add(penalties[i]);
+        }
+    }
+}

--- a/Assets/Scripts/Rules/Pf2eModifiers.cs
+++ b/Assets/Scripts/Rules/Pf2eModifiers.cs
@@ -4,6 +4,9 @@ using System.Linq;
 
 namespace Game.Rules
 {
+    /// <summary>
+    /// PF2e modifier categories that determine whether bonuses and penalties stack.
+    /// </summary>
     public enum Pf2eModifierType
     {
         Untyped,
@@ -12,6 +15,9 @@ namespace Game.Rules
         Status
     }
 
+    /// <summary>
+    /// Roll and DC targets currently supported by the shared PF2e modifier resolver.
+    /// </summary>
     public enum Pf2eStatistic
     {
         AttackRoll,
@@ -24,13 +30,36 @@ namespace Game.Rules
         DifficultyClass
     }
 
+    /// <summary>
+    /// A single PF2e modifier emitted by a rule source, item, condition, or roll context.
+    /// Keep source-specific behavior in providers and pass only normalized modifiers to the resolver.
+    /// </summary>
     public readonly struct Pf2eModifier
     {
+        /// <summary>
+        /// Signed numeric value applied when this modifier is not suppressed.
+        /// </summary>
         public int Value { get; }
+        /// <summary>
+        /// PF2e stacking category for this modifier.
+        /// </summary>
         public Pf2eModifierType Type { get; }
+        /// <summary>
+        /// Short source label used in logs, tests, and modifier audits.
+        /// </summary>
         public string Source { get; }
+        /// <summary>
+        /// Statistic this modifier is allowed to affect.
+        /// </summary>
         public Pf2eStatistic TargetStatistic { get; }
 
+        /// <summary>
+        /// Creates a modifier for one target statistic, preserving a readable source name for logs and audits.
+        /// </summary>
+        /// <param name="value">The signed modifier value.</param>
+        /// <param name="type">The PF2e stacking category for this modifier.</param>
+        /// <param name="source">A short source label used for diagnostics and combat logs.</param>
+        /// <param name="targetStatistic">The statistic this modifier can affect.</param>
         public Pf2eModifier(int value, Pf2eModifierType type, string source, Pf2eStatistic targetStatistic)
         {
             Value = value;
@@ -40,12 +69,30 @@ namespace Game.Rules
         }
     }
 
+    /// <summary>
+    /// Result of resolving a statistic's modifiers, including which typed modifiers were suppressed by PF2e stacking.
+    /// </summary>
     public readonly struct Pf2eModifierResolution
     {
+        /// <summary>
+        /// Final total after typed stacking rules are applied.
+        /// </summary>
         public int Total { get; }
+        /// <summary>
+        /// Modifiers that contributed to the final total.
+        /// </summary>
         public IReadOnlyList<Pf2eModifier> AppliedModifiers { get; }
+        /// <summary>
+        /// Modifiers ignored because another same-type bonus or penalty was stronger.
+        /// </summary>
         public IReadOnlyList<Pf2eModifier> SuppressedModifiers { get; }
 
+        /// <summary>
+        /// Creates a resolved modifier result with immutable applied and suppressed modifier lists.
+        /// </summary>
+        /// <param name="total">The final modifier total after stacking rules are applied.</param>
+        /// <param name="appliedModifiers">Modifiers that contributed to the total.</param>
+        /// <param name="suppressedModifiers">Modifiers ignored because another modifier of the same type was stronger.</param>
         public Pf2eModifierResolution(int total, IReadOnlyList<Pf2eModifier> appliedModifiers, IReadOnlyList<Pf2eModifier> suppressedModifiers)
         {
             Total = total;
@@ -54,6 +101,9 @@ namespace Game.Rules
         }
     }
 
+    /// <summary>
+    /// Applies PF2e typed modifier stacking to already-collected modifiers for a single statistic.
+    /// </summary>
     public static class Pf2eModifierResolver
     {
         /// <summary>
@@ -61,6 +111,9 @@ namespace Game.Rules
         /// circumstance modifiers apply only the best bonus and worst penalty of each type.
         /// Source: https://2e.aonprd.com/Rules.aspx?ID=2278
         /// </summary>
+        /// <param name="modifiers">Candidate modifiers from creature providers and the immediate roll context.</param>
+        /// <param name="statistic">The statistic being resolved; modifiers for other statistics are ignored.</param>
+        /// <returns>The resolved total with applied and suppressed modifier details.</returns>
         public static Pf2eModifierResolution Resolve(IEnumerable<Pf2eModifier> modifiers, Pf2eStatistic statistic)
         {
             List<Pf2eModifier> relevant = modifiers?

--- a/Assets/Scripts/Rules/Pf2eModifiers.cs.meta
+++ b/Assets/Scripts/Rules/Pf2eModifiers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54efbc21eca34134ead829140f6960a2

--- a/Assets/Tests/EditMode/Pf2eModifierTests.cs
+++ b/Assets/Tests/EditMode/Pf2eModifierTests.cs
@@ -7,8 +7,14 @@ using UnityEngine;
 
 namespace TestsCombat
 {
+    /// <summary>
+    /// Verifies the shared PF2e modifier resolver and CreatureComponent integration points.
+    /// </summary>
     public class Pf2eModifierTests
     {
+        /// <summary>
+        /// Confirms PF2e typed bonuses and penalties each keep only the strongest same-type value.
+        /// </summary>
         [Test]
         public void SameTypeBonusesAndPenaltiesDoNotStack()
         {
@@ -26,6 +32,9 @@ namespace TestsCombat
             AssertSuppressed(result, "Lesser cover", "Minor opening");
         }
 
+        /// <summary>
+        /// Confirms different modifier types stack with untyped bonuses and penalties.
+        /// </summary>
         [Test]
         public void DifferentTypedAndUntypedModifiersStack()
         {
@@ -44,6 +53,9 @@ namespace TestsCombat
             Assert.AreEqual(0, result.SuppressedModifiers.Count);
         }
 
+        /// <summary>
+        /// Confirms resolving one statistic ignores modifiers targeting a different statistic.
+        /// </summary>
         [Test]
         public void ResolverFiltersByTargetStatistic()
         {
@@ -58,6 +70,9 @@ namespace TestsCombat
             Assert.IsFalse(result.AppliedModifiers.Any(modifier => modifier.Source == "Attack"));
         }
 
+        /// <summary>
+        /// Confirms cover and off-guard can both affect AC because PF2e tracks bonuses and penalties separately.
+        /// </summary>
         [Test]
         public void CoverAndOffGuardBothApplyAsCircumstanceAcModifiers()
         {
@@ -78,6 +93,9 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(target);
         }
 
+        /// <summary>
+        /// Confirms a stronger circumstance AC bonus suppresses a weaker bonus from another provider.
+        /// </summary>
         [Test]
         public void LowerCircumstanceAcBonusIsSuppressedByCover()
         {
@@ -99,6 +117,9 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(target);
         }
 
+        /// <summary>
+        /// Confirms equipped armor contributes an item AC bonus and suppresses weaker item AC bonuses.
+        /// </summary>
         [Test]
         public void EquippedArmorItemBonusSuppressesLowerItemAcBonus()
         {
@@ -120,6 +141,9 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(target);
         }
 
+        /// <summary>
+        /// Confirms shared resolver entry points cover saves, skills, initiative, and DCs.
+        /// </summary>
         [Test]
         public void SaveSkillInitiativeAndDcHelpersUseSharedResolver()
         {
@@ -153,6 +177,9 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(actor);
         }
 
+        /// <summary>
+        /// Confirms imported weapon action bonuses remain the untyped base total before roll-specific penalties apply.
+        /// </summary>
         [Test]
         public void ImportedWeaponActionBonusRemainsUntypedBaseAttackTotal()
         {

--- a/Assets/Tests/EditMode/Pf2eModifierTests.cs
+++ b/Assets/Tests/EditMode/Pf2eModifierTests.cs
@@ -70,7 +70,7 @@ namespace TestsCombat
 
             Pf2eModifierResolution result = creature.ResolveArmorClass(new[]
             {
-                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.Cover)
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass)
             });
 
             Assert.AreEqual(100, result.Total);
@@ -85,7 +85,8 @@ namespace TestsCombat
             GameObject target = new GameObject("target");
             CreatureComponent creature = target.AddComponent<CreatureComponent>();
             creature.ac = 100;
-            creature.AddModifier(new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Lesser cover", Pf2eStatistic.ArmorClass));
+            Pf2eModifierCollection modifiers = target.AddComponent<Pf2eModifierCollection>();
+            modifiers.Add(new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Lesser cover", Pf2eStatistic.ArmorClass));
 
             Pf2eModifierResolution result = creature.ResolveArmorClass(new[]
             {

--- a/Assets/Tests/EditMode/Pf2eModifierTests.cs
+++ b/Assets/Tests/EditMode/Pf2eModifierTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.Linq;
+using Game.Creature;
+using Game.Rules;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestsCombat
+{
+    public class Pf2eModifierTests
+    {
+        [Test]
+        public void SameTypeBonusesAndPenaltiesDoNotStack()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2278
+            Pf2eModifierResolution result = Pf2eModifierResolver.Resolve(new[]
+            {
+                new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Lesser cover", Pf2eStatistic.ArmorClass),
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Standard cover", Pf2eStatistic.ArmorClass),
+                new Pf2eModifier(-1, Pf2eModifierType.Circumstance, "Minor opening", Pf2eStatistic.ArmorClass),
+                new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass)
+            }, Pf2eStatistic.ArmorClass);
+
+            Assert.AreEqual(0, result.Total);
+            AssertApplied(result, "Standard cover", "Off-Guard");
+            AssertSuppressed(result, "Lesser cover", "Minor opening");
+        }
+
+        [Test]
+        public void DifferentTypedAndUntypedModifiersStack()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2278
+            Pf2eModifierResolution result = Pf2eModifierResolver.Resolve(new[]
+            {
+                new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.AttackRoll),
+                new Pf2eModifier(2, Pf2eModifierType.Item, "Rune", Pf2eStatistic.AttackRoll),
+                new Pf2eModifier(3, Pf2eModifierType.Status, "Bless", Pf2eStatistic.AttackRoll),
+                new Pf2eModifier(4, Pf2eModifierType.Untyped, "Imported total", Pf2eStatistic.AttackRoll),
+                new Pf2eModifier(-5, Pf2eModifierType.Untyped, "MAP", Pf2eStatistic.AttackRoll)
+            }, Pf2eStatistic.AttackRoll);
+
+            Assert.AreEqual(5, result.Total);
+            Assert.AreEqual(5, result.AppliedModifiers.Count);
+            Assert.AreEqual(0, result.SuppressedModifiers.Count);
+        }
+
+        [Test]
+        public void ResolverFiltersByTargetStatistic()
+        {
+            Pf2eModifierResolution result = Pf2eModifierResolver.Resolve(new[]
+            {
+                new Pf2eModifier(7, Pf2eModifierType.Untyped, "Attack", Pf2eStatistic.AttackRoll),
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass)
+            }, Pf2eStatistic.ArmorClass);
+
+            Assert.AreEqual(2, result.Total);
+            AssertApplied(result, "Cover");
+            Assert.IsFalse(result.AppliedModifiers.Any(modifier => modifier.Source == "Attack"));
+        }
+
+        [Test]
+        public void CoverAndOffGuardBothApplyAsCircumstanceAcModifiers()
+        {
+            // Cover AC bonus: https://2e.aonprd.com/Rules.aspx?ID=2372
+            // Off-Guard AC penalty: https://2e.aonprd.com/Conditions.aspx?ID=58
+            GameObject target = new GameObject("target");
+            CreatureComponent creature = target.AddComponent<CreatureComponent>();
+            target.AddComponent<Conditions>().Add("Off-Guard", null);
+            creature.ac = 100;
+
+            Pf2eModifierResolution result = creature.ResolveArmorClass(new[]
+            {
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass, Pf2eRuleReferences.Cover)
+            });
+
+            Assert.AreEqual(100, result.Total);
+            AssertApplied(result, "Armor Class", "Cover", "Off-Guard");
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void LowerCircumstanceAcBonusIsSuppressedByCover()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2278
+            GameObject target = new GameObject("target");
+            CreatureComponent creature = target.AddComponent<CreatureComponent>();
+            creature.ac = 100;
+            creature.AddModifier(new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Lesser cover", Pf2eStatistic.ArmorClass));
+
+            Pf2eModifierResolution result = creature.ResolveArmorClass(new[]
+            {
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "Standard cover", Pf2eStatistic.ArmorClass)
+            });
+
+            Assert.AreEqual(102, result.Total);
+            AssertApplied(result, "Armor Class", "Standard cover");
+            AssertSuppressed(result, "Lesser cover");
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void EquippedArmorItemBonusSuppressesLowerItemAcBonus()
+        {
+            // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2278
+            GameObject target = new GameObject("armored target");
+            CreatureComponent creature = target.AddComponent<CreatureComponent>();
+            creature.dexMod = 3;
+            creature.armorBonuses = new List<ArmorBonus> { new ArmorBonus { category = "light", bonus = 4 } };
+            creature.equippedArmor = new EquipmentArmor { name = "Leather Armor", category = "light", acBonus = 2, dexCap = 4 };
+
+            Pf2eModifierResolution result = creature.ResolveArmorClass(new[]
+            {
+                new Pf2eModifier(1, Pf2eModifierType.Item, "Lesser item AC", Pf2eStatistic.ArmorClass)
+            });
+
+            Assert.AreEqual(19, result.Total);
+            AssertApplied(result, "Base AC", "Dexterity modifier", "light armor proficiency", "Leather Armor");
+            AssertSuppressed(result, "Lesser item AC");
+            UnityEngine.Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void SaveSkillInitiativeAndDcHelpersUseSharedResolver()
+        {
+            GameObject actor = new GameObject("actor");
+            CreatureComponent creature = actor.AddComponent<CreatureComponent>();
+            creature.fortitudeSave = 5;
+            creature.allSaves = 1;
+            creature.strMod = 4;
+            creature.wisMod = 4;
+            creature.initiative = 2;
+
+            Assert.AreEqual(8, creature.ResolveFortitudeSave(new[]
+            {
+                new Pf2eModifier(2, Pf2eModifierType.Status, "Save spell", Pf2eStatistic.FortitudeSave),
+                new Pf2eModifier(1, Pf2eModifierType.Status, "Lesser save spell", Pf2eStatistic.FortitudeSave)
+            }).Total);
+            Assert.AreEqual(5, creature.ResolveSkillCheck("athletics", new[]
+            {
+                new Pf2eModifier(1, Pf2eModifierType.Item, "Athletics item", Pf2eStatistic.SkillCheck)
+            }).Total);
+            Assert.AreEqual(5, creature.ResolveInitiative(new[]
+            {
+                new Pf2eModifier(1, Pf2eModifierType.Status, "Initiative status", Pf2eStatistic.Initiative)
+            }).Total);
+            Assert.AreEqual(23, creature.ResolveDifficultyClass(20, new[]
+            {
+                new Pf2eModifier(2, Pf2eModifierType.Circumstance, "DC circumstance", Pf2eStatistic.DifficultyClass),
+                new Pf2eModifier(1, Pf2eModifierType.Item, "DC item", Pf2eStatistic.DifficultyClass)
+            }).Total);
+
+            UnityEngine.Object.DestroyImmediate(actor);
+        }
+
+        [Test]
+        public void ImportedWeaponActionBonusRemainsUntypedBaseAttackTotal()
+        {
+            GameObject actor = new GameObject("actor");
+            CreatureComponent creature = actor.AddComponent<CreatureComponent>();
+            EquipmentWeapon shortbow = new EquipmentWeapon { name = "Shortbow" };
+            creature.attackBonus = 3;
+            creature.weaponActionBonuses = new List<WeaponActionBonus> { new WeaponActionBonus { weaponName = "Shortbow", bonus = 7 } };
+
+            Pf2eModifierResolution result = creature.ResolveAttackRollForWeapon(shortbow, new[]
+            {
+                new Pf2eModifier(-5, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll)
+            });
+
+            Assert.AreEqual(2, result.Total);
+            AssertApplied(result, "Attack modifier override", "Multiple attack penalty");
+            UnityEngine.Object.DestroyImmediate(actor);
+        }
+
+        private static void AssertApplied(Pf2eModifierResolution result, params string[] sources)
+        {
+            foreach (string source in sources)
+                Assert.IsTrue(result.AppliedModifiers.Any(modifier => modifier.Source == source), source + " should be applied.");
+        }
+
+        private static void AssertSuppressed(Pf2eModifierResolution result, params string[] sources)
+        {
+            foreach (string source in sources)
+                Assert.IsTrue(result.SuppressedModifiers.Any(modifier => modifier.Source == source), source + " should be suppressed.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Pf2eModifierTests.cs.meta
+++ b/Assets/Tests/EditMode/Pf2eModifierTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e6fb89b88ac55b94f8d2065b43668fa8

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -227,6 +227,8 @@ namespace TestsCombat
             Assert.IsNotNull(attackLog);
             StringAssert.Contains("AC: 102 (100 + 2 cover)", attackLog);
             StringAssert.Contains("+ 7 - 5 -2", attackLog);
+            StringAssert.Contains("Attack Modifiers: total 0", attackLog);
+            StringAssert.Contains("AC Modifiers: total 102", attackLog);
 
             UnityEngine.Object.DestroyImmediate(attacker);
             UnityEngine.Object.DestroyImmediate(target);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# sdmay26-02
+
+Unity project for a turn-based Pathfinder-style tactics game.
+
+## Rules Documentation
+
+- [PF2e modifier stacking](docs/pf2e-modifier-stacking.md)

--- a/docs/pf2e-modifier-stacking.md
+++ b/docs/pf2e-modifier-stacking.md
@@ -12,17 +12,28 @@ Each modifier records:
 - `Type`: `Untyped`, `Circumstance`, `Item`, or `Status`.
 - `Source`: human-readable origin for logs and tests.
 - `TargetStatistic`: the statistic the modifier can affect.
-- `RulesReference`: optional AoN link for rules-sensitive sources.
 
 The resolver filters by target statistic. Untyped modifiers stack. For each typed category, the highest bonus applies and lower bonuses of the same type are suppressed; the worst penalty applies and milder penalties of the same type are suppressed. A same-type bonus and same-type penalty can both apply.
 
-## Current Integration
+## Integration Pattern
+
+`CreatureComponent` is the compatibility adapter for current serialized creature stats and the main resolution entrypoint for common rolls. It should not become the global registry for every PF2e effect.
+
+Ongoing effects should provide modifiers through `IPf2eModifierProvider` components on the relevant creature or target. Current examples:
+
+- `Conditions` implements `IPf2eModifierProvider` and delegates condition-specific mappings to `ConditionModifierRules`.
+- `Pf2eModifierCollection` is a generic provider for simple temporary modifiers when a source does not yet have a dedicated component.
+- Strike supplies one-roll contextual modifiers directly as method parameters, such as MAP, range, and cover.
+
+This lets class feats, spells, magic items, areas, and environmental systems own their own modifier logic while `CreatureComponent` only gathers providers and resolves the final total.
+
+## Current Sources
 
 Current serialized creature fields remain compatibility inputs:
 
 - Imported NPC attack totals and weapon action bonuses are treated as untyped base attack modifiers because the current JSON does not decompose them by PF2e modifier type.
 - Imported or manually assigned AC is treated as an untyped base AC unless the creature has equipped armor data available.
-- Equipped armor contributes its armor AC as an item modifier, while Dex and proficiency contributions remain untyped base components.
+- Equipped armor contributes its armor AC as an item modifier; AoN's armor rules define the AC Bonus value as the armor item bonus: https://2e.aonprd.com/Rules.aspx?ID=2166.
 - Saves, skills, initiative, and DC helpers route through the same resolver.
 
 Strike adds current combat modifiers through the resolver:
@@ -32,8 +43,6 @@ Strike adds current combat modifiers through the resolver:
 - Cover: circumstance AC bonus, [AoN](https://2e.aonprd.com/Rules.aspx?ID=2372).
 - Off-Guard / Flat-Footed: circumstance AC penalty, [AoN](https://2e.aonprd.com/Conditions.aspx?ID=58).
 
-## Design Choices
+## Boundaries
 
-The resolver is pure C# so EditMode tests can cover stacking behavior without scene setup. `CreatureComponent` owns runtime modifier storage for now because current combat calculations already read through that component. This avoids a bulk condition/effect refactor while giving future abilities, conditions, equipment, and spells one shared path for typed modifiers.
-
-Damage dice, flat damage, weaknesses, and resistances are intentionally separate. They are not d20 check/DC modifiers and should only move to this model if a future rule requires typed bonuses or penalties to those calculations.
+The resolver is pure C# so EditMode tests can cover stacking behavior without scene setup. Damage dice, flat damage, weaknesses, and resistances are intentionally separate. They are not d20 check/DC modifiers and should only move to this model if a future rule requires typed bonuses or penalties to those calculations.

--- a/docs/pf2e-modifier-stacking.md
+++ b/docs/pf2e-modifier-stacking.md
@@ -1,0 +1,39 @@
+# PF2e Modifier Stacking
+
+This project resolves d20 check and DC modifiers through `Game.Rules.Pf2eModifierResolver`.
+
+Rules reference: Archives of Nethys, [Checks and modifier stacking](https://2e.aonprd.com/Rules.aspx?ID=2278). Do not copy rules prose into code or data; use concise summaries and links.
+
+## Model
+
+Each modifier records:
+
+- `Value`: signed integer bonus or penalty.
+- `Type`: `Untyped`, `Circumstance`, `Item`, or `Status`.
+- `Source`: human-readable origin for logs and tests.
+- `TargetStatistic`: the statistic the modifier can affect.
+- `RulesReference`: optional AoN link for rules-sensitive sources.
+
+The resolver filters by target statistic. Untyped modifiers stack. For each typed category, the highest bonus applies and lower bonuses of the same type are suppressed; the worst penalty applies and milder penalties of the same type are suppressed. A same-type bonus and same-type penalty can both apply.
+
+## Current Integration
+
+Current serialized creature fields remain compatibility inputs:
+
+- Imported NPC attack totals and weapon action bonuses are treated as untyped base attack modifiers because the current JSON does not decompose them by PF2e modifier type.
+- Imported or manually assigned AC is treated as an untyped base AC unless the creature has equipped armor data available.
+- Equipped armor contributes its armor AC as an item modifier, while Dex and proficiency contributions remain untyped base components.
+- Saves, skills, initiative, and DC helpers route through the same resolver.
+
+Strike adds current combat modifiers through the resolver:
+
+- Multiple attack penalty: untyped attack penalty, [AoN](https://2e.aonprd.com/Rules.aspx?ID=2288).
+- Range increment penalty: untyped attack penalty, [AoN](https://2e.aonprd.com/Rules.aspx?ID=2288).
+- Cover: circumstance AC bonus, [AoN](https://2e.aonprd.com/Rules.aspx?ID=2372).
+- Off-Guard / Flat-Footed: circumstance AC penalty, [AoN](https://2e.aonprd.com/Conditions.aspx?ID=58).
+
+## Design Choices
+
+The resolver is pure C# so EditMode tests can cover stacking behavior without scene setup. `CreatureComponent` owns runtime modifier storage for now because current combat calculations already read through that component. This avoids a bulk condition/effect refactor while giving future abilities, conditions, equipment, and spells one shared path for typed modifiers.
+
+Damage dice, flat damage, weaknesses, and resistances are intentionally separate. They are not d20 check/DC modifiers and should only move to this model if a future rule requires typed bonuses or penalties to those calculations.


### PR DESCRIPTION
Closes #81

## Summary
- Added a shared PF2e typed modifier model/resolver for untyped, circumstance, item, and status modifiers.
- Routed Strike attack and AC math through the resolver for base attack totals, MAP, range penalties, cover, and current creature modifiers.
- Added CreatureComponent resolver helpers for attack rolls, AC, saves, skills, initiative, and DCs while preserving existing serialized stat fields and imported JSON totals.
- Documented the design choices and linked AoN rules references in `docs/pf2e-modifier-stacking.md`.

## Testing
- EditMode: 26 passed, 0 failed (`TestResults/EditModeResults.xml`)
- PlayMode: 29 passed, 0 failed (`TestResults/PlayModeResults.xml`)

## Visual Evidence
- Not applicable: rules/math and documentation change only.