### PR TITLE
Add level 1 Rogue rules data

### DIFF
--- a/Assets/Resources/DataFiles/classes/rogue.json
+++ b/Assets/Resources/DataFiles/classes/rogue.json
@@ -1,0 +1,258 @@
+{
+    "_id": "LO9STvskJemPkiAI",
+    "img": "systems/pf2e/icons/classes/rogue.webp",
+    "name": "Rogue",
+    "system": {
+        "ancestryFeatLevels": {
+            "value": [
+                1,
+                5,
+                9,
+                13,
+                17
+            ]
+        },
+        "attacks": {
+            "advanced": 0,
+            "martial": 1,
+            "other": {
+                "name": "",
+                "rank": 0
+            },
+            "simple": 1,
+            "unarmed": 1
+        },
+        "classFeatLevels": {
+            "value": [
+                1,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20
+            ]
+        },
+        "defenses": {
+            "heavy": 0,
+            "light": 1,
+            "medium": 0,
+            "unarmored": 1
+        },
+        "description": {
+            "value": "<p><em>You are skilled and opportunistic. Using your sharp wits and quick reactions, you take advantage of your opponents' missteps and strike where it hurts most. You play a dangerous game, seeking thrills and testing your skills, and likely don't care much for any laws that happen to get in your way. While the path of every rogue is unique and riddled with danger, the one thing you all share in common is the breadth and depth of your skills.</em></p>\n<p><em>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.u4qPrDRBagxG9wj8]{Rogue}</em></p>"
+        },
+        "generalFeatLevels": {
+            "value": [
+                3,
+                7,
+                11,
+                15,
+                19
+            ]
+        },
+        "hp": 8,
+        "items": {
+            "0kdn2": {
+                "img": "systems/pf2e/icons/features/classes/weapon-specialization.webp",
+                "level": 7,
+                "name": "Weapon Specialization",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Specialization"
+            },
+            "1nwhg": {
+                "img": "systems/pf2e/icons/features/classes/weapon-tricks.webp",
+                "level": 5,
+                "name": "Weapon Tricks",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Tricks"
+            },
+            "1zn3l": {
+                "img": "icons/equipment/chest/breastplate-rivited-red.webp",
+                "level": 19,
+                "name": "Light Armor Mastery",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Light Armor Mastery"
+            },
+            "2xl4q": {
+                "img": "icons/weapons/swords/swords-short.webp",
+                "level": 13,
+                "name": "Master Tricks",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Master Tricks"
+            },
+            "3YEZD": {
+                "img": "icons/magic/perception/eye-tendrils-web-purple.webp",
+                "level": 7,
+                "name": "Perception Mastery",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Perception Mastery"
+            },
+            "4al2i": {
+                "img": "icons/skills/melee/hand-grip-sword-orange.webp",
+                "level": 15,
+                "name": "Greater Weapon Specialization",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Greater Weapon Specialization"
+            },
+            "6ddtr": {
+                "img": "icons/equipment/back/mantle-collared-green.webp",
+                "level": 13,
+                "name": "Light Armor Expertise",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Light Armor Expertise"
+            },
+            "BH4zJ": {
+                "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
+                "level": 7,
+                "name": "Evasive Reflexes",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Evasive Reflexes"
+            },
+            "HOjyM": {
+                "img": "icons/sundries/documents/document-sealed-signatures-red.webp",
+                "level": 1,
+                "name": "Rogue's Racket",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Rogue's Racket"
+            },
+            "KvE3P": {
+                "img": "icons/magic/life/cross-explosion-burst-green.webp",
+                "level": 9,
+                "name": "Rogue Resilience",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Rogue Resilience"
+            },
+            "bhpWk": {
+                "img": "icons/commodities/biological/organ-brain-red.webp",
+                "level": 17,
+                "name": "Agile Mind",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Agile Mind"
+            },
+            "cifjd": {
+                "img": "systems/pf2e/icons/features/classes/rogue-expertise.webp",
+                "level": 11,
+                "name": "Rogue Expertise",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Rogue Expertise"
+            },
+            "e9ikq": {
+                "img": "systems/pf2e/icons/features/classes/sneak-attack.webp",
+                "level": 1,
+                "name": "Sneak Attack",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Sneak Attack"
+            },
+            "i7ZpY": {
+                "img": "systems/pf2e/icons/features/classes/improved-evasion.webp",
+                "level": 13,
+                "name": "Greater Rogue Reflexes",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Greater Rogue Reflexes"
+            },
+            "nilrb": {
+                "img": "icons/skills/melee/strike-sword-blood-red.webp",
+                "level": 9,
+                "name": "Debilitating Strikes",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Debilitating Strike"
+            },
+            "pfjze": {
+                "img": "icons/skills/wounds/injury-triple-slash-bleed.webp",
+                "level": 15,
+                "name": "Double Debilitation",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Double Debilitation"
+            },
+            "pvlD2": {
+                "img": "systems/pf2e/icons/features/classes/incredible-sense.webp",
+                "level": 13,
+                "name": "Perception Legend",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Perception Legend"
+            },
+            "qx6de": {
+                "img": "systems/pf2e/icons/features/classes/surprice-attack.webp",
+                "level": 1,
+                "name": "Surprise Attack",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Surprise Attack"
+            },
+            "sjjee": {
+                "img": "icons/environment/settlement/watchtower-silhouette-yellow.webp",
+                "level": 3,
+                "name": "Deny Advantage",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Deny Advantage"
+            },
+            "thypm": {
+                "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
+                "level": 19,
+                "name": "Master Strike",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Master Strike"
+            }
+        },
+        "keyAbility": {
+            "value": [
+                "dex"
+            ]
+        },
+        "perception": 2,
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [],
+        "savingThrows": {
+            "fortitude": 1,
+            "reflex": 2,
+            "will": 2
+        },
+        "skillFeatLevels": {
+            "value": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20
+            ]
+        },
+        "skillIncreaseLevels": {
+            "value": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20
+            ]
+        },
+        "spellcasting": 0,
+        "trainedSkills": {
+            "additional": 7,
+            "value": [
+                "stealth"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "class"
+}

--- a/Assets/Resources/DataFiles/classes/rogue.json.meta
+++ b/Assets/Resources/DataFiles/classes/rogue.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5dcfb393d64c43cb93d58efacc881499
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/rogues-racket.json
+++ b/Assets/Resources/DataFiles/classfeatures/rogues-racket.json
@@ -1,0 +1,52 @@
+{
+    "_id": "uGuCGQvUmioFV2Bd",
+    "img": "icons/sundries/documents/document-sealed-signatures-red.webp",
+    "name": "Rogue's Racket",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You've begun to develop your techniques and approach to a job, while building your reputation in rogues' circles. Choose a rogue's racket from the list below.</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Eldritch Trickster]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Mastermind]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Ruffian]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Scoundrel]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Thief]</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:rogue-racket"
+                    ]
+                },
+                "flag": "roguesRacket",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Rogue.Racket.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.system.rulesSelections.roguesRacket}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/rogues-racket.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/rogues-racket.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d55bdcca20db47c8b383dca19de31ffc
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/sneak-attack.json
+++ b/Assets/Resources/DataFiles/classfeatures/sneak-attack.json
@@ -1,0 +1,95 @@
+{
+    "_id": "j1JE61quDxdge4mg",
+    "img": "systems/pf2e/icons/features/classes/sneak-attack.webp",
+    "name": "Sneak Attack",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>When your enemy can't properly defend itself, you take advantage to deal extra damage. If you Strike a creature that has the @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] condition with an agile or finesse melee weapon, an agile or finesse unarmed attack, a ranged weapon attack, or a ranged unarmed attack, you deal an extra 1d6 precision damage. For a ranged attack with a thrown melee weapon, that weapon must also be agile or finesse.</p>\n<p>As your level increases, so does the number of damage dice for your sneak attack. Increase the number of dice by one at 5th, 11th, and 17th levels.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.system.sneakAttackDamage.number",
+                "predicate": [
+                    "class:rogue"
+                ],
+                "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.system.sneakAttackDamage.faces",
+                "predicate": [
+                    "class:rogue"
+                ],
+                "value": 6
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.TOTMToggle.OffGuard",
+                "option": "target:condition:off-guard",
+                "toggleable": "totm"
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:trait:agile",
+                            "item:trait:finesse",
+                            {
+                                "and": [
+                                    "item:ranged",
+                                    {
+                                        "not": "item:thrown-melee"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "other-tags",
+                "value": "sneak-attack"
+            },
+            {
+                "category": "precision",
+                "diceNumber": "@actor.flags.system.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.system.sneakAttackDamage.faces}",
+                "key": "DamageDice",
+                "predicate": [
+                    "item:tag:sneak-attack",
+                    "target:condition:off-guard"
+                ],
+                "selector": "strike-damage"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/sneak-attack.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/sneak-attack.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd1795ae41e0423d9387f5cb8f0a84bf
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/surprise-attack.json
+++ b/Assets/Resources/DataFiles/classfeatures/surprise-attack.json
@@ -1,0 +1,62 @@
+{
+    "_id": "w6rMqmGzhUahdnA7",
+    "img": "systems/pf2e/icons/features/classes/surprice-attack.webp",
+    "name": "Surprise Attack",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You spring into combat faster than foes can react. On the first round of combat, if you roll Deception or Stealth for initiative, creatures that haven't acted are @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to you.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "encounter:round:1",
+                    {
+                        "lt": [
+                            "self:participant:initiative:rank",
+                            "target:participant:initiative:rank"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "self:participant:initiative:stat:deception",
+                            "self:participant:initiative:stat:stealth"
+                        ]
+                    }
+                ],
+                "selectors": [
+                    "strike-attack-roll",
+                    "spell-attack-roll",
+                    "strike-damage",
+                    "attack-spell-damage"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/surprise-attack.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/surprise-attack.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 245e5c9ae2c0486296a93582aeab9ec8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/thief.json
+++ b/Assets/Resources/DataFiles/classfeatures/thief.json
@@ -1,0 +1,55 @@
+{
+    "_id": "wAh2riuFRzz0edPl",
+    "img": "icons/tools/medical/toolkit-surgical-pink.webp",
+    "name": "Thief",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Nothing beats the thrill of taking something that belongs to someone else. You might be a pickpocket working the streets, a cat burglar sneaking through windows, or even a consultant, testing your clients' vaults for openings.</p>\n<p>When a fight breaks out, you prefer swift, lightweight weapons, and you strike where it hurts. When you make a melee Strike with a finesse weapon or finesse unarmed attack, you can add your Dexterity modifier to the damage roll instead of your Strength modifier.</p>\n<p>You are trained in Thievery.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "ability": "dex",
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:trait:finesse"
+                ],
+                "selector": "melee-strike-damage",
+                "type": "ability"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.thievery.rank",
+                "value": 1
+            }
+        ],
+        "traits": {
+            "otherTags": [
+                "rogue-racket"
+            ],
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/thief.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/thief.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c55fc3982c54b298341e6f7f0390eea
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53162e720f554378808fa1153046d41b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue/nimble-dodge.json
+++ b/Assets/Resources/DataFiles/feats/class/rogue/nimble-dodge.json
@@ -1,0 +1,52 @@
+{
+    "_id": "dNH8OHEvx3vI9NBQ",
+    "folder": "YpoIOlRXXyRIOffL",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Nimble Dodge",
+    "system": {
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "class",
+        "description": {
+            "value": "<p><strong>Trigger</strong> A creature targets you with an attack and you can see the attacker.</p>\n<p><strong>Requirements</strong> You are not encumbered.</p>\n<hr />\n<p>You deftly dodge out of the way, gaining a +2 circumstance bonus to AC against the triggering attack.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "nimble-dodge",
+                "toggleable": true
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "nimble-dodge"
+                ],
+                "selector": "ac",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/rogue/nimble-dodge.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue/nimble-dodge.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 21d219389a4e4693bad974e969d8f6d8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue/overextending-feint.json
+++ b/Assets/Resources/DataFiles/feats/class/rogue/overextending-feint.json
@@ -1,0 +1,55 @@
+{
+    "_id": "9CaaU5szcf3mtJXD",
+    "folder": "YpoIOlRXXyRIOffL",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Overextending Feint",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "class",
+        "description": {
+            "value": "<p>You goad a foe into overextending. On a successful @UUID[Compendium.pf2e.actionspf2e.Item.Feint], you can use the following success and critical success effects instead of any other effects that would occur when you Feint.</p>\n<hr />\n<p><strong>Critical Success</strong> The target takes a –2 circumstance penalty to all attack rolls against you before the end of its next turn.</p>\n<p><strong>Success</strong> The target takes a –2 circumstance penalty to its next attack roll against you before the end of its next turn.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "trained in Deception"
+                }
+            ]
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess",
+                    "success"
+                ],
+                "predicate": [
+                    "action:feint"
+                ],
+                "selector": "skill-check",
+                "text": "PF2E.SpecificRule.Rogue.OverextendingFeint.Note",
+                "title": "{item|name}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/rogue/overextending-feint.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue/overextending-feint.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7eaa4b29b3c84106b588bbaac5fb316a
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue/plant-evidence.json
+++ b/Assets/Resources/DataFiles/feats/class/rogue/plant-evidence.json
@@ -1,0 +1,41 @@
+{
+    "_id": "eww9tuiXPnZFZ3DU",
+    "folder": "YpoIOlRXXyRIOffL",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Plant Evidence",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "class",
+        "description": {
+            "value": "<p>You can put a single item you're holding of light or negligible Bulk onto a person without them noticing by succeeding at a @Check[thievery|defense:perception] check against their Perception DC. If you have the ruffian racket, you can do this as a free action when you successfully @UUID[Compendium.pf2e.actionspf2e.Item.Shove] a target.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "Pickpocket"
+                }
+            ]
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/rogue/plant-evidence.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue/plant-evidence.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7b6a3d73e2c490480bce6d634aab06f
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue/tumble-behind-rogue.json
+++ b/Assets/Resources/DataFiles/feats/class/rogue/tumble-behind-rogue.json
@@ -1,0 +1,67 @@
+{
+    "_id": "YKqMuuC8j35NFh92",
+    "folder": "YpoIOlRXXyRIOffL",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Tumble Behind (Rogue)",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "class",
+        "description": {
+            "value": "<p>You tumble under and behind your foe, your rapid movement letting you catch them off guard. When you successfully [[/act tumble-through]], the foe whose space you passed through is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] against the next attack you make before the end of your turn.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "tumble-behind",
+                "toggleable": true
+            },
+            {
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "tumble-behind"
+                ],
+                "selectors": [
+                    "strike-attack-roll",
+                    "strike-damage"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:tumble-through"
+                ],
+                "selector": "skill-check",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/rogue/tumble-behind-rogue.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue/tumble-behind-rogue.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f1afb08d2e7f40208f5b0f5f68e8a6c8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/rogue/twin-feint.json
+++ b/Assets/Resources/DataFiles/feats/class/rogue/twin-feint.json
@@ -1,0 +1,37 @@
+{
+    "_id": "9XALeVNcmlIxf3tJ",
+    "folder": "YpoIOlRXXyRIOffL",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Twin Feint",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "category": "class",
+        "description": {
+            "value": "<p><strong>Requirements</strong> You are wielding two melee weapons, each in a different hand.</p>\n<hr />\n<p>You use an attack with one weapon to distract your foe from a second attack coming at a different angle. Make one Strike with each of your two melee weapons, both against the same target. The target is automatically @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] against the second attack. Apply your multiple attack penalty to the Strikes normally.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/rogue/twin-feint.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/rogue/twin-feint.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a620aef132634c17b11838381ed33ef4
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/playerCharacters/Lena.json
+++ b/Assets/Resources/DataFiles/playerCharacters/Lena.json
@@ -1,0 +1,142 @@
+{
+  "name": "Lena",
+  "type": "player",
+  "system": {
+    "abilities": {
+      "str": 1,
+      "dex": 4,
+      "con": 1,
+      "int": 1,
+      "wis": 1,
+      "cha": 0
+    },
+    "attributes": {
+      "ac": 17,
+      "allSaves": 0,
+      "hp": {
+        "details": "",
+        "max": 16,
+        "temp": 0,
+        "value": 16
+      },
+      "speed": [
+        {
+          "value": 25
+        }
+      ]
+    },
+    "details": {
+      "languages": {
+        "details": "",
+        "value": [
+          "common"
+        ]
+      },
+      "level": 1,
+      "publicNotes": "Level 1 thief rogue rules test character.",
+      "publicNotesParagraphs": [
+        "Level 1 thief rogue rules test character."
+      ],
+      "publication": {
+        "license": "ORC",
+        "remaster": true,
+        "title": "Player Core"
+      }
+    },
+    "initiative": {
+      "statistic": "perception"
+    },
+    "perception": {
+      "details": "",
+      "mod": 6,
+      "senses": []
+    },
+    "resources": {},
+    "saves": {
+      "fortitude": 4,
+      "reflex": 7,
+      "will": 6
+    },
+    "skills": {
+      "stealth": 7,
+      "thievery": 7
+    },
+    "traits": {
+      "rarity": "common",
+      "size": "med",
+      "value": [
+        "human",
+        "humanoid"
+      ]
+    },
+    "immunities": [],
+    "weaknesses": [],
+    "resistances": []
+  },
+  "equipment": [
+    {
+      "name": "Dogslicer",
+      "type": "weapon",
+      "hands": 1,
+      "category": "martial",
+      "quantity": 1
+    },
+    {
+      "name": "Shortbow",
+      "type": "weapon",
+      "hands": 2,
+      "category": "martial",
+      "quantity": 1
+    },
+    {
+      "name": "Arrows",
+      "type": "ammo",
+      "quantity": 20
+    },
+    {
+      "name": "Leather Armor",
+      "type": "armor",
+      "hands": 0,
+      "category": "light",
+      "quantity": 1,
+      "acBonus": 1,
+      "dexCap": 4
+    }
+  ],
+  "actions": [],
+  "reactions": [],
+  "passives": [],
+  "conditions": [],
+  "weaponBonuses": {
+    "unarmed": 0,
+    "simple": 0,
+    "martial": 0,
+    "advanced": 0
+  },
+  "armorBonuses": {
+    "unarmored": 0,
+    "light": 0,
+    "medium": 0,
+    "heavy": 0
+  },
+  "playerOnlyStuff": [
+    {
+      "gender": "female",
+      "ancestry": "Human",
+      "heritage": "...",
+      "background": "Bandit",
+      "className": "Rogue",
+      "ancestryFeat": "...",
+      "classFeat": "Nimble Dodge",
+      "subclass": "Thief",
+      "trainedSkills": [
+        "stealth",
+        "thievery"
+      ],
+      "ruleSelections": {
+        "roguesRacket": "Compendium.pf2e.classfeatures.Item.Thief"
+      }
+    }
+  ],
+  "Source": "project/playerCharacters"
+}

--- a/Assets/Resources/DataFiles/playerCharacters/Lena.json.meta
+++ b/Assets/Resources/DataFiles/playerCharacters/Lena.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b52ea7200d874019a4be2be2cf4e9211
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -12,6 +12,9 @@ public class Strike
     public List<DamageValue> FlatDamages;
     public List<string> Traits = new List<string>();
     public int? AttackModifierOverride { get; set; }
+    public string ItemSlug { get; set; }
+    public string WeaponCategory { get; set; }
+    public bool IsRangedAttack { get; set; }
     public GameObject From = null;
     public GameObject To = null;
     private StrikeTargetResult TargetingResult = null;
@@ -30,6 +33,9 @@ public class Strike
         this.FlatDamages = new List<DamageValue>(strike.FlatDamages);
         this.Traits = new List<string>(strike.Traits);
         this.AttackModifierOverride = strike.AttackModifierOverride;
+        this.ItemSlug = strike.ItemSlug;
+        this.WeaponCategory = strike.WeaponCategory;
+        this.IsRangedAttack = strike.IsRangedAttack;
     }
 
     public void Damage(GameObject from_go, GameObject to_go)
@@ -44,7 +50,7 @@ public class Strike
         evaluated.To = to_go;
         evaluated.TargetingResult = targetingResult;
 
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(from_go.GetComponent<CreatureComponent>(), evaluated);
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(from_go.GetComponent<CreatureComponent>(), evaluated, to_go.GetComponent<CreatureComponent>());
         OnStrikeEvent.Invoke(new(evaluated, from_go));
         evaluated.DamageEvaluate();
     }

--- a/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using UnityEngine;
 using GridPublic;
 using GridPrivate;
+using Game.Creature.Rules;
 
 namespace Game.Strikes
 {
@@ -161,6 +162,9 @@ public class StrikeWeapon : MultiFrameEntityAction
 
         Strike = new Strike(damageList, flatDamageList);
         Strike.Traits = Weapon.traits ?? new List<string>();
+        Strike.ItemSlug = Pf2eSlug.FromName(Weapon.name);
+        Strike.WeaponCategory = Weapon.category;
+        Strike.IsRangedAttack = IsRangedWeapon();
         Strike.AttackModifierOverride = cc.GetAttackBonusForWeapon(weapon);
     }
 

--- a/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
@@ -20,6 +20,8 @@ public class Unarmed : MultiFrameEntityAction
         Strike = new Strike(damages, flatDamages);
         // Unarmed strike traits based on PF2e rules
         Strike.Traits = new List<string>() {"agile", "finesse", "nonlethal", "unarmed"};
+        Strike.ItemSlug = "unarmed";
+        Strike.WeaponCategory = "unarmed";
     }
 
     public Strike GetStrike()

--- a/Assets/Scripts/Creature/Rules/CharacterBuild.cs
+++ b/Assets/Scripts/Creature/Rules/CharacterBuild.cs
@@ -14,6 +14,7 @@ namespace Game.Creature.Rules
         public string SubclassName;
         public string ClassFeatName;
         public readonly Dictionary<string, string> RuleSelections = new(StringComparer.OrdinalIgnoreCase);
+        public readonly List<string> TrainedSkills = new();
 
         /// <summary>
         /// Reads the current creature JSON shape into build choices without requiring Foundry-derived data to be rewritten.
@@ -35,6 +36,26 @@ namespace Game.Creature.Rules
                     build.ClassName = firstPlayerBlock.Value<string>("className");
                     build.SubclassName = firstPlayerBlock.Value<string>("subclass");
                     build.ClassFeatName = firstPlayerBlock.Value<string>("classFeat");
+
+                    if (firstPlayerBlock["ruleSelections"] is JObject selections)
+                    {
+                        foreach (JProperty selection in selections.Properties())
+                        {
+                            string value = selection.Value?.Value<string>();
+                            if (!string.IsNullOrWhiteSpace(value))
+                                build.RuleSelections[selection.Name] = value;
+                        }
+                    }
+
+                    if (firstPlayerBlock["trainedSkills"] is JArray trainedSkills)
+                    {
+                        foreach (JToken skill in trainedSkills)
+                        {
+                            string value = skill.Value<string>();
+                            if (!string.IsNullOrWhiteSpace(value))
+                                build.TrainedSkills.Add(value);
+                        }
+                    }
                 }
             }
             catch (Exception ex)

--- a/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
@@ -26,11 +26,12 @@ namespace Game.Creature.Rules
 
             prepared.RollOptions.Add($"self:level:{creature.level}");
             AddArmorRollOptions(creature, prepared);
+            AddSavedSkillRanks(prepared);
 
             if (catalog.TryResolveByNameOrSlug(build.ClassName, out Pf2eItem classItem))
             {
                 prepared.AddOwnedItem(classItem);
-                ApplyClassBaseMath(creature, classItem);
+                ApplyClassBaseMath(creature, classItem, prepared);
                 GrantClassItems(creature.level, classItem, catalog, prepared);
             }
 
@@ -59,7 +60,7 @@ namespace Game.Creature.Rules
             return creature.Prepared;
         }
 
-        private static void ApplyClassBaseMath(CreatureComponent creature, Pf2eItem classItem)
+        private static void ApplyClassBaseMath(CreatureComponent creature, Pf2eItem classItem, PreparedCharacter prepared)
         {
             JObject system = classItem.System;
             if (system == null)
@@ -74,6 +75,9 @@ namespace Game.Creature.Rules
             ApplyArmorBonus(creature, "light", system.SelectToken("defenses.light")?.Value<int>() ?? 0);
             ApplyArmorBonus(creature, "medium", system.SelectToken("defenses.medium")?.Value<int>() ?? 0);
             ApplyArmorBonus(creature, "heavy", system.SelectToken("defenses.heavy")?.Value<int>() ?? 0);
+
+            foreach (JToken skill in system.SelectToken("trainedSkills.value") as JArray ?? new JArray())
+                UpgradeSkillRank(prepared, skill.Value<string>(), 1);
         }
 
         private static void ApplyWeaponBonus(CreatureComponent creature, string category, int rank)
@@ -130,6 +134,7 @@ namespace Game.Creature.Rules
         {
             prepared.Modifiers.Clear();
             prepared.Adjustments.Clear();
+            prepared.DamageDice.Clear();
             prepared.ItemAlterations.Clear();
             prepared.UnsupportedRuleKeys.Clear();
 
@@ -162,12 +167,18 @@ namespace Game.Creature.Rules
                     if (predicateMatches)
                         ApplyGrantItem(rule, source, prepared, catalog);
                     break;
+                case "ActiveEffectLike":
+                    if (predicateMatches)
+                        ApplyActiveEffectLike(rule, prepared);
+                    break;
                 case "FlatModifier":
                     prepared.Modifiers.Add(new RuleModifier
                     {
                         Selector = rule.Value<string>("selector"),
-                        Slug = rule.Value<string>("slug"),
-                        Value = rule.Value<int?>("value") ?? 0,
+                        Slug = rule.Value<string>("slug") ?? source.Slug,
+                        Value = ResolveRuleInt(rule["value"], prepared),
+                        Type = rule.Value<string>("type"),
+                        Ability = rule.Value<string>("ability"),
                         Predicate = rule["predicate"]?.DeepClone()
                     });
                     break;
@@ -182,6 +193,16 @@ namespace Game.Creature.Rules
                         Predicate = rule["predicate"]?.DeepClone()
                     });
                     break;
+                case "DamageDice":
+                    prepared.DamageDice.Add(new RuleDamageDice
+                    {
+                        Selector = rule.Value<string>("selector"),
+                        Category = rule.Value<string>("category"),
+                        DiceNumber = ResolveRuleInt(rule["diceNumber"], prepared),
+                        DieSize = ResolveDieSize(rule["dieSize"], prepared),
+                        Predicate = rule["predicate"]?.DeepClone()
+                    });
+                    break;
                 case "ItemAlteration":
                     prepared.ItemAlterations.Add(new ItemAlterationRule
                     {
@@ -193,10 +214,10 @@ namespace Game.Creature.Rules
                     });
                     break;
                 case "RollOption":
-                    if (!predicateMatches)
+                    if (!predicateMatches || rule["toggleable"] != null)
                         break;
                     string option = rule.Value<string>("option");
-                    if (!string.IsNullOrWhiteSpace(option))
+                    if (!string.IsNullOrWhiteSpace(option) && !option.StartsWith("target:", StringComparison.OrdinalIgnoreCase))
                         prepared.RollOptions.Add(option);
                     break;
                 case "TempHP":
@@ -208,31 +229,151 @@ namespace Game.Creature.Rules
                     break;
             }
         }
+
         private static void ApplyChoiceSet(JObject rule, PreparedCharacter prepared, Pf2eItemCatalog catalog)
         {
             string flag = rule.Value<string>("flag");
             if (string.IsNullOrWhiteSpace(flag) || prepared.Build.RuleSelections.ContainsKey(flag))
                 return;
 
-            Pf2eItem selected = catalog.Resolve(prepared.Build.ClassFeatName);
-            if (selected != null)
-                prepared.Build.RuleSelections[flag] = $"Compendium.pf2e.feats-srd.Item.{selected.Name}";
+            string selectedName = string.Equals(flag, "roguesRacket", StringComparison.OrdinalIgnoreCase)
+                ? prepared.Build.SubclassName
+                : prepared.Build.ClassFeatName;
+            Pf2eItem selected = catalog.Resolve(selectedName);
+            if (selected == null)
+                return;
+
+            string pack = selected.Type == "feat" && selected.System?.Value<string>("category") == "class"
+                ? "feats-srd"
+                : "classfeatures";
+            prepared.Build.RuleSelections[flag] = $"Compendium.pf2e.{pack}.Item.{selected.Name}";
         }
 
         private static void ApplyGrantItem(JObject rule, Pf2eItem source, PreparedCharacter prepared, Pf2eItemCatalog catalog)
         {
-            string uuid = rule.Value<string>("uuid");
+            string uuid = ResolveRulesSelectionReference(rule.Value<string>("uuid"), prepared);
             if (string.IsNullOrWhiteSpace(uuid))
                 return;
 
-            if (uuid.StartsWith("{item|flags.pf2e.rulesSelections.", StringComparison.OrdinalIgnoreCase))
-            {
-                string flag = uuid.Replace("{item|flags.pf2e.rulesSelections.", string.Empty).TrimEnd('}');
-                prepared.Build.RuleSelections.TryGetValue(flag, out uuid);
-            }
-
             Pf2eItem granted = catalog.Resolve(uuid);
             prepared.AddOwnedItem(granted, source.Slug);
+        }
+
+        private static string ResolveRulesSelectionReference(string uuid, PreparedCharacter prepared)
+        {
+            if (string.IsNullOrWhiteSpace(uuid) || !uuid.StartsWith("{item|flags.", StringComparison.OrdinalIgnoreCase))
+                return uuid;
+
+            const string rulesSelections = ".rulesSelections.";
+            int index = uuid.IndexOf(rulesSelections, StringComparison.OrdinalIgnoreCase);
+            if (index < 0)
+                return uuid;
+
+            string flag = uuid.Substring(index + rulesSelections.Length).TrimEnd('}');
+            return prepared.Build.RuleSelections.TryGetValue(flag, out string selection) ? selection : null;
+        }
+
+        private static void ApplyActiveEffectLike(JObject rule, PreparedCharacter prepared)
+        {
+            string path = rule.Value<string>("path");
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            int value = ResolveRuleInt(rule["value"], prepared);
+            if (path.StartsWith("system.skills.", StringComparison.OrdinalIgnoreCase) && path.EndsWith(".rank", StringComparison.OrdinalIgnoreCase))
+            {
+                string skill = path.Substring("system.skills.".Length, path.Length - "system.skills.".Length - ".rank".Length);
+                UpgradeSkillRank(prepared, skill, value);
+                return;
+            }
+
+            string normalizedPath = path.StartsWith("@actor.", StringComparison.OrdinalIgnoreCase) ? path.Substring("@actor.".Length) : path;
+            if (string.Equals(rule.Value<string>("mode"), "override", StringComparison.OrdinalIgnoreCase))
+                prepared.RuleValues[normalizedPath] = value;
+            else if (!prepared.RuleValues.TryGetValue(normalizedPath, out int current) || value > current)
+                prepared.RuleValues[normalizedPath] = value;
+        }
+
+        private static void AddSavedSkillRanks(PreparedCharacter prepared)
+        {
+            foreach (string skill in prepared.Build.TrainedSkills)
+                UpgradeSkillRank(prepared, skill, 1);
+        }
+
+        private static void UpgradeSkillRank(PreparedCharacter prepared, string skill, int rank)
+        {
+            if (string.IsNullOrWhiteSpace(skill) || rank <= 0)
+                return;
+
+            if (!prepared.SkillRanks.TryGetValue(skill, out int current) || rank > current)
+                prepared.SkillRanks[skill] = rank;
+        }
+
+        private static int ResolveRuleInt(JToken token, PreparedCharacter prepared)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                return 0;
+            if (token.Type == JTokenType.Integer)
+                return token.Value<int>();
+
+            string value = token.Value<string>();
+            if (int.TryParse(value, out int parsed))
+                return parsed;
+            if (string.IsNullOrWhiteSpace(value))
+                return 0;
+
+            if (value.StartsWith("@actor.", StringComparison.OrdinalIgnoreCase))
+            {
+                string path = value.Substring("@actor.".Length);
+                return prepared.RuleValues.TryGetValue(path, out int fact) ? fact : 0;
+            }
+
+            if (value.Contains("lt(@actor.level, 5)", StringComparison.OrdinalIgnoreCase))
+            {
+                int level = GetPreparedLevel(prepared);
+                if (level < 5)
+                    return 1;
+                if (level < 11)
+                    return 2;
+                if (level < 17)
+                    return 3;
+                return 4;
+            }
+
+            return 0;
+        }
+
+        private static int ResolveDieSize(JToken token, PreparedCharacter prepared)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                return 0;
+            if (token.Type == JTokenType.Integer)
+                return token.Value<int>();
+
+            string value = token.Value<string>();
+            if (string.IsNullOrWhiteSpace(value))
+                return 0;
+            if (value.StartsWith("d", StringComparison.OrdinalIgnoreCase) && int.TryParse(value.Substring(1), out int sides))
+                return sides;
+            if (int.TryParse(value, out sides))
+                return sides;
+
+            const string actorFlagPrefix = "d{actor|";
+            if (value.StartsWith(actorFlagPrefix, StringComparison.OrdinalIgnoreCase) && value.EndsWith("}"))
+            {
+                string path = value.Substring(actorFlagPrefix.Length, value.Length - actorFlagPrefix.Length - 1);
+                return prepared.RuleValues.TryGetValue(path, out int fact) ? fact : 0;
+            }
+
+            return 0;
+        }
+
+        private static int GetPreparedLevel(PreparedCharacter prepared)
+        {
+            string levelOption = prepared.RollOptions.FirstOrDefault(option => option.StartsWith("self:level:", StringComparison.OrdinalIgnoreCase));
+            if (levelOption != null && int.TryParse(levelOption.Substring("self:level:".Length), out int level))
+                return level;
+            return 0;
         }
 
         private static void AddArmorRollOptions(CreatureComponent creature, PreparedCharacter prepared)

--- a/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
@@ -13,45 +13,20 @@ namespace Game.Creature.Rules
     public static class Pf2eRulesEngine
     {
         /// <summary>
-        /// Applies prepared strike-damage modifiers and adjustments to a Strike before damage is resolved.
+        /// Applies prepared strike-damage modifiers, damage dice, and adjustments to a Strike before damage is resolved.
         /// </summary>
         /// <param name="attacker">The creature making the Strike and owning the prepared rule state.</param>
         /// <param name="strike">The Strike being modified by matching PF2e rule elements.</param>
-        public static void ApplyStrikeDamageModifiers(CreatureComponent attacker, Strike strike)
+        /// <param name="target">Optional target creature for target-scoped predicates.</param>
+        public static void ApplyStrikeDamageModifiers(CreatureComponent attacker, Strike strike, CreatureComponent target = null)
         {
             PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(attacker);
-            List<string> itemOptions = BuildStrikeItemOptions(strike);
-            List<RuleModifier> modifiers = prepared.Modifiers
-                .Where(m => string.Equals(m.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
-                .Where(m => Pf2ePredicate.Evaluate(m.Predicate, prepared, itemOptions))
-                .GroupBy(m => m.Slug, StringComparer.OrdinalIgnoreCase)
-                .Select(g => g.Last())
-                .ToList();
-
-            foreach (RuleAdjustment adjustment in prepared.Adjustments
-                .Where(a => string.Equals(a.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
-                .Where(a => Pf2ePredicate.Evaluate(a.Predicate, prepared, itemOptions))
-                .OrderBy(a => a.Priority))
-            {
-                RuleModifier modifier = modifiers.LastOrDefault(m => string.Equals(m.Slug, adjustment.Slug, StringComparison.OrdinalIgnoreCase));
-                if (modifier == null)
-                    continue;
-
-                if (string.Equals(adjustment.Mode, "upgrade", StringComparison.OrdinalIgnoreCase))
-                    modifier.Value = Math.Max(modifier.Value, Mathf.RoundToInt(adjustment.Value));
-                else if (string.Equals(adjustment.Mode, "multiply", StringComparison.OrdinalIgnoreCase))
-                    modifier.Value = Mathf.FloorToInt(modifier.Value * adjustment.Value);
-            }
-
-            foreach (RuleModifier modifier in modifiers)
-            {
-                if (modifier.Value == 0)
-                    continue;
-
-                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
-                strike.FlatDamages.Add(new DamageValue(damageType, modifier.Value));
-            }
+            List<string> itemOptions = BuildStrikeItemOptions(prepared, strike, target);
+            ApplyAbilityDamageModifiers(attacker, strike, prepared, itemOptions);
+            ApplyFlatStrikeDamageModifiers(strike, prepared, itemOptions);
+            ApplyStrikeDamageDice(strike, prepared, itemOptions);
         }
+
 
         /// <summary>
         /// Runs encounter-cleanup rule hooks for each combatant; action-specific details stay in their own rule classes.
@@ -101,16 +76,10 @@ namespace Game.Creature.Rules
             if (prepared == null)
                 return traits;
 
-            List<string> itemOptions = traits.Select(trait => $"item:trait:{trait}").ToList();
-            itemOptions.Add($"item:slug:{itemSlug}");
-
+            List<string> itemOptions = BuildItemOptions(itemSlug, null, false, traits, null);
             foreach (ItemAlterationRule alteration in prepared.ItemAlterations)
             {
-                if (!string.Equals(alteration.ItemType, itemType, StringComparison.OrdinalIgnoreCase))
-                    continue;
-                if (!string.Equals(alteration.Property, "traits", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                if (!string.Equals(alteration.Mode, "add", StringComparison.OrdinalIgnoreCase))
+                if (!MatchesAlteration(alteration, itemType, "traits"))
                     continue;
                 if (!Pf2ePredicate.Evaluate(alteration.Predicate, prepared, itemOptions))
                     continue;
@@ -121,20 +90,173 @@ namespace Game.Creature.Rules
             return traits;
         }
 
-        private static List<string> BuildStrikeItemOptions(Strike strike)
+        private static void ApplyFlatStrikeDamageModifiers(Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        {
+            List<RuleModifier> modifiers = prepared.Modifiers
+                .Where(m => string.Equals(m.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(m => Pf2ePredicate.Evaluate(m.Predicate, prepared, itemOptions))
+                .GroupBy(m => m.Slug, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.Last())
+                .ToList();
+
+            foreach (RuleAdjustment adjustment in prepared.Adjustments
+                .Where(a => string.Equals(a.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(a => Pf2ePredicate.Evaluate(a.Predicate, prepared, itemOptions))
+                .OrderBy(a => a.Priority))
+            {
+                RuleModifier modifier = modifiers.LastOrDefault(m => string.Equals(m.Slug, adjustment.Slug, StringComparison.OrdinalIgnoreCase));
+                if (modifier == null)
+                    continue;
+
+                if (string.Equals(adjustment.Mode, "upgrade", StringComparison.OrdinalIgnoreCase))
+                    modifier.Value = Math.Max(modifier.Value, Mathf.RoundToInt(adjustment.Value));
+                else if (string.Equals(adjustment.Mode, "multiply", StringComparison.OrdinalIgnoreCase))
+                    modifier.Value = Mathf.FloorToInt(modifier.Value * adjustment.Value);
+            }
+
+            foreach (RuleModifier modifier in modifiers)
+            {
+                if (modifier.Value == 0)
+                    continue;
+
+                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
+                strike.FlatDamages.Add(new DamageValue(damageType, modifier.Value));
+            }
+        }
+
+        private static void ApplyAbilityDamageModifiers(CreatureComponent attacker, Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        {
+            if (attacker == null || strike == null || strike.IsRangedAttack)
+                return;
+
+            foreach (RuleModifier modifier in prepared.Modifiers
+                .Where(m => string.Equals(m.Selector, "melee-strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(m => !string.IsNullOrWhiteSpace(m.Ability))
+                .Where(m => Pf2ePredicate.Evaluate(m.Predicate, prepared, itemOptions)))
+            {
+                int abilityModifier = GetAbilityModifier(attacker, modifier.Ability);
+                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
+                if (strike.FlatDamages.Count == 0)
+                    strike.FlatDamages.Add(new DamageValue(damageType, abilityModifier));
+                else
+                    strike.FlatDamages[0] = new DamageValue(damageType, abilityModifier);
+            }
+        }
+
+        private static void ApplyStrikeDamageDice(Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        {
+            foreach (RuleDamageDice damageDice in prepared.DamageDice
+                .Where(d => string.Equals(d.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
+                .Where(d => d.DiceNumber > 0 && d.DieSize > 0)
+                .Where(d => Pf2ePredicate.Evaluate(d.Predicate, prepared, itemOptions)))
+            {
+                strike.Damages.Add(new Dice(damageDice.DiceNumber, damageDice.DieSize, damageDice.Category ?? "precision"));
+            }
+        }
+
+        private static List<string> BuildStrikeItemOptions(PreparedCharacter prepared, Strike strike, CreatureComponent target)
+        {
+            List<string> options = BuildItemOptions(strike?.ItemSlug, strike?.WeaponCategory, strike?.IsRangedAttack ?? false, strike?.Traits, strike?.Damages.FirstOrDefault());
+            AddAlteredItemTags(prepared, options);
+            AddTargetConditionOptions(target, options);
+            return options;
+        }
+
+        private static List<string> BuildItemOptions(string itemSlug, string category, bool isRanged, IEnumerable<string> traits, Dice firstDamageDie)
         {
             List<string> options = new();
-            foreach (string trait in strike.Traits ?? new List<string>())
-                options.Add($"item:trait:{trait}");
+            foreach (string trait in traits ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(trait))
+                    continue;
 
-            if (strike.Traits != null && strike.Traits.Contains("thrown"))
-                options.Add("item:thrown");
-            if (strike.Traits != null && strike.Traits.Contains("ranged"))
+                options.Add($"item:trait:{trait}");
+                if (string.Equals(trait, "ranged", StringComparison.OrdinalIgnoreCase))
+                    options.Add("item:ranged");
+                if (trait.StartsWith("thrown", StringComparison.OrdinalIgnoreCase))
+                    options.Add("item:thrown");
+            }
+
+            if (!string.IsNullOrWhiteSpace(itemSlug))
+                options.Add($"item:slug:{itemSlug}");
+            if (!string.IsNullOrWhiteSpace(category))
+                options.Add($"item:category:{category}");
+            if (firstDamageDie != null)
+                options.Add($"item:damage:die:faces:{firstDamageDie.sidesPerDie}");
+            if (isRanged)
                 options.Add("item:ranged");
-            if (strike.Traits != null && strike.Traits.Contains("unarmed"))
+            if (options.Contains("item:trait:unarmed", StringComparer.OrdinalIgnoreCase))
                 options.Add("item:category:unarmed");
 
             return options;
         }
+
+        private static void AddAlteredItemTags(PreparedCharacter prepared, List<string> options)
+        {
+            if (prepared == null)
+                return;
+
+            foreach (ItemAlterationRule alteration in prepared.ItemAlterations)
+            {
+                if (!MatchesAlteration(alteration, "weapon", "other-tags"))
+                    continue;
+                if (!Pf2ePredicate.Evaluate(alteration.Predicate, prepared, options))
+                    continue;
+
+                string option = $"item:tag:{alteration.Value}";
+                if (!options.Contains(option, StringComparer.OrdinalIgnoreCase))
+                    options.Add(option);
+            }
+        }
+
+        private static void AddTargetConditionOptions(CreatureComponent target, List<string> options)
+        {
+            Conditions conditions = target?.GetComponent<Conditions>();
+            if (conditions == null)
+                return;
+
+            foreach (string condition in conditions.GetConditionNames())
+            {
+                string slug = Pf2eSlug.FromName(condition);
+                if (string.IsNullOrWhiteSpace(slug))
+                    continue;
+
+                AddOption(options, $"target:condition:{slug}");
+                if (string.Equals(slug, "flat-footed", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(slug, "offguard", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddOption(options, "target:condition:off-guard");
+                }
+            }
+        }
+
+        private static void AddOption(List<string> options, string option)
+        {
+            if (!options.Contains(option, StringComparer.OrdinalIgnoreCase))
+                options.Add(option);
+        }
+
+        private static bool MatchesAlteration(ItemAlterationRule alteration, string itemType, string property)
+        {
+            return alteration != null
+                && string.Equals(alteration.ItemType, itemType, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(alteration.Property, property, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(alteration.Mode, "add", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int GetAbilityModifier(CreatureComponent creature, string ability)
+        {
+            return ability?.ToLowerInvariant() switch
+            {
+                "str" => creature.strMod,
+                "dex" => creature.dexMod,
+                "con" => creature.conMod,
+                "int" => creature.intMod,
+                "wis" => creature.wisMod,
+                "cha" => creature.chaMod,
+                _ => 0
+            };
+        }
+
     }
 }

--- a/Assets/Scripts/Creature/Rules/Pf2eSlug.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eSlug.cs
@@ -17,7 +17,7 @@ namespace Game.Creature.Rules
             if (string.IsNullOrWhiteSpace(value))
                 return string.Empty;
 
-            string lower = value.Trim().ToLowerInvariant();
+            string lower = value.Trim().ToLowerInvariant().Replace("'", string.Empty);
             char[] chars = lower.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray();
             string slug = new string(chars);
             while (slug.Contains("--"))

--- a/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
+++ b/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
@@ -15,9 +15,11 @@ namespace Game.Creature.Rules
         public HashSet<string> RollOptions { get; } = new(StringComparer.OrdinalIgnoreCase);
         public List<RuleModifier> Modifiers { get; } = new();
         public List<RuleAdjustment> Adjustments { get; } = new();
+        public List<RuleDamageDice> DamageDice { get; } = new();
         public List<ItemAlterationRule> ItemAlterations { get; } = new();
         public List<ActivePf2eEffect> ActiveEffects { get; } = new();
         public Dictionary<string, int> SkillRanks { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, int> RuleValues { get; } = new(StringComparer.OrdinalIgnoreCase);
         public List<string> UnsupportedRuleKeys { get; } = new();
 
         /// <summary>
@@ -174,6 +176,8 @@ namespace Game.Creature.Rules
         public string Selector;
         public string Slug;
         public int Value;
+        public string Type;
+        public string Ability;
         public JToken Predicate;
     }
 
@@ -187,6 +191,17 @@ namespace Game.Creature.Rules
         public string Mode;
         public float Value;
         public int Priority;
+        public JToken Predicate;
+    }
+    /// <summary>
+    /// Represents a supported DamageDice rule element after item preparation.
+    /// </summary>
+    public sealed class RuleDamageDice
+    {
+        public string Selector;
+        public string Category;
+        public int DiceNumber;
+        public int DieSize;
         public JToken Predicate;
     }
 

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs
@@ -30,6 +30,10 @@ public class Pf2eRulesTests
         Assert.That(catalog.Resolve("Compendium.pf2e.actionspf2e.Item.Rage")?.Slug, Is.EqualTo("rage"));
         Assert.That(catalog.Resolve("Compendium.pf2e.feat-effects.Item.Effect: Rage")?.Slug, Is.EqualTo("effect-rage"));
         Assert.That(catalog.Resolve("Raging Intimidation")?.Slug, Is.EqualTo("raging-intimidation"));
+        Assert.That(catalog.Resolve("Compendium.pf2e.classes.Item.Rogue")?.Slug, Is.EqualTo("rogue"));
+        Assert.That(catalog.Resolve("Compendium.pf2e.classfeatures.Item.Sneak Attack")?.Slug, Is.EqualTo("sneak-attack"));
+        Assert.That(catalog.Resolve("Compendium.pf2e.classfeatures.Item.Thief")?.Slug, Is.EqualTo("thief"));
+        Assert.That(catalog.Resolve("Nimble Dodge")?.Slug, Is.EqualTo("nimble-dodge"));
     }
 
     [Test]
@@ -183,6 +187,111 @@ public class Pf2eRulesTests
         Assert.That(duringRage, Does.Contain("rage"));
     }
 
+    [Test]
+    public void LenaPreparesRogueFeaturesFromBuildData()
+    {
+        GameObject lena = CreatureJsonConverter.CreateFromFile("DataFiles/playerCharacters/Lena");
+        created.Add(lena);
+        CreatureComponent creature = lena.GetComponent<CreatureComponent>();
+
+        Assert.That(creature.Build.ClassName, Is.EqualTo("Rogue"));
+        Assert.That(creature.Build.SubclassName, Is.EqualTo("Thief"));
+        Assert.That(creature.Prepared.HasOwnedItem("rogue"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("rogues-racket"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("sneak-attack"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("surprise-attack"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("thief"), Is.True);
+        Assert.That(creature.Prepared.HasOwnedItem("nimble-dodge"), Is.True);
+        Assert.That(creature.Prepared.SkillRanks["stealth"], Is.EqualTo(1));
+        Assert.That(creature.Prepared.SkillRanks["thievery"], Is.EqualTo(1));
+        Assert.That(creature.weaponBonuses.First(b => b.category == "martial").bonus, Is.EqualTo(2));
+        Assert.That(creature.armorBonuses.First(b => b.category == "light").bonus, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void RogueToggleableRollOptionsAreNotAlwaysActive()
+    {
+        CreatureComponent creature = CreatePreparedRogue();
+
+        Assert.That(creature.Prepared.RollOptions, Does.Not.Contain("target:condition:off-guard"));
+        Assert.That(creature.Prepared.RollOptions, Does.Not.Contain("nimble-dodge"));
+    }
+
+    [Test]
+    public void ThiefUsesDexterityForFinesseMeleeDamage()
+    {
+        CreatureComponent creature = CreatePreparedRogue();
+
+        Strike finesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
+        {
+            Traits = new List<string> { "agile", "finesse" },
+            ItemSlug = "dogslicer",
+            WeaponCategory = "martial"
+        };
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, finesseStrike);
+        Assert.That(finesseStrike.FlatDamages[0].DamageAmount, Is.EqualTo(creature.dexMod));
+
+        Strike nonFinesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
+        {
+            Traits = new List<string> { "forceful" },
+            ItemSlug = "scimitar",
+            WeaponCategory = "martial"
+        };
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, nonFinesseStrike);
+        Assert.That(nonFinesseStrike.FlatDamages[0].DamageAmount, Is.EqualTo(creature.strMod));
+    }
+
+    [Test]
+    public void SneakAttackAddsPrecisionDamageOnlyAgainstOffGuardTargets()
+    {
+        CreatureComponent rogue = CreatePreparedRogue();
+        CreatureComponent target = CreateTarget("Target");
+
+        Strike normalTarget = CreateDogslicerStrike(rogue);
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, normalTarget, target);
+        Assert.That(normalTarget.Damages.Count, Is.EqualTo(1));
+
+        target.GetComponent<Conditions>().Add("Off-Guard", new ConditionSource());
+        Strike offGuardTarget = CreateDogslicerStrike(rogue);
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, offGuardTarget, target);
+        Assert.That(offGuardTarget.Damages.Count, Is.EqualTo(2));
+        Assert.That(offGuardTarget.Damages.Last().numberOfDice, Is.EqualTo(1));
+        Assert.That(offGuardTarget.Damages.Last().sidesPerDie, Is.EqualTo(6));
+        Assert.That(offGuardTarget.Damages.Last().damageType, Is.EqualTo("precision"));
+
+        Strike ineligibleWeapon = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
+        {
+            Traits = new List<string> { "forceful" },
+            ItemSlug = "scimitar",
+            WeaponCategory = "martial"
+        };
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, ineligibleWeapon, target);
+        Assert.That(ineligibleWeapon.Damages.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void SneakAttackSupportsRangedWeaponsAndFlatFootedAlias()
+    {
+        CreatureComponent rogue = CreatePreparedRogue();
+        CreatureComponent target = CreateTarget("Flat-Footed Target");
+        target.GetComponent<Conditions>().Add("Flat-Footed", new ConditionSource());
+
+        Strike shortbowStrike = new(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+        {
+            Traits = new List<string> { "deadly-d10" },
+            ItemSlug = "shortbow",
+            WeaponCategory = "martial",
+            IsRangedAttack = true
+        };
+
+        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, shortbowStrike, target);
+
+        Assert.That(shortbowStrike.Damages.Count, Is.EqualTo(2));
+        Assert.That(shortbowStrike.Damages.Last().numberOfDice, Is.EqualTo(1));
+        Assert.That(shortbowStrike.Damages.Last().sidesPerDie, Is.EqualTo(6));
+        Assert.That(shortbowStrike.Damages.Last().damageType, Is.EqualTo("precision"));
+    }
+
     private CreatureComponent CreatePreparedBarbarian()
     {
         GameObject go = new("Prepared Barbarian");
@@ -201,6 +310,47 @@ public class Pf2eRulesTests
         return creature;
     }
 
+    private CreatureComponent CreatePreparedRogue()
+    {
+        GameObject go = new("Prepared Rogue");
+        created.Add(go);
+        CreatureComponent creature = go.AddComponent<CreatureComponent>();
+        go.AddComponent<Conditions>();
+        creature.level = 1;
+        creature.strMod = 1;
+        creature.dexMod = 4;
+        creature.Build = new CharacterBuild
+        {
+            ClassName = "Rogue",
+            SubclassName = "Thief",
+            ClassFeatName = "Nimble Dodge"
+        };
+        creature.Build.TrainedSkills.Add("stealth");
+        creature.Prepared = Pf2eCharacterPreparer.Prepare(creature, creature.Build);
+        return creature;
+    }
+
+    private CreatureComponent CreateTarget(string name)
+    {
+        GameObject go = new(name);
+        created.Add(go);
+        CreatureComponent creature = go.AddComponent<CreatureComponent>();
+        go.AddComponent<Conditions>();
+        creature.ac = 15;
+        creature.hp = 10;
+        creature.maxHp = 10;
+        return creature;
+    }
+
+    private static Strike CreateDogslicerStrike(CreatureComponent rogue)
+    {
+        return new Strike(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
+        {
+            Traits = new List<string> { "agile", "finesse" },
+            ItemSlug = "dogslicer",
+            WeaponCategory = "martial"
+        };
+    }
     private sealed class TestActionController : ActionController
     {
         public override void EndTurn()

--- a/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/Pf2eBarbarianSmokeTests.cs
@@ -62,6 +62,45 @@ public class Pf2eBarbarianSmokeTests
         Assert.That(torgrimCreature.tempHp, Is.EqualTo(torgrimCreature.level + torgrimCreature.conMod));
     }
 
+    [UnityTest]
+    public IEnumerator LenaRoguePreparedCharacterSurvivesCombatStart()
+    {
+        GameObject teamRulesGo = Create("TeamRules");
+        teamRulesGo.AddComponent<TeamRules>();
+        GameObject logGo = Create("TestCombatLog");
+        logGo.AddComponent<TestCombatLog>();
+        GameObject managerGo = Create("CombatManager");
+        CombatManager manager = managerGo.AddComponent<CombatManager>();
+
+        GameObject lena = CreatureJsonConverter.CreateFromFile("DataFiles/playerCharacters/Lena");
+        created.Add(lena);
+        lena.AddComponent<Conditions>();
+        lena.AddComponent<TestActionController>();
+        Team lenaTeam = lena.AddComponent<Team>();
+        lenaTeam.Name = "Players";
+
+        GameObject enemy = Create("Enemy");
+        CreatureComponent enemyCreature = enemy.AddComponent<CreatureComponent>();
+        enemyCreature.name = "Enemy";
+        enemyCreature.level = 1;
+        enemyCreature.hp = 10;
+        enemyCreature.maxHp = 10;
+        enemy.AddComponent<Conditions>();
+        enemy.AddComponent<TestActionController>();
+        Team enemyTeam = enemy.AddComponent<Team>();
+        enemyTeam.Name = "Enemies";
+
+        manager.AddCombatant(lena.GetComponent<ActionController>());
+        manager.AddCombatant(enemy.GetComponent<ActionController>());
+        manager.StartCombat();
+        yield return null;
+
+        CreatureComponent lenaCreature = lena.GetComponent<CreatureComponent>();
+        Assert.That(lenaCreature.Prepared.HasOwnedItem("rogue"), Is.True);
+        Assert.That(lenaCreature.Prepared.HasOwnedItem("sneak-attack"), Is.True);
+        Assert.That(lenaCreature.Prepared.HasOwnedItem("thief"), Is.True);
+        Assert.That(lenaCreature.Prepared.HasActiveEffect("rage"), Is.False);
+    }
     private GameObject Create(string name)
     {
         GameObject go = new(name);

--- a/Docs/PF2E_RULE_PIPELINE.md
+++ b/Docs/PF2E_RULE_PIPELINE.md
@@ -18,26 +18,32 @@ Legacy `passives` callbacks remain only for creatures without a player build, so
 
 ## Supported Rule Elements
 
-The first implementation supports the subset needed for level-1 barbarian behavior:
+The implementation supports the subset needed for the current level-1 Barbarian and Thief Rogue slices:
 
-- `FlatModifier` for selector-based numeric bonuses such as Rage damage.
+- `FlatModifier` for selector-based numeric bonuses such as Rage damage and Thief finesse melee damage.
 - `AdjustModifier` for slug-targeted upgrades and multipliers such as Fury Instinct and agile Rage damage.
 - `ChoiceSet` for persisted build selections.
 - `GrantItem` for adding owned items while preserving the granting item slug.
-- `ItemAlteration` for conditional trait changes such as Raging Intimidation adding `rage`.
-- `RollOption` for feature/effect flags.
+- `ItemAlteration` for conditional trait and other-tag changes such as Raging Intimidation adding `rage` and Sneak Attack tagging eligible weapons.
+- `RollOption` for non-toggle feature/effect flags. Toggleable and target-scoped options are not enabled automatically.
 - `TempHP` through source-tracked Rage temp HP runtime state.
+- `DamageDice` for strike-damage dice such as Rogue Sneak Attack precision damage.
+- `ActiveEffectLike` for the supported skill-rank and numeric actor-flag paths used by the current class feature data.
 - `Resistance` is accepted as schema data but not applied to damage yet.
 
 Unsupported rule keys are collected on `PreparedCharacter.UnsupportedRuleKeys` and ignored rather than removed from source JSON.
 
 ## Predicates
 
-Predicates support atomic roll options, `and`, `or`, `not`, and numeric `gte`. The implemented atoms cover current barbarian data, including class, feat, feature, effect, item trait, ranged/thrown, armor category, and skill-rank checks.
+Predicates support atomic roll options, `and`, `or`, `not`, and numeric `gte`. The implemented atoms cover current Barbarian and Rogue data, including class, feat, feature, effect, item trait, item tag, ranged/thrown, armor category, target condition, and skill-rank checks.
 
 ## Barbarian V1
 
 Rage applies active effect state and source-tracked temporary HP. Strike damage is evaluated from prepared rule modifiers instead of static `OnStrikeEvent` listeners. Quick-Tempered runs from combat-start timing after initiative is rolled. Fury Instinct defaults Torgrim's bonus level-1 barbarian feat selection to Raging Intimidation when saved build data does not override it.
+
+## Rogue V1
+
+The first Rogue slice supports a level-1 Thief Rogue. Rogue's Racket resolves saved `roguesRacket` selections or defaults from `CharacterBuild.SubclassName`. Sneak Attack adds 1d6 precision damage only for eligible Strikes against targets with Off-Guard condition state. Off-Guard AC penalties are resolved by the shared `Conditions` modifier provider, while this pipeline only consumes target condition options for damage predicates and maps legacy `Flat-Footed`/`OffGuard` condition names to the same target option. Thief finesse melee Strikes use Dexterity for base ability damage. Surprise Attack and level-1 Rogue class feats are imported as catalog/build data, but their custom action, reaction, and ephemeral-effect behavior is deferred.
 
 ## Tests
 

--- a/Docs/foundry-pf2e-import-manifest.json
+++ b/Docs/foundry-pf2e-import-manifest.json
@@ -10,6 +10,46 @@
     {
       "localPath": "Assets/Resources/DataFiles/effects/effect-rage-temporary-hit-points-immunity.json",
       "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feat-effects/effect-rage-temporary-hit-points-immunity.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/classes/rogue.json",
+      "localPath": "Assets/Resources/DataFiles/classes/rogue.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/class-features/rogues-racket.json",
+      "localPath": "Assets/Resources/DataFiles/classfeatures/rogues-racket.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/class-features/sneak-attack.json",
+      "localPath": "Assets/Resources/DataFiles/classfeatures/sneak-attack.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/class-features/surprise-attack.json",
+      "localPath": "Assets/Resources/DataFiles/classfeatures/surprise-attack.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/class-features/thief.json",
+      "localPath": "Assets/Resources/DataFiles/classfeatures/thief.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feats/class/rogue/level-1/nimble-dodge.json",
+      "localPath": "Assets/Resources/DataFiles/feats/class/rogue/nimble-dodge.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feats/class/rogue/level-1/overextending-feint.json",
+      "localPath": "Assets/Resources/DataFiles/feats/class/rogue/overextending-feint.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feats/class/rogue/level-1/plant-evidence.json",
+      "localPath": "Assets/Resources/DataFiles/feats/class/rogue/plant-evidence.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feats/class/rogue/level-1/tumble-behind-rogue.json",
+      "localPath": "Assets/Resources/DataFiles/feats/class/rogue/tumble-behind-rogue.json"
+    },
+    {
+      "upstreamUrl": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/packs/pf2e/feats/class/rogue/level-1/twin-feint.json",
+      "localPath": "Assets/Resources/DataFiles/feats/class/rogue/twin-feint.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds level 1 Rogue support to the PF2e data-driven class/rules pipeline, continuing the Barbarian refactor pattern from PR #83 and aligning with the typed modifier architecture from PR #84.

## Changes

- Add Rogue class data, level 1 Rogue class features, level 1 Rogue class feats, and a sample Thief Rogue character (`Lena`).
- Extend character preparation to load saved trained skills, Rogue's Racket selections, subclass grants, `ActiveEffectLike` skill/rule values, and `DamageDice` rule elements.
- Add strike metadata needed by PF2e predicates: item slug, weapon category, ranged state, traits, and target condition options.
- Implement the current Rogue runtime slice:
  - Thief uses Dexterity for eligible finesse melee Strike ability damage.
  - Sneak Attack adds precision damage for eligible melee/ranged Strikes against Off-Guard targets.
  - Legacy `Flat-Footed`/`OffGuard` condition names map to the Off-Guard target predicate option.
- Keep Off-Guard AC penalties in the shared `Conditions` modifier provider introduced by PR #84; Rogue rules only consume target condition options for damage predicates.
- Update PF2e rule pipeline docs and import manifest provenance.

## Validation

- EditMode Unity tests: `40 passed / 0 failed`
- PlayMode Unity tests: `31 passed / 0 failed`
- `git diff --check`: clean before commit

## Test Coverage Notes

Added/updated deterministic EditMode coverage for:

- Rogue catalog resolution.
- Lena's prepared Rogue class, racket, feature, feat, skill, weapon, and armor data.
- Toggleable/target-scoped RollOptions not becoming always-on prepared options.
- Thief Dex-to-damage for eligible finesse melee weapons and no change for ineligible weapons.
- Sneak Attack positive and negative cases for Off-Guard targets.
- Ranged Sneak Attack eligibility.
- `Flat-Footed` alias handling for the Off-Guard target predicate.

Added PlayMode smoke coverage that Lena's prepared Rogue character survives combat-start rule processing.

## Deferred

Custom runtime behavior for imported Rogue feats such as Nimble Dodge, Twin Feint, Tumble Behind, Plant Evidence, and Overextending Feint is intentionally deferred; this PR imports them as catalog/build data only.