### PR TITLE
Add streamlined GitHub issue helper

### DIFF
--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-workflow
-description: Work with GitHub issues, pull requests, PR descriptions, issue comments, inline PR review comments, review-comment replies, and gists through safer Python wrappers around the gh CLI. Use when Codex needs to create or update issues, post or edit comments, reply to PR review comments, update PR bodies, fetch comments, or upload temporary review assets while avoiding PowerShell quoting, JSON, and Hashtable string-conversion problems.
+description: Work with GitHub issues, native sub-issues, pull requests, PR descriptions, issue comments, inline PR review comments, review-comment replies, and gists through safer Python wrappers around the gh CLI. Use when Codex needs to create or update issues, post or edit comments, reply to PR review comments, update PR bodies, fetch comments, or upload temporary review assets while avoiding PowerShell quoting, JSON, and Hashtable string-conversion problems.
 ---
 
 # GitHub Workflow
@@ -10,6 +10,7 @@ Use this skill for GitHub operations where multiline text, JSON payloads, review
 ## Rules
 
 - Use markdown body files for all comment, issue, and PR body text. Do not pass multiline bodies inline through PowerShell.
+- Put temporary body files and generated workflow artifacts under `.agent-temp/` at the checkout root. Create it on demand and delete task-specific files when done.
 - Run mutating commands with `--dry-run` first unless the user explicitly asks for the write and the payload is already reviewed.
 - Keep authentication delegated to `gh`; these scripts call `gh api` and do not manage tokens.
 - Distinguish comment types:
@@ -21,22 +22,25 @@ Use this skill for GitHub operations where multiline text, JSON payloads, review
 
 ## Scripts
 
-All scripts live in `scripts/` and accept `--repo owner/name`. They print GitHub API output for live calls and a structured plan for `--dry-run` calls.
+All scripts live in `scripts/` and accept `--repo owner/name`. Most scripts print GitHub API output for live calls and a structured plan for `--dry-run` calls; `gh_create_issue.py` prints a concise created issue/link summary.
 
 ### Issues
 
 ```powershell
-python .agents/skills/github-workflow/scripts/gh_issue.py create --repo silvertreestudios/sdmay26-02 --title "[Area] Title" --body-file C:\tmp\issue.md --label "type: bug" --dry-run
-python .agents/skills/github-workflow/scripts/gh_issue.py update --repo silvertreestudios/sdmay26-02 --issue 76 --body-file C:\tmp\issue.md --dry-run
-python .agents/skills/github-workflow/scripts/gh_issue.py comment --repo silvertreestudios/sdmay26-02 --issue 76 --body-file C:\tmp\comment.md --dry-run
+New-Item -ItemType Directory -Path .agent-temp -Force | Out-Null
+python .agents/skills/github-workflow/scripts/gh_create_issue.py --repo silvertreestudios/sdmay26-02 --title "[Area] Title" --body-file .agent-temp/issue.md --label "type: bug" --dry-run
+python .agents/skills/github-workflow/scripts/gh_create_issue.py --repo silvertreestudios/sdmay26-02 --title "[Area] Child title" --body-file .agent-temp/child.md --label "type: bug" --parent-issue 88 --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py create --repo silvertreestudios/sdmay26-02 --title "[Area] Title" --body-file .agent-temp/issue.md --label "type: bug" --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py update --repo silvertreestudios/sdmay26-02 --issue 76 --body-file .agent-temp/issue.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_issue.py comment --repo silvertreestudios/sdmay26-02 --issue 76 --body-file .agent-temp/comment.md --dry-run
 python .agents/skills/github-workflow/scripts/gh_issue.py list-comments --repo silvertreestudios/sdmay26-02 --issue 76
 ```
 
 ### Pull Requests
 
 ```powershell
-python .agents/skills/github-workflow/scripts/gh_pr.py update-body --repo silvertreestudios/sdmay26-02 --pr 123 --body-file C:\tmp\pr-body.md --dry-run
-python .agents/skills/github-workflow/scripts/gh_pr.py comment --repo silvertreestudios/sdmay26-02 --pr 123 --body-file C:\tmp\comment.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_pr.py update-body --repo silvertreestudios/sdmay26-02 --pr 123 --body-file .agent-temp/pr-body.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_pr.py comment --repo silvertreestudios/sdmay26-02 --pr 123 --body-file .agent-temp/comment.md --dry-run
 python .agents/skills/github-workflow/scripts/gh_pr.py list-comments --repo silvertreestudios/sdmay26-02 --pr 123
 ```
 
@@ -44,8 +48,8 @@ python .agents/skills/github-workflow/scripts/gh_pr.py list-comments --repo silv
 
 ```powershell
 python .agents/skills/github-workflow/scripts/gh_review_comments.py list --repo silvertreestudios/sdmay26-02 --pr 123
-python .agents/skills/github-workflow/scripts/gh_review_comments.py reply --repo silvertreestudios/sdmay26-02 --pr 123 --comment-id 456789 --body-file C:\tmp\reply.md --dry-run
-python .agents/skills/github-workflow/scripts/gh_review_comments.py update --repo silvertreestudios/sdmay26-02 --comment-id 456789 --body-file C:\tmp\reply.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_review_comments.py reply --repo silvertreestudios/sdmay26-02 --pr 123 --comment-id 456789 --body-file .agent-temp/reply.md --dry-run
+python .agents/skills/github-workflow/scripts/gh_review_comments.py update --repo silvertreestudios/sdmay26-02 --comment-id 456789 --body-file .agent-temp/reply.md --dry-run
 ```
 
 ### Gists
@@ -53,7 +57,7 @@ python .agents/skills/github-workflow/scripts/gh_review_comments.py update --rep
 Use gists for temporary review artifacts that do not belong in the PR branch. Prefer committed files or PR screenshots when the artifact is part of the work product.
 
 ```powershell
-python .agents/skills/github-workflow/scripts/gh_gist.py create --description "PR 123 screenshots" --file C:\tmp\screen.png --dry-run
+python .agents/skills/github-workflow/scripts/gh_gist.py create --description "PR 123 screenshots" --file .agent-temp/screen.png --dry-run
 ```
 
 ## Verification
@@ -63,6 +67,7 @@ When changing this skill, run:
 ```powershell
 python C:\Users\Josh\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents/skills/github-workflow
 python -c "from pathlib import Path; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in Path('.agents/skills/github-workflow/scripts').glob('*.py')]"
+python .agents/skills/github-workflow/scripts/gh_create_issue.py --help
 python .agents/skills/github-workflow/scripts/gh_issue.py --help
 python .agents/skills/github-workflow/scripts/gh_pr.py --help
 python .agents/skills/github-workflow/scripts/gh_review_comments.py --help

--- a/.agents/skills/github-workflow/agents/openai.yaml
+++ b/.agents/skills/github-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "GitHub Workflow"
-  short_description: "Safer gh workflows for issues and PRs"
+  short_description: "Safer gh workflows for issues, sub-issues, and PRs"
   default_prompt: "Use $github-workflow to handle GitHub issue, PR, review comment, or gist operations safely."

--- a/.agents/skills/github-workflow/scripts/gh_common.py
+++ b/.agents/skills/github-workflow/scripts/gh_common.py
@@ -98,6 +98,49 @@ def gh_api(
     return completed.returncode
 
 
+def gh_api_json(
+    endpoint: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    method = method.upper()
+    require_gh()
+    args = [
+        "gh",
+        "api",
+        endpoint,
+        "--method",
+        method,
+        "--header",
+        "Accept: application/vnd.github+json",
+        "--header",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+    ]
+
+    stdin = None
+    if payload is not None:
+        args.extend(["--input", "-"])
+        stdin = json.dumps(payload, ensure_ascii=False)
+
+    completed = subprocess.run(args, input=stdin, text=True, capture_output=True, check=False)
+    if completed.returncode != 0:
+        if completed.stdout:
+            print(completed.stdout, end="")
+        if completed.stderr:
+            print(completed.stderr, end="", file=sys.stderr)
+        raise SystemExit(completed.returncode)
+
+    if not completed.stdout.strip():
+        return None
+
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        print(completed.stdout, end="")
+        raise SystemExit(f"GitHub API returned non-JSON output: {exc}") from exc
+
+
 def gh_command(args: list[str], *, dry_run: bool = False) -> int:
     if dry_run:
         print(json.dumps({"dry_run": True, "command": args}, indent=2, ensure_ascii=False))

--- a/.agents/skills/github-workflow/scripts/gh_create_issue.py
+++ b/.agents/skills/github-workflow/scripts/gh_create_issue.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+sys.dont_write_bytecode = True
+
+from gh_common import add_body_file_argument, add_dry_run_argument, add_repo_argument, gh_api_json, read_body, repo_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create a GitHub issue and optionally link it as a native sub-issue.")
+    add_repo_argument(parser)
+    parser.add_argument("--title", required=True)
+    add_body_file_argument(parser)
+    parser.add_argument("--label", action="append", default=[], help="Label to apply; may be repeated.")
+    parser.add_argument("--assignee", action="append", default=[], help="Assignee login; may be repeated.")
+    parser.add_argument("--parent-issue", type=int, help="Parent issue number to attach the new issue under.")
+    add_dry_run_argument(parser)
+    return parser
+
+
+def print_dry_run(base: str, create_payload: dict[str, object], parent_issue: int | None) -> int:
+    steps: list[dict[str, object]] = [
+        {
+            "method": "POST",
+            "endpoint": f"{base}/issues",
+            "payload": create_payload,
+        }
+    ]
+
+    if parent_issue is not None:
+        steps.append(
+            {
+                "method": "POST",
+                "endpoint": f"{base}/issues/{parent_issue}/sub_issues",
+                "payload": {"sub_issue_id": "<created issue id>"},
+            }
+        )
+
+    print(json.dumps({"dry_run": True, "steps": steps}, indent=2, ensure_ascii=False))
+    return 0
+
+
+def summarize_issue(issue: object) -> dict[str, object]:
+    if not isinstance(issue, dict):
+        return {"raw": issue}
+
+    summary: dict[str, object] = {}
+    for key in ("number", "id", "title", "html_url", "state", "sub_issues_summary"):
+        value = issue.get(key)
+        if value is not None:
+            summary[key] = value
+    return summary
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    base = repo_path(args.repo)
+
+    create_payload: dict[str, object] = {"title": args.title, "body": read_body(args.body_file)}
+    if args.label:
+        create_payload["labels"] = args.label
+    if args.assignee:
+        create_payload["assignees"] = args.assignee
+
+    if args.dry_run:
+        return print_dry_run(base, create_payload, args.parent_issue)
+
+    issue = gh_api_json(f"{base}/issues", method="POST", payload=create_payload)
+    result: dict[str, object] = {"issue": summarize_issue(issue)}
+
+    if args.parent_issue is not None:
+        issue_id = issue.get("id") if isinstance(issue, dict) else None
+        if not isinstance(issue_id, int):
+            raise SystemExit("Created issue response did not include a numeric id; cannot create sub-issue link.")
+
+        parent = gh_api_json(
+            f"{base}/issues/{args.parent_issue}/sub_issues",
+            method="POST",
+            payload={"sub_issue_id": issue_id},
+        )
+        result["parent"] = summarize_issue(parent)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ InitTestScene*.unity*
 /TestResults/
 /CodeCoverage/
 /BenchmarkSuite1/obj/
+/.agent-temp/
 
 # Unity recovery and merge leftovers
 /[Aa]ssets/_Recovery/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ Do not add `-quit` to Unity Test Framework command-line runs in this project. Th
 
 Write test results outside tracked Unity asset folders. Do not commit `Library/`, `Logs/`, `Temp/`, generated `.csproj` files, generated `.sln` files, coverage output, or crash/recovery artifacts.
 
+Use `.agent-temp/` at the checkout root for temporary body files, generated command payloads, screenshots awaiting upload, and other short-lived agent workflow artifacts. Create it on demand, clean up task-specific files when done, and avoid OS temp directories for repo workflow files unless explicitly requested.
+
 ## Unity MCP
 
 - This repo is configured for MCP for Unity through `Packages/manifest.json` and `.codex/config.toml`.


### PR DESCRIPTION
## Summary
- add `gh_create_issue.py` for one-command issue creation and optional native sub-issue linking
- add parsed GitHub API JSON support for workflow helpers
- document `.agent-temp/` as the repo-local temp artifact location and ignore it

## Validation
- `python C:\Users\Josh\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents/skills/github-workflow`
- `python -c "from pathlib import Path; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in Path('.agents/skills/github-workflow/scripts').glob('*.py')]"`
- `python .agents/skills/github-workflow/scripts/gh_create_issue.py --help`
- `python .agents/skills/github-workflow/scripts/gh_create_issue.py --repo silvertreestudios/sdmay26-02 --title "[Test] Dry run" --body-file .agent-temp/issue-body.md --label "type: bug" --dry-run`
- `python .agents/skills/github-workflow/scripts/gh_create_issue.py --repo silvertreestudios/sdmay26-02 --title "[Test] Dry-run child" --body-file .agent-temp/issue-body.md --label "type: bug" --parent-issue 88 --dry-run`
- existing GitHub workflow helper `--help` commands
- `git diff --check`
