### PR TITLE
Fix zombie Slowed passive application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,6 @@ InitTestScene*.unity*
 
 # Stray editor command files
 wqWQ
-
+# Python cache files
+__pycache__/
+*.py[cod]

--- a/Assets/Scripts/Creature/Conditions/Abilities/DefinedAbilities.cs
+++ b/Assets/Scripts/Creature/Conditions/Abilities/DefinedAbilities.cs
@@ -39,12 +39,21 @@ public static class DefinedAbilities
 
     private static Ability Slow = new("Slow", (GameObject g) =>
     {
+        ActionController actionController = g.GetComponent<ActionController>();
+        if (actionController == null)
+            return;
+
+        Conditions conditions = g.GetComponent<Conditions>() ?? g.AddComponent<Conditions>();
+        if (conditions.Contains("Slowed", Slow))
+            return;
+
         Condition slow;
         if ((slow = DefinedConditions.TryGet("Slowed 1")) != null)
         {
             slow.Apply(Slow, g);
         }
-        g.GetComponent<ActionController>().GetReactionsEvent.AddListener(
+
+        actionController.GetReactionsEvent.AddListener(
             (List<EntityAction> reactions) => reactions.Clear()
         );
     });

--- a/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
@@ -56,9 +56,26 @@ namespace Game.Creature.Rules
                 if (creature == null)
                     continue;
 
+                ApplyImportedPassiveAbilities(controller, creature);
+
                 PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(creature);
                 if (prepared.HasOwnedItem("quick-tempered"))
                     new Rage(0).UseRage(controller.gameObject);
+            }
+        }
+
+        private static void ApplyImportedPassiveAbilities(ActionController controller, CreatureComponent creature)
+        {
+            if (controller == null || creature?.passives == null)
+                return;
+
+            foreach (string passive in creature.passives)
+            {
+                if (string.IsNullOrWhiteSpace(passive))
+                    continue;
+
+                Ability ability = DefinedAbilities.TryGet(passive);
+                ability?.Apply(controller.gameObject);
             }
         }
 

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs
@@ -54,6 +54,36 @@ public class Pf2eRulesTests
     }
 
     [Test]
+    public void ZombiePassiveSlowAppliesAtCombatStart()
+    {
+        GameObject zombie = CreatureJsonConverter.CreateFromFile("DataFiles/pathfinder-monster-core/zombie-shambler");
+        created.Add(zombie);
+        TestActionController actionController = zombie.AddComponent<TestActionController>();
+
+        Assert.That(zombie.GetComponent<CreatureComponent>().passives, Does.Contain("Slow"));
+
+        Pf2eRulesEngine.ApplyCombatStartRules(new[] { actionController });
+
+        Assert.That(zombie.GetComponent<Conditions>().Contains("Slowed"), Is.True);
+        actionController.StartTurn();
+        Assert.That(actionController.ActionPoints, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ZombiePassiveSlowDoesNotStackWhenCombatStartRulesRunAgain()
+    {
+        GameObject zombie = CreatureJsonConverter.CreateFromFile("DataFiles/pathfinder-monster-core/zombie-shambler");
+        created.Add(zombie);
+        TestActionController actionController = zombie.AddComponent<TestActionController>();
+
+        Pf2eRulesEngine.ApplyCombatStartRules(new[] { actionController });
+        Pf2eRulesEngine.ApplyCombatStartRules(new[] { actionController });
+
+        actionController.StartTurn();
+        Assert.That(actionController.ActionPoints, Is.EqualTo(2));
+    }
+
+    [Test]
     public void PredicateSupportsAtomicCompoundAndNumericChecks()
     {
         PreparedCharacter prepared = new(new CharacterBuild());

--- a/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
+++ b/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
@@ -132,6 +132,65 @@ namespace TestsUI
             }
         }
 
+        [UnityTest]
+        public IEnumerator CombatTrackerShowsReducedActionsForSlowedCreature()
+        {
+            VisualElement cardHolder = null;
+            yield return WaitUntilWithTimeout(timeout, () =>
+            {
+                cardHolder = root.Q<VisualElement>("CardHolder");
+                player = CombatManagerInterface.GetInstance().WhosTurn();
+                return cardHolder != null && cardHolder.childCount > 0 && player != null;
+            });
+            Assert.IsNotNull(cardHolder, "CardHolder not found in UI.");
+            Assert.IsNotNull(player, "Current player was not ready.");
+
+            ActionController actionController = player.GetComponent<ActionController>();
+            Assert.IsNotNull(actionController, "Current combatant has no ActionController.");
+
+            List<GameObject> combatants = CombatManagerInterface.GetInstance().GetCombatants();
+            foreach (GameObject combatant in combatants)
+            {
+                ActionController combatantActionController = combatant.GetComponent<ActionController>();
+                if (combatantActionController != null)
+                    combatantActionController.ActionPoints = 0;
+            }
+
+            Conditions conditions = player.GetComponent<Conditions>() ?? player.AddComponent<Conditions>();
+            Condition slowed = DefinedConditions.TryGet("Slowed 1");
+            Assert.IsNotNull(slowed, "Slowed 1 condition definition was not found.");
+
+            slowed.Apply(new ConditionSource(), player);
+            actionController.StartTurn();
+
+            int matchingCards = 0;
+            yield return WaitUntilWithTimeout(timeout, () =>
+            {
+                matchingCards = CountCardsWithMedallionState(cardHolder, 2, 1);
+                return matchingCards == 1;
+            });
+
+            Assert.IsTrue(conditions.Contains("Slowed"), "Combatant should have the Slowed condition.");
+            Assert.AreEqual(2u, actionController.ActionPoints, "Slowed 1 should leave the combatant with two actions at turn start.");
+            Assert.AreEqual(1, matchingCards, "Combat tracker should show exactly one card with two available actions for Slowed 1.");
+        }
+
+        private int CountCardsWithMedallionState(VisualElement cardHolder, int expectedFilled, int expectedEmpty)
+        {
+            int matchingCards = 0;
+            for (int i = 0; i < cardHolder.childCount; i++)
+            {
+                List<VisualElement> medallions = cardHolder.ElementAt(i).Query<VisualElement>(className: "action-medallion").ToList();
+                if (medallions.Count == 3
+                    && CountMedallionsWithClass(medallions, "action-medallion--filled") == expectedFilled
+                    && CountMedallionsWithClass(medallions, "action-medallion--empty") == expectedEmpty)
+                {
+                    matchingCards++;
+                }
+            }
+            return matchingCards;
+        }
+
         private int CountMedallionsWithClass(List<VisualElement> medallions, string className)
         {
             int count = 0;


### PR DESCRIPTION
## Summary
- apply imported passive abilities during combat start so zombie `Slow` is wired before turns begin
- make the Slow passive idempotent so repeated combat-start setup cannot stack action loss listeners
- add regression coverage for zombie Slowed action economy from the imported zombie JSON
- add PlayMode UI coverage confirming a Slowed creature shows the reduced action count in the combat tracker

Fixes #89

## Tests
- `& "C:\Program Files\Unity\Hub\Editor\6000.2.1f1\Editor\Unity.exe" -batchmode -runTests -projectPath . -testPlatform editmode -testResults TestResults/EditModeResults.xml -logFile TestResults/EditMode.log`
  - Passed: 48/48
- `& "C:\Program Files\Unity\Hub\Editor\6000.2.1f1\Editor\Unity.exe" -batchmode -runTests -projectPath . -testPlatform playmode -testResults TestResults/PlayModeResults.xml -logFile TestResults/PlayMode.log`
  - Passed: 32/32

## Playtest Notes
- PlayMode run loaded combat scenes containing zombie-shambler instances and logged `Applied ability Slow` for zombies during combat start.
- `CombatTrackerShowsReducedActionsForSlowedCreature` verifies the combat tracker displays two filled action medallions and one empty medallion for a Slowed 1 combatant.