### PR TITLE
Compact structured combat log

### DIFF
--- a/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
@@ -107,6 +107,8 @@ public class AttackResultContext
     public List<Dice> DamageDice { get; set; } = new();
     public List<DamageValue> FlatDamages { get; set; } = new();
     public List<DamageValue> DamageValues { get; set; } = new();
+    public DamageRollResolution DamageResolution { get; set; }
+    public List<CombatLogDetail> LogDetails { get; } = new();
     public StrikeTargetResult TargetingResult { get; set; }
     public int BaseArmorClass { get; set; }
     public int TargetArmorClass { get; set; }
@@ -165,12 +167,16 @@ public static class AttackResultPipeline
         if (context.DamageDice.Count > 0)
             OnDamageDealt.Invoke(context.DamageDice[0].damageType);
 
-        context.DamageValues = DamageRoller.RollDamage(context.DamageDice, context.FlatDamages);
-        DamageRoller.EvaluateCriticalDamage(context.Degree, context.DamageValues);
+        context.DamageResolution = DamageRoller.StartDamageResolution(context.DamageDice, context.FlatDamages);
+        context.DamageValues = context.DamageResolution.DamageValues;
+        DamageRoller.ApplyCriticalDamage(context.DamageResolution, context.Degree);
         ApplyPhase(effects, AttackResultEffectPhase.AfterCriticalDoubling, context);
         ApplyPhase(effects, AttackResultEffectPhase.BeforeDefenseAdjustments, context);
-        DamageRoller.ApplyWeaknessAndResistance(context.DamageValues, context.TargetCreature.weaknesses, context.TargetCreature.resistances);
-        int totalDamage = DamageRoller.SumDamage(context.DamageValues);
+        context.DamageResolution.DamageValues = context.DamageValues;
+        DamageRoller.ApplyWeaknessAndResistance(context.DamageResolution, context.TargetCreature.weaknesses, context.TargetCreature.resistances);
+        DamageRoller.FinalizeDamageResolution(context.DamageResolution);
+        context.DamageValues = context.DamageResolution.DamageValues;
+        int totalDamage = context.DamageResolution.TotalDamage;
         context.FinalAppliedDamage = (uint)Mathf.Max(0, totalDamage);
         context.TargetCreature.TakeDamage(context.FinalAppliedDamage);
         ApplyPhase(effects, AttackResultEffectPhase.AfterDamageApplied, context);
@@ -300,7 +306,9 @@ internal sealed class DeadlyAttackResultEffect : IAttackResultEffect
         string damageType = context.DamageDice[0].damageType;
         DamageValue extraDamage = new DamageValue(damageType, UnityEngine.Random.Range(1, sides + 1));
         context.DamageValues = DamageRoller.AddOrMergeDamage(context.DamageValues, extraDamage);
-        CombatLog.GetInstance().Log("  +" + extraDamage.DamageAmount + " " + trait + " critical damage!");
+        if (context.DamageResolution != null)
+            context.DamageResolution.DamageValues = context.DamageValues;
+        context.LogDetails.Add(new CombatLogDetail("Critical Trait", "+" + extraDamage.DamageAmount + " " + trait + " critical damage"));
     }
 }
 
@@ -327,7 +335,7 @@ internal sealed class FatalDamageDieUpgradeEffect : IAttackResultEffect
             return;
 
         context.DamageDice[0] = new Dice(primary.numberOfDice, sides, primary.damageType);
-        CombatLog.GetInstance().Log("  " + trait + " upgrades critical damage dice to d" + sides + ".");
+        context.LogDetails.Add(new CombatLogDetail("Critical Trait", trait + " upgrades critical damage dice to d" + sides));
     }
 }
 

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -80,20 +80,8 @@ public class Strike
 
         D20Result attackRoll = D20.Roll(totalModifier, targetAc);
 
-        string log = "Attack:\n  AC: " + targetAc;
-        if (coverBonus != 0)
-            log += " (" + baseAcResolution.Total + " + " + coverBonus + " cover)";
-        log += "\n  Attack Roll: " + attackRoll.total
-            + " (" + attackRoll.roll + " + " + attackBonus + " - " + mapPenalty;
-        if (rangePenalty != 0)
-            log += " " + rangePenalty;
-        log += ")\n  Result: " + attackRoll.degree;
-        log += "\n  Attack Modifiers: " + FormatResolution(attackResolution);
-        log += "\n  AC Modifiers: " + FormatResolution(targetAcResolution);
-
         if (attackRoll.degree == DegreeOfSuccess.Success || attackRoll.degree == DegreeOfSuccess.CriticalSuccess)
         {
-            CombatLog.GetInstance().Log(log);
             AttackResultContext context = new AttackResultContext
             {
                 AttackerObject = From,
@@ -118,13 +106,89 @@ public class Strike
                 CoverAcBonus = coverBonus
             };
             AttackResultPipeline.ProcessHit(context);
+            CombatLog.GetInstance().LogEntry(BuildAttackLogEntry(attackRoll, targetAc, baseAcResolution.Total, attackResolution, targetAcResolution, mapPenalty, rangePenalty, coverBonus, context));
         }
         else
         {
             OnAttackMiss.Invoke(From);
-            log += "\nAttack Missed!";
-            CombatLog.GetInstance().Log(log);
+            CombatLog.GetInstance().LogEntry(BuildAttackLogEntry(attackRoll, targetAc, baseAcResolution.Total, attackResolution, targetAcResolution, mapPenalty, rangePenalty, coverBonus, null));
         }
+    }
+
+    private CombatLogEntry BuildAttackLogEntry(
+        D20Result attackRoll,
+        int targetAc,
+        int baseAc,
+        Pf2eModifierResolution attackResolution,
+        Pf2eModifierResolution targetAcResolution,
+        int mapPenalty,
+        int rangePenalty,
+        int coverBonus,
+        AttackResultContext context)
+    {
+        CombatLogEntry entry = new CombatLogEntry
+        {
+            Kind = CombatLogEntryKind.Attack,
+            Outcome = ToCombatLogOutcome(attackRoll.degree),
+            Actor = From != null ? From.name : string.Empty,
+            Target = To != null ? To.name : string.Empty,
+            Action = GetActionLabel(),
+            Roll = new CombatLogRoll
+            {
+                NaturalRoll = attackRoll.roll,
+                TotalModifier = attackResolution.Total,
+                Total = attackRoll.total,
+                DifficultyClass = targetAc
+            },
+            Damage = context?.DamageResolution?.Damage
+        };
+
+        entry.Tags.Add("attack");
+        entry.Details.Add(new CombatLogDetail("D20 Roll", attackRoll.total + " (" + attackRoll.roll + " + " + attackResolution.Total + ")"));
+        entry.Details.Add(new CombatLogDetail("Target AC", FormatArmorClass(targetAc, baseAc, coverBonus)));
+        entry.Details.Add(new CombatLogDetail("Attack Modifiers", FormatResolution(attackResolution)));
+        entry.Details.Add(new CombatLogDetail("AC Modifiers", FormatResolution(targetAcResolution)));
+        entry.Details.Add(new CombatLogDetail("MAP", mapPenalty == 0 ? "none" : "-" + mapPenalty));
+        entry.Details.Add(new CombatLogDetail("Range Penalty", rangePenalty == 0 ? "none" : rangePenalty.ToString()));
+        entry.Details.Add(new CombatLogDetail("Cover", coverBonus == 0 ? "none" : "+" + coverBonus + " AC"));
+        entry.Details.Add(new CombatLogDetail("Result", attackRoll.degree.ToString()));
+
+        if (context != null)
+        {
+            foreach (CombatLogDetail detail in context.DamageResolution.Details)
+                entry.Details.Add(detail);
+            foreach (CombatLogDetail detail in context.LogDetails)
+                entry.Details.Add(detail);
+        }
+
+        return entry;
+    }
+
+    private string GetActionLabel()
+    {
+        if (!string.IsNullOrWhiteSpace(SourceInfo?.Name))
+            return SourceInfo.Name;
+        if (!string.IsNullOrWhiteSpace(ItemSlug))
+            return ItemSlug == "unarmed" ? "Unarmed Strike" : ItemSlug;
+        return "Strike";
+    }
+
+    private static string FormatArmorClass(int targetAc, int baseAc, int coverBonus)
+    {
+        if (coverBonus == 0)
+            return targetAc.ToString();
+        return targetAc + " (" + baseAc + " + " + coverBonus + " cover)";
+    }
+
+    private static CombatLogOutcome ToCombatLogOutcome(DegreeOfSuccess degree)
+    {
+        return degree switch
+        {
+            DegreeOfSuccess.CriticalSuccess => CombatLogOutcome.CriticalSuccess,
+            DegreeOfSuccess.Success => CombatLogOutcome.Success,
+            DegreeOfSuccess.CriticalFail => CombatLogOutcome.CriticalFailure,
+            _ => CombatLogOutcome.Failure
+        };
     }
 
     private static List<Dice> CloneDamageDice(List<Dice> diceList)

--- a/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
@@ -194,7 +194,6 @@ public class StrikeWeapon : MultiFrameEntityAction
                 yield break;
             }
 
-            CombatLog.GetInstance().Log("- " + attacker.name + " strikes " + target.Value.Target.name + " with " + weaponName + ".");
             Strike.Damage(attacker, target.Value.Target, target.Value);
             cc?.MarkWeaponFired(Weapon);
             if (ac)

--- a/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
@@ -22,6 +22,7 @@ public class Unarmed : MultiFrameEntityAction
         Strike.Traits = new List<string>() {"agile", "finesse", "nonlethal", "unarmed"};
         Strike.ItemSlug = "unarmed";
         Strike.WeaponCategory = "unarmed";
+        Strike.SourceInfo = new AttackSourceInfo("Unarmed Strike", "unarmed", "unarmed", Strike.Traits);
     }
 
     public Strike GetStrike()
@@ -43,9 +44,7 @@ public class Unarmed : MultiFrameEntityAction
             
         // null target value equates to canceled action
         if(target.Value != null && target.Value.Target != null)
-        {
-            CombatLog.GetInstance().Log("- " + attacker.name + " attacks " + target.Value.Target.name + " with unarmed strike.");
-            Debug.Log(attacker + " Striking " + target.Value.Target);
+        {            Debug.Log(attacker + " Striking " + target.Value.Target);
             Strike.Damage(attacker, target.Value.Target, target.Value);
             if (ac)
             {

--- a/Assets/Scripts/Combat/Logging.meta
+++ b/Assets/Scripts/Combat/Logging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 626e220b513c46544803398ae33689dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/Logging/CombatLogDamage.cs
+++ b/Assets/Scripts/Combat/Logging/CombatLogDamage.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+public sealed class CombatLogDamage
+{
+    public List<CombatLogDamagePart> Parts { get; } = new();
+    public int Total { get; set; }
+
+    public string Summary
+    {
+        get
+        {
+            if (Total <= 0)
+                return "No damage";
+            if (Parts.Count == 1)
+                return Total + " " + Parts[0].DamageType;
+            return Total + " damage";
+        }
+    }
+}
+
+public sealed class CombatLogDamagePart
+{
+    public string DamageType { get; set; } = string.Empty;
+    public int Amount { get; set; }
+
+    public CombatLogDamagePart()
+    {
+    }
+
+    public CombatLogDamagePart(string damageType, int amount)
+    {
+        DamageType = damageType ?? string.Empty;
+        Amount = amount;
+    }
+}
+

--- a/Assets/Scripts/Combat/Logging/CombatLogDamage.cs.meta
+++ b/Assets/Scripts/Combat/Logging/CombatLogDamage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19036ac670ab04e4cb382b7fc7cca601

--- a/Assets/Scripts/Combat/Logging/CombatLogDetail.cs
+++ b/Assets/Scripts/Combat/Logging/CombatLogDetail.cs
@@ -1,0 +1,16 @@
+public sealed class CombatLogDetail
+{
+    public string Label { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+
+    public CombatLogDetail()
+    {
+    }
+
+    public CombatLogDetail(string label, string value)
+    {
+        Label = label ?? string.Empty;
+        Value = value ?? string.Empty;
+    }
+}
+

--- a/Assets/Scripts/Combat/Logging/CombatLogDetail.cs.meta
+++ b/Assets/Scripts/Combat/Logging/CombatLogDetail.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24b68cf85189ddd419006cc89a6c760d

--- a/Assets/Scripts/Combat/Logging/CombatLogEntry.cs
+++ b/Assets/Scripts/Combat/Logging/CombatLogEntry.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+
+public enum CombatLogEntryKind
+{
+    System,
+    Attack,
+    Movement,
+    Turn,
+    Damage
+}
+
+public enum CombatLogOutcome
+{
+    None,
+    System,
+    Success,
+    CriticalSuccess,
+    Failure,
+    CriticalFailure,
+    Damage
+}
+
+public sealed class CombatLogEntry
+{
+    public CombatLogEntryKind Kind { get; set; } = CombatLogEntryKind.System;
+    public CombatLogOutcome Outcome { get; set; } = CombatLogOutcome.System;
+    public string Actor { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public CombatLogRoll Roll { get; set; }
+    public CombatLogDamage Damage { get; set; }
+    public List<CombatLogDetail> Details { get; } = new();
+    public HashSet<string> Tags { get; } = new();
+    public bool Expanded { get; set; }
+
+    public static CombatLogEntry FromMessage(string message, IEnumerable<string> tags = null, CombatLogEntryKind kind = CombatLogEntryKind.System)
+    {
+        CombatLogEntry entry = new CombatLogEntry
+        {
+            Kind = kind,
+            Outcome = kind == CombatLogEntryKind.Damage ? CombatLogOutcome.Damage : CombatLogOutcome.System,
+            Message = message ?? string.Empty
+        };
+        if (tags != null)
+        {
+            foreach (string tag in tags)
+            {
+                if (!string.IsNullOrWhiteSpace(tag))
+                    entry.Tags.Add(tag.ToLowerInvariant());
+            }
+        }
+        return entry;
+    }
+}
+

--- a/Assets/Scripts/Combat/Logging/CombatLogEntry.cs.meta
+++ b/Assets/Scripts/Combat/Logging/CombatLogEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f54d622514df5541937bbaa95ba34fc

--- a/Assets/Scripts/Combat/Logging/CombatLogEntryFormatter.cs
+++ b/Assets/Scripts/Combat/Logging/CombatLogEntryFormatter.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+public static class CombatLogEntryFormatter
+{
+    public static string ToSummary(CombatLogEntry entry)
+    {
+        if (entry == null)
+            return string.Empty;
+
+        if (entry.Kind != CombatLogEntryKind.Attack)
+            return string.IsNullOrWhiteSpace(entry.Message) ? JoinNonEmpty(" | ", entry.Actor, entry.Action, entry.Target) : entry.Message;
+
+        string participants = JoinNonEmpty(" -> ", entry.Actor, entry.Target);
+        string damage = entry.Damage == null ? "No damage" : entry.Damage.Summary;
+        return JoinNonEmpty(" | ", participants, entry.Action, entry.Roll?.Summary, FormatOutcome(entry.Outcome), damage);
+    }
+
+    public static string ToPlainText(CombatLogEntry entry)
+    {
+        if (entry == null)
+            return string.Empty;
+
+        string text = ToSummary(entry);
+        if (entry.Details.Count == 0)
+            return text;
+
+        List<string> lines = new() { text };
+        foreach (CombatLogDetail detail in entry.Details)
+        {
+            if (detail == null)
+                continue;
+            lines.Add("  " + detail.Label + ": " + detail.Value);
+        }
+        return string.Join("\n", lines);
+    }
+
+    public static string FormatOutcome(CombatLogOutcome outcome)
+    {
+        return outcome switch
+        {
+            CombatLogOutcome.CriticalSuccess => "Critical Hit",
+            CombatLogOutcome.Success => "Hit",
+            CombatLogOutcome.CriticalFailure => "Critical Miss",
+            CombatLogOutcome.Failure => "Miss",
+            CombatLogOutcome.Damage => "Damage",
+            CombatLogOutcome.System => "System",
+            _ => string.Empty
+        };
+    }
+
+    private static string JoinNonEmpty(string separator, params string[] parts)
+    {
+        List<string> filtered = new();
+        foreach (string part in parts)
+        {
+            if (!string.IsNullOrWhiteSpace(part))
+                filtered.Add(part);
+        }
+        return string.Join(separator, filtered);
+    }
+}
+

--- a/Assets/Scripts/Combat/Logging/CombatLogEntryFormatter.cs.meta
+++ b/Assets/Scripts/Combat/Logging/CombatLogEntryFormatter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d3afebb7be990b41b35b6693743f073

--- a/Assets/Scripts/Combat/Logging/CombatLogRoll.cs
+++ b/Assets/Scripts/Combat/Logging/CombatLogRoll.cs
@@ -1,0 +1,11 @@
+public sealed class CombatLogRoll
+{
+    public int NaturalRoll { get; set; }
+    public int TotalModifier { get; set; }
+    public int Total { get; set; }
+    public int DifficultyClass { get; set; }
+    public string Label { get; set; } = "Attack Roll";
+
+    public string Summary => Total + " vs AC " + DifficultyClass;
+}
+

--- a/Assets/Scripts/Combat/Logging/CombatLogRoll.cs.meta
+++ b/Assets/Scripts/Combat/Logging/CombatLogRoll.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a038a25516d9756428e27d4263ca18ff

--- a/Assets/Scripts/Creature/Damage.cs
+++ b/Assets/Scripts/Creature/Damage.cs
@@ -1,12 +1,8 @@
 using UnityEngine;
-//using System;
 using System.Collections.Generic;
-// using System.Diagnostics;
 
 namespace Game.Creature
 {
-
-    // Tuple for damage type and amount
     [System.Serializable] public struct DamageValue
     {
         public string DamageType;
@@ -19,49 +15,75 @@ namespace Game.Creature
         }
     }
 
-    // Input list of Dice, output total rolled damage
+    public sealed class DamageRollResolution
+    {
+        public List<DamageValue> DamageValues { get; set; } = new();
+        public CombatLogDamage Damage { get; set; } = new();
+        public List<CombatLogDetail> Details { get; } = new();
+        public int TotalDamage { get; set; }
+    }
+
     public class DamageRoller
     {
-        // Roll damage for a single Dice
         public static List<DamageValue> RollDamage(Dice dice){
             return RollDamage(new List<Dice> { dice }, new List<DamageValue>());
         }
-        // Roll damage for a single Dice with a single flat DamageValue
+
         public static List<DamageValue> RollDamage(Dice dice, DamageValue damageFlat){
             return RollDamage(new List<Dice> { dice }, new List<DamageValue> { damageFlat });
         }
 
-        // Roll damage based on list of Dice
         public static List<DamageValue> RollDamage(List<Dice> damageRolls, List<DamageValue> damageFlats){
-            List<DamageValue> damageInstances = new List<DamageValue>();
-            string log = "  Damage: ";
-            log += "\n  Rolled ";
-            foreach (Dice dice in damageRolls){
-                DamageValue damageValue = new DamageValue(dice.damageType, dice.Roll());
-                string damageTypeCapitalized = char.ToUpper(damageValue.DamageType[0]) + damageValue.DamageType.Substring(1);
-                log += " "+dice.numberOfDice+"d"+dice.sidesPerDie+": "+damageValue.DamageAmount+" " + damageTypeCapitalized + ", ";
-                // Group damage by type (string comparison)
-                damageInstances = AddOrMergeDamage(damageInstances, damageValue);
-
-            }
-            log += "\n       ";
-            // For each flat damage in damageFlats...
-            foreach (DamageValue damageFlat in damageFlats){
-                // Group damage by type (string comparison)
-                string damageTypeCapitalized = char.ToUpper(damageFlat.DamageType[0]) + damageFlat.DamageType.Substring(1);
-                log += " +"+damageFlat.DamageAmount + " " + damageTypeCapitalized + ", ";
-                damageInstances = AddOrMergeDamage(damageInstances, damageFlat);
-            }
-            // TODO: append traits list?
-
+            DamageRollResolution resolution = RollBaseDamage(damageRolls, damageFlats);
+            string log = "  Damage: \n  Rolled " + DetailValue(resolution.Details, "Rolled") + "\n       " + DetailValue(resolution.Details, "Flat Damage");
             Debug.Log(log);
             CombatLog.GetInstance().Log(log);
-            return damageInstances;
+            return resolution.DamageValues;
         }
 
-        /// <summary>
-        /// Returns a new damage list with the supplied value merged by damage type, leaving the input list unchanged.
-        /// </summary>
+        public static DamageRollResolution ResolveDamage(
+            List<Dice> damageRolls,
+            List<DamageValue> damageFlats,
+            DegreeOfSuccess degree,
+            List<DamageValue> weaknesses,
+            List<DamageValue> resistances)
+        {
+            DamageRollResolution resolution = RollBaseDamage(damageRolls, damageFlats);
+            ApplyCriticalDamage(degree, resolution.DamageValues, resolution.Details);
+            ApplyWeaknessAndResistance(resolution.DamageValues, weaknesses, resistances, resolution.Details);
+            resolution.TotalDamage = SumDamageWithoutLogging(resolution.DamageValues);
+            resolution.Damage = BuildCombatLogDamage(resolution.DamageValues, resolution.TotalDamage);
+            resolution.Details.Add(new CombatLogDetail("Total Damage", resolution.TotalDamage + " damage"));
+            return resolution;
+        }
+
+        public static DamageRollResolution StartDamageResolution(List<Dice> damageRolls, List<DamageValue> damageFlats)
+        {
+            return RollBaseDamage(damageRolls, damageFlats);
+        }
+
+        public static void ApplyCriticalDamage(DamageRollResolution resolution, DegreeOfSuccess degree)
+        {
+            if (resolution == null)
+                return;
+            ApplyCriticalDamage(degree, resolution.DamageValues, resolution.Details);
+        }
+
+        public static void ApplyWeaknessAndResistance(DamageRollResolution resolution, List<DamageValue> weaknesses, List<DamageValue> resistances)
+        {
+            if (resolution == null)
+                return;
+            ApplyWeaknessAndResistance(resolution.DamageValues, weaknesses, resistances, resolution.Details);
+        }
+
+        public static void FinalizeDamageResolution(DamageRollResolution resolution)
+        {
+            if (resolution == null)
+                return;
+            resolution.TotalDamage = SumDamageWithoutLogging(resolution.DamageValues);
+            resolution.Damage = BuildCombatLogDamage(resolution.DamageValues, resolution.TotalDamage);
+            resolution.Details.Add(new CombatLogDetail("Total Damage", resolution.TotalDamage + " damage"));
+        }
         public static List<DamageValue> AddOrMergeDamage(IEnumerable<DamageValue> damageValues, DamageValue damageValue){
             List<DamageValue> merged = damageValues == null ? new List<DamageValue>() : new List<DamageValue>(damageValues);
             int index = merged.FindIndex(damage => damage.DamageType == damageValue.DamageType);
@@ -75,47 +97,132 @@ namespace Game.Creature
             }
             return merged;
         }
+
         public static int SumDamage(List<DamageValue> damageValues){
-            int totalDamage = 0;
-            foreach (DamageValue dv in damageValues){
-                totalDamage += dv.DamageAmount;
-            }
+            int totalDamage = SumDamageWithoutLogging(damageValues);
             CombatLog.GetInstance().Log("  Total: " + totalDamage +" Damage!");
             return totalDamage;
         }
 
         public static void EvaluateCriticalDamage(DegreeOfSuccess attackRoll, List<DamageValue> damageValues){
-            if (attackRoll == DegreeOfSuccess.CriticalSuccess){
+            List<CombatLogDetail> details = new();
+            ApplyCriticalDamage(attackRoll, damageValues, details);
+            if (attackRoll == DegreeOfSuccess.CriticalSuccess)
                 CombatLog.GetInstance().Log("  x2 for Critical Hit!");
-                for (int i = 0; i < damageValues.Count; i++)
-                {
-                    var dv = damageValues[i];
-                    dv.DamageAmount *= 2;
-                    damageValues[i] = dv;
-                }
+        }
+
+        public static void ApplyWeaknessAndResistance(List<DamageValue> incoming, List<DamageValue> weaknesses, List<DamageValue> resistances){
+            List<CombatLogDetail> details = new();
+            ApplyWeaknessAndResistance(incoming, weaknesses, resistances, details);
+            foreach (CombatLogDetail detail in details)
+            {
+                if (detail.Label == "Weakness")
+                    CombatLog.GetInstance().Log("  " + detail.Value + " for weakness!");
+                else if (detail.Label == "Resistance")
+                    CombatLog.GetInstance().Log("  " + detail.Value + " for resistance!");
             }
         }
 
-        // Called by creature receiving damage via TakeDamage
-        public static void ApplyWeaknessAndResistance(List<DamageValue> incoming, List<DamageValue> weaknesses, List<DamageValue> resistances){
-            // for each incoming damage type, apply suitable weaknesses, resistances, and set to 0 if net negative
+        private static DamageRollResolution RollBaseDamage(List<Dice> damageRolls, List<DamageValue> damageFlats)
+        {
+            DamageRollResolution resolution = new();
+            List<string> rollParts = new();
+            List<string> flatParts = new();
+
+            if (damageRolls != null)
+            {
+                foreach (Dice dice in damageRolls){
+                    DamageValue damageValue = new DamageValue(dice.damageType, dice.Roll());
+                    rollParts.Add(dice.numberOfDice + "d" + dice.sidesPerDie + " = " + damageValue.DamageAmount + " " + FormatDamageType(damageValue.DamageType));
+                    resolution.DamageValues = AddOrMergeDamage(resolution.DamageValues, damageValue);
+                }
+            }
+
+            if (damageFlats != null)
+            {
+                foreach (DamageValue damageFlat in damageFlats){
+                    flatParts.Add(FormatSigned(damageFlat.DamageAmount) + " " + FormatDamageType(damageFlat.DamageType));
+                    resolution.DamageValues = AddOrMergeDamage(resolution.DamageValues, damageFlat);
+                }
+            }
+
+            resolution.Details.Add(new CombatLogDetail("Rolled", rollParts.Count == 0 ? "none" : string.Join(", ", rollParts)));
+            resolution.Details.Add(new CombatLogDetail("Flat Damage", flatParts.Count == 0 ? "none" : string.Join(", ", flatParts)));
+            return resolution;
+        }
+
+        private static void ApplyCriticalDamage(DegreeOfSuccess attackRoll, List<DamageValue> damageValues, List<CombatLogDetail> details){
+            if (attackRoll != DegreeOfSuccess.CriticalSuccess)
+                return;
+
+            details.Add(new CombatLogDetail("Critical", "x2 damage before weakness and resistance"));
+            for (int i = 0; i < damageValues.Count; i++)
+            {
+                var dv = damageValues[i];
+                dv.DamageAmount *= 2;
+                damageValues[i] = dv;
+            }
+        }
+
+        private static void ApplyWeaknessAndResistance(List<DamageValue> incoming, List<DamageValue> weaknesses, List<DamageValue> resistances, List<CombatLogDetail> details){
+            weaknesses ??= new List<DamageValue>();
+            resistances ??= new List<DamageValue>();
             for (int i = 0; i < incoming.Count; i++)
             {
                 var inc = incoming[i];
-                if (weaknesses.Exists(di => di.DamageType == inc.DamageType)){
-                    //Debug.Log(""+inc.DamageAmount+" "+inc.DamageType+" incoming, applying weaknesses:");
-                    var existingInstance = weaknesses.Find(di => di.DamageType == inc.DamageType);
+                if (weaknesses.Exists(di => SameDamageType(di.DamageType, inc.DamageType))){
+                    var existingInstance = weaknesses.Find(di => SameDamageType(di.DamageType, inc.DamageType));
                     inc.DamageAmount += existingInstance.DamageAmount;
-                    CombatLog.GetInstance().Log("  +" + existingInstance.DamageAmount + " " + char.ToUpper(existingInstance.DamageType[0]) + existingInstance.DamageType.Substring(1) + " for weakness!");
+                    details.Add(new CombatLogDetail("Weakness", "+" + existingInstance.DamageAmount + " " + FormatDamageType(existingInstance.DamageType)));
                 }
-                if (resistances.Exists(di => di.DamageType == inc.DamageType)){
-                    var existingInstance = resistances.Find(di => di.DamageType == inc.DamageType);
+                if (resistances.Exists(di => SameDamageType(di.DamageType, inc.DamageType))){
+                    var existingInstance = resistances.Find(di => SameDamageType(di.DamageType, inc.DamageType));
                     inc.DamageAmount -= existingInstance.DamageAmount;
-                    CombatLog.GetInstance().Log("  -" + existingInstance.DamageAmount + " " + char.ToUpper(existingInstance.DamageType[0]) + existingInstance.DamageType.Substring(1) + " for resistance!");
+                    details.Add(new CombatLogDetail("Resistance", "-" + existingInstance.DamageAmount + " " + FormatDamageType(existingInstance.DamageType)));
                 }
                 if (inc.DamageAmount < 0) inc.DamageAmount = 0;
                 incoming[i] = inc;
             }
+        }
+
+        private static CombatLogDamage BuildCombatLogDamage(List<DamageValue> damageValues, int total)
+        {
+            CombatLogDamage damage = new() { Total = total };
+            foreach (DamageValue damageValue in damageValues)
+                damage.Parts.Add(new CombatLogDamagePart(damageValue.DamageType.ToLowerInvariant(), damageValue.DamageAmount));
+            return damage;
+        }
+
+        private static int SumDamageWithoutLogging(List<DamageValue> damageValues){
+            int totalDamage = 0;
+            if (damageValues == null)
+                return totalDamage;
+            foreach (DamageValue dv in damageValues)
+                totalDamage += dv.DamageAmount;
+            return totalDamage;
+        }
+
+        private static string DetailValue(List<CombatLogDetail> details, string label)
+        {
+            CombatLogDetail detail = details.Find(item => item.Label == label);
+            return detail == null ? "none" : detail.Value;
+        }
+
+        private static bool SameDamageType(string left, string right)
+        {
+            return string.Equals(left, right, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string FormatDamageType(string damageType)
+        {
+            if (string.IsNullOrWhiteSpace(damageType))
+                return string.Empty;
+            return char.ToUpper(damageType[0]) + damageType.Substring(1).ToLowerInvariant();
+        }
+
+        private static string FormatSigned(int value)
+        {
+            return value >= 0 ? "+" + value : value.ToString();
         }
     }
 }

--- a/Assets/Tests/EditMode/CombatLogEntryFormatterTests.cs
+++ b/Assets/Tests/EditMode/CombatLogEntryFormatterTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using Game.Creature;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestsCombat
+{
+    public class CombatLogEntryFormatterTests
+    {
+        [Test]
+        public void AttackSummaryIsOutcomeFirstAndCompact()
+        {
+            CombatLogEntry entry = new CombatLogEntry
+            {
+                Kind = CombatLogEntryKind.Attack,
+                Outcome = CombatLogOutcome.CriticalSuccess,
+                Actor = "Lena",
+                Target = "Zombie",
+                Action = "Longsword",
+                Roll = new CombatLogRoll { Total = 23, DifficultyClass = 18 },
+                Damage = new CombatLogDamage { Total = 18 }
+            };
+            entry.Damage.Parts.Add(new CombatLogDamagePart("slashing", 18));
+
+            Assert.AreEqual("Lena -> Zombie | Longsword | 23 vs AC 18 | Critical Hit | 18 slashing", CombatLogEntryFormatter.ToSummary(entry));
+        }
+
+        [Test]
+        public void PlainTextIncludesExpandedAttackDetails()
+        {
+            CombatLogEntry entry = new CombatLogEntry
+            {
+                Kind = CombatLogEntryKind.Attack,
+                Outcome = CombatLogOutcome.Success,
+                Actor = "Archer",
+                Target = "Kobold",
+                Action = "Shortbow",
+                Roll = new CombatLogRoll { Total = 17, DifficultyClass = 16 }
+            };
+            entry.Details.Add(new CombatLogDetail("MAP", "-5"));
+            entry.Details.Add(new CombatLogDetail("Cover", "+2 AC"));
+
+            string text = CombatLogEntryFormatter.ToPlainText(entry);
+
+            StringAssert.Contains("Archer -> Kobold | Shortbow | 17 vs AC 16 | Hit | No damage", text);
+            StringAssert.Contains("MAP: -5", text);
+            StringAssert.Contains("Cover: +2 AC", text);
+        }
+
+        [Test]
+        public void TagsArePreservedOnMessageEntries()
+        {
+            CombatLogEntry entry = CombatLogEntry.FromMessage("hidden", new[] { "Dev", "Rules" });
+
+            CollectionAssert.AreEquivalent(new[] { "dev", "rules" }, entry.Tags.ToArray());
+        }
+
+        [Test]
+        public void PlainTextFallbackUsesMessage()
+        {
+            CombatLogEntry entry = CombatLogEntry.FromMessage("UI System Test Log");
+
+            Assert.AreEqual("UI System Test Log", CombatLogEntryFormatter.ToPlainText(entry));
+        }
+    }
+
+    public class DamageRollerStructuredResolutionTests
+    {
+        [Test]
+        public void StructuredDamageResolutionIncludesCritWeaknessResistanceAndTotal()
+        {
+            Random.State state = Random.state;
+            Random.InitState(1);
+
+            DamageRollResolution resolution = DamageRoller.ResolveDamage(
+                new List<Dice> { new Dice(1, 1, "slashing") },
+                new List<DamageValue> { new DamageValue("slashing", 2) },
+                DegreeOfSuccess.CriticalSuccess,
+                new List<DamageValue> { new DamageValue("slashing", 3) },
+                new List<DamageValue> { new DamageValue("slashing", 1) });
+
+            Assert.AreEqual(8, resolution.TotalDamage);
+            Assert.AreEqual(8, resolution.Damage.Total);
+            Assert.AreEqual("slashing", resolution.Damage.Parts[0].DamageType);
+            Assert.IsTrue(resolution.Details.Any(detail => detail.Label == "Critical"));
+            Assert.IsTrue(resolution.Details.Any(detail => detail.Label == "Weakness" && detail.Value.Contains("+3")));
+            Assert.IsTrue(resolution.Details.Any(detail => detail.Label == "Resistance" && detail.Value.Contains("-1")));
+
+            Random.state = state;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CombatLogEntryFormatterTests.cs.meta
+++ b/Assets/Tests/EditMode/CombatLogEntryFormatterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43a7619ed9472334e85ea721292a9c90

--- a/Assets/Tests/EditMode/Pf2eCriticalEffectPipelineTests.cs
+++ b/Assets/Tests/EditMode/Pf2eCriticalEffectPipelineTests.cs
@@ -37,14 +37,14 @@ namespace TestsCombat
             AttackResultPipeline.ProcessHit(normal);
 
             Assert.AreEqual(1u, normal.FinalAppliedDamage);
-            Assert.IsFalse(log.Messages.Any(message => message.Contains("deadly-d10 critical damage")));
+            Assert.IsFalse(normal.LogDetails.Any(detail => detail.Value.Contains("deadly-d10 critical damage")));
 
             AttackResultContext critical = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, new List<string> { "deadly-d10" });
             AttackResultPipeline.ProcessHit(critical);
 
             Assert.Greater(critical.FinalAppliedDamage, 2u);
             Assert.LessOrEqual(critical.FinalAppliedDamage, 12u);
-            Assert.IsTrue(log.Messages.Any(message => message.Contains("deadly-d10 critical damage")));
+            Assert.IsTrue(critical.LogDetails.Any(detail => detail.Value.Contains("deadly-d10 critical damage")));
 
             UnityEngine.Random.state = randomState;
             UnityEngine.Object.DestroyImmediate(attacker);
@@ -78,8 +78,8 @@ namespace TestsCombat
             Assert.AreEqual(12, critical.DamageDice[0].sidesPerDie);
             Assert.GreaterOrEqual(critical.FinalAppliedDamage, 3u);
             Assert.LessOrEqual(critical.FinalAppliedDamage, 36u);
-            Assert.IsTrue(log.Messages.Any(message => message.Contains("fatal-d12 upgrades critical damage dice")));
-            Assert.IsTrue(log.Messages.Any(message => message.Contains("fatal-d12 critical damage")));
+            Assert.IsTrue(critical.LogDetails.Any(detail => detail.Value.Contains("fatal-d12 upgrades critical damage dice")));
+            Assert.IsTrue(critical.LogDetails.Any(detail => detail.Value.Contains("fatal-d12 critical damage")));
 
             UnityEngine.Random.state = randomState;
             UnityEngine.Object.DestroyImmediate(attacker);

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -224,12 +224,18 @@ namespace TestsCombat
                 RangePenalty = -2
             });
 
-            string attackLog = log.Messages.FirstOrDefault(message => message.StartsWith("Attack:", StringComparison.Ordinal));
+            string attackLog = log.Messages.FirstOrDefault(message => message.StartsWith("attacker -> target | Strike", StringComparison.Ordinal));
             Assert.IsNotNull(attackLog);
-            StringAssert.Contains("AC: 102 (100 + 2 cover)", attackLog);
-            StringAssert.Contains("+ 7 - 5 -2", attackLog);
+            StringAssert.Contains("vs AC 102", attackLog);
+            StringAssert.Contains("Target AC: 102 (100 + 2 cover)", attackLog);
+            StringAssert.Contains("MAP: -5", attackLog);
+            StringAssert.Contains("Range Penalty: -2", attackLog);
+            StringAssert.Contains("Cover: +2 AC", attackLog);
             StringAssert.Contains("Attack Modifiers: total 0", attackLog);
             StringAssert.Contains("AC Modifiers: total 102", attackLog);
+            StringAssert.Contains("Multiple attack penalty -5", attackLog);
+            StringAssert.Contains("Range penalty -2", attackLog);
+            StringAssert.Contains("suppressed [none]", attackLog);
 
             UnityEngine.Object.DestroyImmediate(attacker);
             UnityEngine.Object.DestroyImmediate(target);

--- a/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
+++ b/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
@@ -316,11 +316,24 @@ namespace TestsUI
             });
             Assert.IsNotNull(logList, "Could not find the ListView associated with the Combat Log.");
 
-            // Send a test log
-            combatLogComponent.Log("UI System Test Log");
+            CombatLogEntry entry = new CombatLogEntry
+            {
+                Kind = CombatLogEntryKind.Attack,
+                Outcome = CombatLogOutcome.Success,
+                Actor = "UI Tester",
+                Target = "Training Dummy",
+                Action = "Longsword",
+                Roll = new CombatLogRoll { Total = 23, DifficultyClass = 18 },
+                Damage = new CombatLogDamage { Total = 7 }
+            };
+            entry.Damage.Parts.Add(new CombatLogDamagePart("slashing", 7));
+            entry.Details.Add(new CombatLogDetail("D20 Roll", "23 (15 + 8)"));
+
+            combatLogComponent.LogEntry(entry);
             yield return null;
 
-            Assert.IsTrue(logList.itemsSource != null && logList.itemsSource.Count > 0, "Combat Log list view items source should not be empty after logging.");
+            Assert.IsTrue(logList.itemsSource != null && logList.itemsSource.Count > 0, "Combat Log list view items source should not be empty after structured logging.");
+            Assert.IsInstanceOf<CombatLogEntry>(logList.itemsSource[logList.itemsSource.Count - 1], "Combat Log list view should be backed by structured entries.");
 
             
             PushButton(toggleButton);

--- a/Assets/UIStuff/HUD/CombatLog.cs
+++ b/Assets/UIStuff/HUD/CombatLog.cs
@@ -1,4 +1,3 @@
-using Game.Strikes;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -10,17 +9,25 @@ public class CombatLog : CombatLogInterface
     {
         public HashSet<string> Tags;
         public string Message;
-        public CombatLogMessage(string message) { Message = message; Tags = new(); }
-        public CombatLogMessage(string message, HashSet<string> tags) { Message = message; Tags = tags; }
+        public CombatLogEntry Entry;
+
+        public CombatLogMessage(string message) : this(CombatLogEntry.FromMessage(message), new HashSet<string>()) { }
+        public CombatLogMessage(string message, HashSet<string> tags) : this(CombatLogEntry.FromMessage(message, tags), tags) { }
+
+        public CombatLogMessage(CombatLogEntry entry, HashSet<string> tags)
+        {
+            Entry = entry ?? CombatLogEntry.FromMessage(string.Empty);
+            Tags = tags ?? new HashSet<string>();
+            Message = CombatLogEntryFormatter.ToPlainText(Entry);
+        }
     }
 
     public VisualTreeAsset CombatLogTemplate;
     protected ListView LogList;
-    protected List<string> CurrentLogs;
+    protected List<CombatLogEntry> CurrentEntries;
     protected List<CombatLogMessage> Messages = new();
     protected HashSet<string> WhiteListTags = new();
     protected HashSet<string> BlackListTags = new();
-
 
     protected override void Awake()
     {
@@ -30,7 +37,6 @@ public class CombatLog : CombatLogInterface
 
     void OnEnable()
     {
-        // Find the holder and add the defined CombatLog UI
         VisualElement logHolder = Ui.Q<VisualElement>("CombatLog");
         var logList = CombatLogTemplate.Instantiate();
         logHolder.Add(logList);
@@ -39,51 +45,29 @@ public class CombatLog : CombatLogInterface
         VisualElement resizeHandle = logHolder.Q<VisualElement>("ResizeHandle");
         if (resizeHandle != null) { logHolder.Remove(resizeHandle); logHolder.Add(resizeHandle); }
 
-        CurrentLogs = new List<string>();
+        CurrentEntries = new List<CombatLogEntry>();
 
-        // This is a lamba expression that returns the new visual element for an item
-        // Can replace new TextElement() with Prefab.Instantiate();
-        Func<VisualElement> makeItem = () => new TextElement();
-
-        // This personalizes the item from makeItem
-        Action<VisualElement, int> bindItem = (e, i) =>
-        {
-            // Cast to TextElement, but if bindItem is a container and use bindItem.Q<Something>("Name");
-            ((TextElement)e).text = CurrentLogs[i];
-        };
-
-        LogList.makeItem = makeItem;
-        LogList.bindItem = bindItem;
-        LogList.itemsSource = CurrentLogs;
+        LogList.makeItem = MakeLogEntryElement;
+        LogList.bindItem = BindLogEntryElement;
+        LogList.itemsSource = CurrentEntries;
         LogList.selectionType = SelectionType.None;
     }
 
-    /// <summary>
-    /// Expensive to refresh whole list, use UpdatelogList for small changes
-    /// </summary>
     protected void RefreshLogList()
     {
-        CurrentLogs = GetMessages();
-        LogList.itemsSource = CurrentLogs;
+        CurrentEntries = GetVisibleEntries();
+        LogList.itemsSource = CurrentEntries;
         LogList.Rebuild();
-        // Scroll to bottom after refresh
-        if (LogList != null && CurrentLogs.Count > 0) {
-            LogList.ScrollToItem(CurrentLogs.Count - 1);
-        }
+        if (LogList != null && CurrentEntries.Count > 0)
+            LogList.ScrollToItem(CurrentEntries.Count - 1);
     }
 
-    /// <summary>
-    /// Updates the list for small changes
-    /// </summary>
-    /// <param name="message"></param>
-    protected void UpdateLogList(string message)
+    protected void UpdateLogList(CombatLogEntry entry)
     {
-        CurrentLogs.Add(timestamp() + message);
+        CurrentEntries.Add(entry);
         LogList.RefreshItems();
-        // Scroll to the bottom
-        if (LogList != null) {
-            LogList.ScrollToItem(CurrentLogs.Count - 1);
-        }
+        if (LogList != null)
+            LogList.ScrollToItem(CurrentEntries.Count - 1);
     }
 
     [ContextMenu("Enable Dev Mode")]
@@ -107,7 +91,7 @@ public class CombatLog : CombatLogInterface
         CombatLogMessage message = new CombatLogMessage(msg, new HashSet<string> { "dev" });
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
     }
 
     public override void DevLog(string msg, string tag)
@@ -115,29 +99,25 @@ public class CombatLog : CombatLogInterface
         CombatLogMessage message = new CombatLogMessage(msg, new HashSet<string> { "dev", tag.ToLower() });
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
     }
 
     public override void DevLog(string msg, List<string> tags)
     {
-        HashSet<string> t = new();
-        foreach (string tag in tags) 
-        {
-            t.Add(tag.ToLower());
-        }
+        HashSet<string> t = NormalizeTags(tags);
         t.Add("dev");
         CombatLogMessage message = new CombatLogMessage(msg, t);
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
     }
 
     public override void Log(string msg)
     {
-        CombatLogMessage message = new CombatLogMessage(msg, new());
+        CombatLogMessage message = new CombatLogMessage(msg, new HashSet<string>());
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
     }
 
     public override void Log(string msg, string tag)
@@ -146,20 +126,34 @@ public class CombatLog : CombatLogInterface
         CombatLogMessage message = new CombatLogMessage(msg, t);
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
     }
 
     public override void Log(string msg, List<string> tags)
     {
-        HashSet<string> t = new();
-        foreach (string tag in tags)
-        {
-            t.Add(tag.ToLower());
-        }
+        HashSet<string> t = NormalizeTags(tags);
         CombatLogMessage message = new CombatLogMessage(msg, t);
         Messages.Add(message);
         if (Filter(message))
-            UpdateLogList(msg);
+            UpdateLogList(message.Entry);
+    }
+
+    public override void LogEntry(CombatLogEntry entry)
+    {
+        HashSet<string> tags = new HashSet<string>();
+        if (entry?.Tags != null)
+        {
+            foreach (string tag in entry.Tags)
+            {
+                if (!string.IsNullOrWhiteSpace(tag))
+                    tags.Add(tag.ToLower());
+            }
+        }
+
+        CombatLogMessage message = new CombatLogMessage(entry, tags);
+        Messages.Add(message);
+        if (Filter(message))
+            UpdateLogList(message.Entry);
     }
 
     public override List<string> GetMessages()
@@ -185,11 +179,6 @@ public class CombatLog : CombatLogInterface
         RefreshLogList();
     }
 
-    /// <summary>
-    /// Helper function, returns true if msg passes filters
-    /// </summary>
-    /// <param name="msg"></param>
-    /// <returns></returns>
     protected bool Filter(CombatLogMessage msg)
     {
         foreach (string tag in WhiteListTags)
@@ -205,8 +194,112 @@ public class CombatLog : CombatLogInterface
         return true;
     }
 
-    private string timestamp()
+    private List<CombatLogEntry> GetVisibleEntries()
     {
-        return DateTime.Now.ToString("(HH:mm:ss) ");
+        List<CombatLogEntry> entries = new();
+        foreach (CombatLogMessage msg in Messages)
+        {
+            if (Filter(msg))
+                entries.Add(msg.Entry);
+        }
+        return entries;
+    }
+
+    private static HashSet<string> NormalizeTags(IEnumerable<string> tags)
+    {
+        HashSet<string> normalized = new();
+        if (tags == null)
+            return normalized;
+
+        foreach (string tag in tags)
+        {
+            if (!string.IsNullOrWhiteSpace(tag))
+                normalized.Add(tag.ToLower());
+        }
+        return normalized;
+    }
+
+    private VisualElement MakeLogEntryElement()
+    {
+        VisualElement root = new VisualElement();
+        root.AddToClassList("combat-log-entry");
+
+        VisualElement accent = new VisualElement();
+        accent.AddToClassList("combat-log-entry__accent");
+        root.Add(accent);
+
+        VisualElement body = new VisualElement();
+        body.AddToClassList("combat-log-entry__body");
+        root.Add(body);
+
+        VisualElement line = new VisualElement();
+        line.AddToClassList("combat-log-entry__line");
+        body.Add(line);
+
+        Label summary = new Label { name = "Summary" };
+        summary.AddToClassList("combat-log-entry__summary");
+        line.Add(summary);
+
+        Label roll = new Label { name = "RollChip" };
+        roll.AddToClassList("combat-log-entry__chip");
+        line.Add(roll);
+
+        Label damage = new Label { name = "DamageChip" };
+        damage.AddToClassList("combat-log-entry__chip");
+        line.Add(damage);
+
+        VisualElement details = new VisualElement { name = "Details" };
+        details.AddToClassList("combat-log-entry__details");
+        body.Add(details);
+
+        root.RegisterCallback<ClickEvent>(_ =>
+        {
+            if (root.userData is not CombatLogEntry entry || entry.Details.Count == 0)
+                return;
+
+            entry.Expanded = !entry.Expanded;
+            LogList?.RefreshItems();
+        });
+
+        return root;
+    }
+
+    private void BindLogEntryElement(VisualElement root, int index)
+    {
+        CombatLogEntry entry = CurrentEntries[index];
+        root.userData = entry;
+        root.EnableInClassList("combat-log-entry--attack", entry.Kind == CombatLogEntryKind.Attack);
+        root.EnableInClassList("combat-log-entry--expanded", entry.Expanded);
+        SetOutcomeClass(root, entry.Outcome);
+
+        Label summary = root.Q<Label>("Summary");
+        summary.text = CombatLogEntryFormatter.ToSummary(entry);
+
+        Label roll = root.Q<Label>("RollChip");
+        roll.text = entry.Roll?.Summary ?? CombatLogEntryFormatter.FormatOutcome(entry.Outcome);
+        roll.style.display = string.IsNullOrWhiteSpace(roll.text) ? DisplayStyle.None : DisplayStyle.Flex;
+
+        Label damage = root.Q<Label>("DamageChip");
+        damage.text = entry.Damage?.Summary ?? string.Empty;
+        damage.style.display = string.IsNullOrWhiteSpace(damage.text) ? DisplayStyle.None : DisplayStyle.Flex;
+
+        VisualElement details = root.Q<VisualElement>("Details");
+        details.Clear();
+        details.style.display = entry.Expanded && entry.Details.Count > 0 ? DisplayStyle.Flex : DisplayStyle.None;
+        foreach (CombatLogDetail detail in entry.Details)
+        {
+            Label detailLabel = new Label(detail.Label + ": " + detail.Value);
+            detailLabel.AddToClassList("combat-log-entry__detail");
+            details.Add(detailLabel);
+        }
+    }
+
+    private static void SetOutcomeClass(VisualElement root, CombatLogOutcome outcome)
+    {
+        root.EnableInClassList("combat-log-entry--hit", outcome == CombatLogOutcome.Success);
+        root.EnableInClassList("combat-log-entry--crit", outcome == CombatLogOutcome.CriticalSuccess);
+        root.EnableInClassList("combat-log-entry--miss", outcome == CombatLogOutcome.Failure || outcome == CombatLogOutcome.CriticalFailure);
+        root.EnableInClassList("combat-log-entry--damage", outcome == CombatLogOutcome.Damage);
+        root.EnableInClassList("combat-log-entry--system", outcome == CombatLogOutcome.System || outcome == CombatLogOutcome.None);
     }
 }

--- a/Assets/UIStuff/HUD/CombatLog.uss
+++ b/Assets/UIStuff/HUD/CombatLog.uss
@@ -1,31 +1,115 @@
 :root {
-
 }
 
 #CombatLog {
-    --unity-item-height: 50;
+    --unity-item-height: 48;
+    background-color: rgba(20, 22, 24, 0.78);
 }
 
 #CombatLog > .unity-scroller--vertical {
-    display: none;
+    display: flex;
+    width: 8px;
 }
 
 #CombatLog .unity-list-view__item {
-    background-color: rgba(86, 92, 68, 0.2);
-    color: rgb(233, 196, 140);
-    font-size: 25px;
-    padding-top: 6px;
-    padding-bottom: 6px;
-    padding-left: 10px;
-    padding-right: 10px;
-    transition-duration: 1s;
-    transition-property: background-color, color, font-size;
+    background-color: rgba(24, 25, 26, 0.82);
+    color: rgb(232, 224, 209);
+    font-size: 14px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 4px;
+    padding-right: 4px;
+    border-bottom-width: 1px;
+    border-bottom-color: rgba(236, 212, 169, 0.14);
 }
 
 #CombatLog .unity-list-view__item:hover {
-    background-color: rgb(86, 92, 68);
-    color: rgb(233, 196, 140);
-    font-size: 25px;
-    transition-duraton: 0.5s;
-    transition-property: background-color, color, font-size;
+    background-color: rgba(42, 43, 41, 0.92);
+    color: rgb(245, 235, 216);
+    font-size: 14px;
+}
+
+.combat-log-entry {
+    flex-direction: row;
+    min-height: 42px;
+    border-radius: 4px;
+    background-color: rgba(35, 34, 31, 0.88);
+    border-left-width: 0;
+}
+
+.combat-log-entry__accent {
+    width: 4px;
+    background-color: rgb(128, 128, 128);
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+}
+
+.combat-log-entry__body {
+    flex-grow: 1;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 7px;
+    padding-right: 7px;
+}
+
+.combat-log-entry__line {
+    flex-direction: row;
+    align-items: center;
+    min-height: 28px;
+}
+
+.combat-log-entry__summary {
+    flex-grow: 1;
+    white-space: normal;
+    font-size: 14px;
+    color: rgb(236, 226, 209);
+    -unity-font-style: bold;
+}
+
+.combat-log-entry__chip {
+    margin-left: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-radius: 3px;
+    background-color: rgba(11, 11, 11, 0.42);
+    color: rgb(232, 196, 140);
+    font-size: 12px;
+    min-width: 42px;
+    -unity-text-align: middle-center;
+}
+
+.combat-log-entry__details {
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top-width: 1px;
+    border-top-color: rgba(236, 212, 169, 0.16);
+}
+
+.combat-log-entry__detail {
+    font-size: 13px;
+    color: rgb(207, 201, 190);
+    white-space: normal;
+    margin-bottom: 2px;
+}
+
+.combat-log-entry--hit .combat-log-entry__accent {
+    background-color: rgb(92, 168, 112);
+}
+
+.combat-log-entry--crit .combat-log-entry__accent {
+    background-color: rgb(231, 173, 69);
+}
+
+.combat-log-entry--miss .combat-log-entry__accent {
+    background-color: rgb(158, 88, 82);
+}
+
+.combat-log-entry--damage .combat-log-entry__accent {
+    background-color: rgb(178, 91, 67);
+}
+
+.combat-log-entry--system .combat-log-entry__accent {
+    background-color: rgb(103, 128, 154);
 }

--- a/Assets/UIStuff/HUD/CombatLogInterface.cs
+++ b/Assets/UIStuff/HUD/CombatLogInterface.cs
@@ -72,5 +72,10 @@ public abstract class CombatLogInterface : SingletonMonoBehaviour<CombatLogInter
     /// <param name="tags"></param>
     public abstract void Log(string msg, List<string> tags);
 
+    public virtual void LogEntry(CombatLogEntry entry)
+    {
+        Log(CombatLogEntryFormatter.ToPlainText(entry));
+    }
+
     public abstract List<string> GetMessages();
 }


### PR DESCRIPTION
Closes #91

## Summary
- Adds structured combat log entry models and plaintext formatting compatibility.
- Renders combat log entries as compact outcome-first rows/cards with expandable attack details.
- Routes Strike damage through structured damage resolution so each attack emits one concise log card.
- Preserves legacy string logging, dev tags, filtering, toggle, opacity, and resize behavior.

## Verification
- EditMode targeted run: 13/13 passed.
- PlayMode UI targeted run: 1/1 passed for `TestsUI.GameUITests.CombatLogFunctionalityTest`.

## Screenshot
Real Unity Game View capture from `UnitTestingScene`:

![Compact structured combat log](https://gist.githubusercontent.com/clausman/b90460b9bb74a3f6dc37c9545a0563ec/raw/combat-log-gameview-expanded.png)

Gist: https://gist.github.com/clausman/b90460b9bb74a3f6dc37c9545a0563ec
