### PR TITLE
Implement grid area targeting mechanics

### DIFF
--- a/Assets/Scripts/Grid/AreaTargeting.cs
+++ b/Assets/Scripts/Grid/AreaTargeting.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -32,6 +31,28 @@ namespace GridPublic
         public int LineWidthFeet { get; set; } = 5;
         public bool IncludeCenter { get; set; }
         public bool RequiresLineOfEffect { get; set; } = true;
+    }
+
+    public class AreaTargetSource
+    {
+        public AreaTargetSource()
+        {
+        }
+
+        public AreaTargetSource(GameObject sourceObject)
+        {
+            SourceObject = sourceObject;
+            Cell = sourceObject == null ? Vector3Int.zero : Vector3Int.RoundToInt(sourceObject.transform.position);
+        }
+
+        public AreaTargetSource(Vector3Int cell)
+        {
+            Cell = cell;
+        }
+
+        public GameObject SourceObject { get; set; }
+        public Vector3Int Cell { get; set; }
+        public Vector3Int OriginCell => SourceObject == null ? Cell : Vector3Int.RoundToInt(SourceObject.transform.position);
     }
 
     public class AreaPlacement
@@ -76,20 +97,32 @@ namespace GridPrivate
 
         public static GridPublic.AreaTargetResult Evaluate(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
         {
-            if (actor == null || tiles == null || request == null || placement == null || request.SizeFeet <= 0)
+            return Evaluate(new GridPublic.AreaTargetSource(actor), tiles, request, placement);
+        }
+
+        public static GridPublic.AreaTargetResult Evaluate(GridPublic.AreaTargetSource source, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            if (source == null || tiles == null || request == null || placement == null || request.SizeFeet <= 0)
                 return null;
-            if (!IsPlacementInRange(actor, request, placement))
+            if (!IsPlacementInRange(source, request, placement))
                 return null;
 
-            List<Vector3Int> cells = CellsForPlacement(actor, tiles, request, placement);
+            List<Vector3Int> cells = CellsForPlacement(source, tiles, request, placement);
             if (cells.Count == 0)
                 return null;
 
+            GridPublic.AreaPlacement resultPlacement = new()
+            {
+                Shape = placement.Shape,
+                OriginCell = request.Shape == GridPublic.AreaShape.Burst ? placement.OriginCell : source.OriginCell,
+                OriginCorner = placement.OriginCorner,
+                Direction = placement.Direction
+            };
             GridPublic.AreaTargetResult result = new()
             {
-                Placement = placement,
+                Placement = resultPlacement,
                 Cells = cells,
-                Creatures = GetCreatures(actor, tiles, request, placement, cells)
+                Creatures = GetCreatures(source, tiles, request, placement, cells)
             };
             return result;
         }
@@ -120,17 +153,22 @@ namespace GridPrivate
 
         public static GridPublic.AreaPlacement PlacementFromHover(GameObject actor, GridPublic.AreaTargetRequest request, GridPublic.GridHoverInfo hover)
         {
-            if (actor == null || request == null)
+            return PlacementFromHover(new GridPublic.AreaTargetSource(actor), request, hover);
+        }
+
+        public static GridPublic.AreaPlacement PlacementFromHover(GridPublic.AreaTargetSource source, GridPublic.AreaTargetRequest request, GridPublic.GridHoverInfo hover)
+        {
+            if (source == null || request == null)
                 return null;
 
-            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
-            Vector3Int hoverCell = hover?.Cell ?? actorCell;
+            Vector3Int sourceCell = source.OriginCell;
+            Vector3Int hoverCell = hover?.Cell ?? sourceCell;
             GridPublic.AreaPlacement placement = new()
             {
                 Shape = request.Shape,
-                OriginCell = actorCell,
+                OriginCell = sourceCell,
                 OriginCorner = hover?.NearestCorner ?? new Vector2Int(hoverCell.x, hoverCell.z),
-                Direction = DirectionFromDelta(hoverCell - actorCell)
+                Direction = DirectionFromDelta(hoverCell - sourceCell)
             };
 
             if (request.Shape == GridPublic.AreaShape.Burst)
@@ -173,23 +211,22 @@ namespace GridPrivate
             return (GridPublic.AreaDirection)octant;
         }
 
-        private static bool IsPlacementInRange(GameObject actor, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        private static bool IsPlacementInRange(GridPublic.AreaTargetSource source, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
         {
             if (request.Shape != GridPublic.AreaShape.Burst || request.RangeFeet <= 0)
                 return true;
 
-            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
-            return DistanceCellToCornerFeet(actorCell, placement.OriginCorner) <= request.RangeFeet;
+            return DistanceCellToCornerFeet(source.OriginCell, placement.OriginCorner) <= request.RangeFeet;
         }
 
-        private static List<Vector3Int> CellsForPlacement(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        private static List<Vector3Int> CellsForPlacement(GridPublic.AreaTargetSource source, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
         {
             return request.Shape switch
             {
                 GridPublic.AreaShape.Burst => BurstCells(tiles, request, placement),
-                GridPublic.AreaShape.Cone => ConeCells(actor, tiles, request, placement),
-                GridPublic.AreaShape.Emanation => EmanationCells(actor, tiles, request),
-                GridPublic.AreaShape.Line => LineCells(actor, tiles, request, placement),
+                GridPublic.AreaShape.Cone => ConeCells(source, tiles, request, placement),
+                GridPublic.AreaShape.Emanation => EmanationCells(source, tiles, request),
+                GridPublic.AreaShape.Line => LineCells(source, tiles, request, placement),
                 _ => new List<Vector3Int>()
             };
         }
@@ -212,10 +249,10 @@ namespace GridPrivate
             return cells;
         }
 
-        private static List<Vector3Int> ConeCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        private static List<Vector3Int> ConeCells(GridPublic.AreaTargetSource source, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
         {
             List<Vector3Int> cells = new();
-            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            Vector3Int start = source.OriginCell;
             int radiusCells = Mathf.CeilToInt(request.SizeFeet / 5.0f);
             Vector2 direction = ToVector2(DirectionOffset(placement.Direction)).normalized;
 
@@ -237,10 +274,10 @@ namespace GridPrivate
             return cells;
         }
 
-        private static List<Vector3Int> EmanationCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request)
+        private static List<Vector3Int> EmanationCells(GridPublic.AreaTargetSource source, Tile[,] tiles, GridPublic.AreaTargetRequest request)
         {
             List<Vector3Int> cells = new();
-            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            Vector3Int start = source.OriginCell;
             int radiusCells = Mathf.CeilToInt(request.SizeFeet / 5.0f);
             for (int x = start.x - radiusCells; x <= start.x + radiusCells; x++)
             {
@@ -258,10 +295,10 @@ namespace GridPrivate
             return cells;
         }
 
-        private static List<Vector3Int> LineCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        private static List<Vector3Int> LineCells(GridPublic.AreaTargetSource source, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
         {
             List<Vector3Int> cells = new();
-            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            Vector3Int start = source.OriginCell;
             float lengthCells = request.SizeFeet / 5.0f;
             int widthCells = Mathf.Max(1, Mathf.CeilToInt(Mathf.Max(5, request.LineWidthFeet) / 5.0f));
             int search = Mathf.CeilToInt(lengthCells) + widthCells + 1;
@@ -291,17 +328,17 @@ namespace GridPrivate
         }
 
         private static List<GridPublic.AreaAffectedCreature> GetCreatures(
-            GameObject actor,
+            GridPublic.AreaTargetSource source,
             Tile[,] tiles,
             GridPublic.AreaTargetRequest request,
             GridPublic.AreaPlacement placement,
             List<Vector3Int> cells)
         {
             List<GridPublic.AreaAffectedCreature> creatures = new();
-            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
+            Vector3Int sourceCell = source.OriginCell;
             Vector2 sourcePoint = request.Shape == GridPublic.AreaShape.Burst
                 ? new Vector2(placement.OriginCorner.x, placement.OriginCorner.y)
-                : new Vector2(actorCell.x + 0.5f, actorCell.z + 0.5f);
+                : new Vector2(sourceCell.x + 0.5f, sourceCell.z + 0.5f);
 
             foreach (Vector3Int cell in cells)
             {
@@ -309,7 +346,7 @@ namespace GridPrivate
                 {
                     int clearRays = request.Shape == GridPublic.AreaShape.Burst
                         ? GridTargeting.CountClearRaysFromPoint(tiles, sourcePoint, cell)
-                        : GridTargeting.CountClearRays(tiles, actorCell, cell);
+                        : GridTargeting.CountClearRays(tiles, sourceCell, cell);
                     GridPublic.StrikeLineOfEffect lineOfEffect = clearRays > 0
                         ? GridPublic.StrikeLineOfEffect.Clear
                         : GridPublic.StrikeLineOfEffect.Blocked;

--- a/Assets/Scripts/Grid/AreaTargeting.cs
+++ b/Assets/Scripts/Grid/AreaTargeting.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GridPublic
+{
+    public enum AreaShape
+    {
+        Burst,
+        Cone,
+        Emanation,
+        Line
+    }
+
+    public enum AreaDirection
+    {
+        East,
+        NorthEast,
+        North,
+        NorthWest,
+        West,
+        SouthWest,
+        South,
+        SouthEast
+    }
+
+    public class AreaTargetRequest
+    {
+        public AreaShape Shape { get; set; }
+        public int SizeFeet { get; set; }
+        public int RangeFeet { get; set; }
+        public int LineWidthFeet { get; set; } = 5;
+        public bool IncludeCenter { get; set; }
+        public bool RequiresLineOfEffect { get; set; } = true;
+    }
+
+    public class AreaPlacement
+    {
+        public AreaShape Shape { get; set; }
+        public Vector3Int OriginCell { get; set; }
+        public Vector2Int OriginCorner { get; set; }
+        public AreaDirection Direction { get; set; }
+    }
+
+    public class AreaAffectedCreature
+    {
+        public GameObject Creature { get; set; }
+        public Vector3Int Cell { get; set; }
+        public StrikeLineOfEffect LineOfEffect { get; set; }
+        public StrikeCover Cover { get; set; }
+        public int ClearRays { get; set; }
+        public bool IsAffected => Creature != null && LineOfEffect == StrikeLineOfEffect.Clear;
+    }
+
+    public class AreaTargetResult
+    {
+        public AreaPlacement Placement { get; set; }
+        public List<Vector3Int> Cells { get; set; } = new();
+        public List<AreaAffectedCreature> Creatures { get; set; } = new();
+        public bool IsLegal => Placement != null && Cells.Count > 0;
+    }
+
+    public class GridHoverInfo
+    {
+        public Vector3Int Cell { get; set; }
+        public Vector3 WorldPosition { get; set; }
+        public Vector2Int NearestCorner { get; set; }
+    }
+}
+
+namespace GridPrivate
+{
+    public static class AreaTargeting
+    {
+        private const float AngleEpsilon = 0.01f;
+
+        public static GridPublic.AreaTargetResult Evaluate(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            if (actor == null || tiles == null || request == null || placement == null || request.SizeFeet <= 0)
+                return null;
+            if (!IsPlacementInRange(actor, request, placement))
+                return null;
+
+            List<Vector3Int> cells = CellsForPlacement(actor, tiles, request, placement);
+            if (cells.Count == 0)
+                return null;
+
+            GridPublic.AreaTargetResult result = new()
+            {
+                Placement = placement,
+                Cells = cells,
+                Creatures = GetCreatures(actor, tiles, request, placement, cells)
+            };
+            return result;
+        }
+
+        public static List<Vector3Int> CellsInPlacementRange(Tile[,] tiles, Vector3Int start, GridPublic.AreaTargetRequest request)
+        {
+            List<Vector3Int> result = new();
+            if (tiles == null || request == null)
+                return result;
+
+            int rangeFeet = request.Shape == GridPublic.AreaShape.Burst && request.RangeFeet > 0
+                ? request.RangeFeet
+                : Mathf.Max(request.SizeFeet, 5);
+            int maxCells = Mathf.CeilToInt(rangeFeet / 5.0f);
+            for (int x = start.x - maxCells; x <= start.x + maxCells; x++)
+            {
+                for (int z = start.z - maxCells; z <= start.z + maxCells; z++)
+                {
+                    Vector3Int cell = new(x, start.y, z);
+                    if (!GridTargeting.IsInBounds(tiles, cell) || tiles[x, z] == null)
+                        continue;
+                    if (GridTargeting.MeasureGridDistanceFeet(start, cell) <= rangeFeet)
+                        result.Add(cell);
+                }
+            }
+            return result;
+        }
+
+        public static GridPublic.AreaPlacement PlacementFromHover(GameObject actor, GridPublic.AreaTargetRequest request, GridPublic.GridHoverInfo hover)
+        {
+            if (actor == null || request == null)
+                return null;
+
+            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
+            Vector3Int hoverCell = hover?.Cell ?? actorCell;
+            GridPublic.AreaPlacement placement = new()
+            {
+                Shape = request.Shape,
+                OriginCell = actorCell,
+                OriginCorner = hover?.NearestCorner ?? new Vector2Int(hoverCell.x, hoverCell.z),
+                Direction = DirectionFromDelta(hoverCell - actorCell)
+            };
+
+            if (request.Shape == GridPublic.AreaShape.Burst)
+                placement.OriginCell = hoverCell;
+            return placement;
+        }
+
+        public static Vector2Int NearestCorner(Vector3Int cell, Vector3 worldPosition)
+        {
+            int x = worldPosition.x >= cell.x ? cell.x + 1 : cell.x;
+            int z = worldPosition.z >= cell.z ? cell.z + 1 : cell.z;
+            return new Vector2Int(x, z);
+        }
+
+        public static Vector3Int DirectionOffset(GridPublic.AreaDirection direction)
+        {
+            return direction switch
+            {
+                GridPublic.AreaDirection.East => new Vector3Int(1, 0, 0),
+                GridPublic.AreaDirection.NorthEast => new Vector3Int(1, 0, 1),
+                GridPublic.AreaDirection.North => new Vector3Int(0, 0, 1),
+                GridPublic.AreaDirection.NorthWest => new Vector3Int(-1, 0, 1),
+                GridPublic.AreaDirection.West => new Vector3Int(-1, 0, 0),
+                GridPublic.AreaDirection.SouthWest => new Vector3Int(-1, 0, -1),
+                GridPublic.AreaDirection.South => new Vector3Int(0, 0, -1),
+                GridPublic.AreaDirection.SouthEast => new Vector3Int(1, 0, -1),
+                _ => new Vector3Int(1, 0, 0)
+            };
+        }
+
+        public static GridPublic.AreaDirection DirectionFromDelta(Vector3Int delta)
+        {
+            if (delta.x == 0 && delta.z == 0)
+                return GridPublic.AreaDirection.East;
+
+            float angle = Mathf.Atan2(delta.z, delta.x) * Mathf.Rad2Deg;
+            if (angle < 0)
+                angle += 360.0f;
+            int octant = Mathf.RoundToInt(angle / 45.0f) % 8;
+            return (GridPublic.AreaDirection)octant;
+        }
+
+        private static bool IsPlacementInRange(GameObject actor, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            if (request.Shape != GridPublic.AreaShape.Burst || request.RangeFeet <= 0)
+                return true;
+
+            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
+            return DistanceCellToCornerFeet(actorCell, placement.OriginCorner) <= request.RangeFeet;
+        }
+
+        private static List<Vector3Int> CellsForPlacement(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            return request.Shape switch
+            {
+                GridPublic.AreaShape.Burst => BurstCells(tiles, request, placement),
+                GridPublic.AreaShape.Cone => ConeCells(actor, tiles, request, placement),
+                GridPublic.AreaShape.Emanation => EmanationCells(actor, tiles, request),
+                GridPublic.AreaShape.Line => LineCells(actor, tiles, request, placement),
+                _ => new List<Vector3Int>()
+            };
+        }
+
+        private static List<Vector3Int> BurstCells(Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            List<Vector3Int> cells = new();
+            int radiusCells = Mathf.CeilToInt(request.SizeFeet / 5.0f);
+            for (int x = placement.OriginCorner.x - radiusCells - 1; x <= placement.OriginCorner.x + radiusCells; x++)
+            {
+                for (int z = placement.OriginCorner.y - radiusCells - 1; z <= placement.OriginCorner.y + radiusCells; z++)
+                {
+                    Vector3Int cell = new(x, 0, z);
+                    if (!IsTemplateCell(tiles, cell))
+                        continue;
+                    if (DistanceCornerToCellFeet(placement.OriginCorner, cell) <= request.SizeFeet)
+                        cells.Add(cell);
+                }
+            }
+            return cells;
+        }
+
+        private static List<Vector3Int> ConeCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            List<Vector3Int> cells = new();
+            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            int radiusCells = Mathf.CeilToInt(request.SizeFeet / 5.0f);
+            Vector2 direction = ToVector2(DirectionOffset(placement.Direction)).normalized;
+
+            for (int x = start.x - radiusCells; x <= start.x + radiusCells; x++)
+            {
+                for (int z = start.z - radiusCells; z <= start.z + radiusCells; z++)
+                {
+                    Vector3Int cell = new(x, start.y, z);
+                    if (cell == start || !IsTemplateCell(tiles, cell))
+                        continue;
+                    if (GridTargeting.MeasureGridDistanceFeet(start, cell) > request.SizeFeet)
+                        continue;
+
+                    Vector2 offset = new(cell.x - start.x, cell.z - start.z);
+                    if (Vector2.Angle(direction, offset) <= 45.0f + AngleEpsilon)
+                        cells.Add(cell);
+                }
+            }
+            return cells;
+        }
+
+        private static List<Vector3Int> EmanationCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request)
+        {
+            List<Vector3Int> cells = new();
+            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            int radiusCells = Mathf.CeilToInt(request.SizeFeet / 5.0f);
+            for (int x = start.x - radiusCells; x <= start.x + radiusCells; x++)
+            {
+                for (int z = start.z - radiusCells; z <= start.z + radiusCells; z++)
+                {
+                    Vector3Int cell = new(x, start.y, z);
+                    if (!request.IncludeCenter && cell == start)
+                        continue;
+                    if (!IsTemplateCell(tiles, cell))
+                        continue;
+                    if (GridTargeting.MeasureGridDistanceFeet(start, cell) <= request.SizeFeet)
+                        cells.Add(cell);
+                }
+            }
+            return cells;
+        }
+
+        private static List<Vector3Int> LineCells(GameObject actor, Tile[,] tiles, GridPublic.AreaTargetRequest request, GridPublic.AreaPlacement placement)
+        {
+            List<Vector3Int> cells = new();
+            Vector3Int start = Vector3Int.RoundToInt(actor.transform.position);
+            float lengthCells = request.SizeFeet / 5.0f;
+            int widthCells = Mathf.Max(1, Mathf.CeilToInt(Mathf.Max(5, request.LineWidthFeet) / 5.0f));
+            int search = Mathf.CeilToInt(lengthCells) + widthCells + 1;
+            Vector2 direction = ToVector2(DirectionOffset(placement.Direction)).normalized;
+
+            for (int x = start.x - search; x <= start.x + search; x++)
+            {
+                for (int z = start.z - search; z <= start.z + search; z++)
+                {
+                    Vector3Int cell = new(x, start.y, z);
+                    if (cell == start || !IsTemplateCell(tiles, cell))
+                        continue;
+
+                    Vector2 offset = new(cell.x - start.x, cell.z - start.z);
+                    float projection = Vector2.Dot(offset, direction);
+                    if (projection <= 0.0f || projection > lengthCells + AngleEpsilon)
+                        continue;
+
+                    float perpendicular = Mathf.Abs(offset.x * direction.y - offset.y * direction.x);
+                    float halfWidth = Mathf.Max(0.01f, (widthCells - 1) * 0.5f + 0.01f);
+                    if (perpendicular <= halfWidth)
+                        cells.Add(cell);
+                }
+            }
+            cells.Sort((a, b) => GridTargeting.MeasureGridDistanceFeet(start, a).CompareTo(GridTargeting.MeasureGridDistanceFeet(start, b)));
+            return cells;
+        }
+
+        private static List<GridPublic.AreaAffectedCreature> GetCreatures(
+            GameObject actor,
+            Tile[,] tiles,
+            GridPublic.AreaTargetRequest request,
+            GridPublic.AreaPlacement placement,
+            List<Vector3Int> cells)
+        {
+            List<GridPublic.AreaAffectedCreature> creatures = new();
+            Vector3Int actorCell = Vector3Int.RoundToInt(actor.transform.position);
+            Vector2 sourcePoint = request.Shape == GridPublic.AreaShape.Burst
+                ? new Vector2(placement.OriginCorner.x, placement.OriginCorner.y)
+                : new Vector2(actorCell.x + 0.5f, actorCell.z + 0.5f);
+
+            foreach (Vector3Int cell in cells)
+            {
+                foreach (GameObject occupant in GridTargeting.OccupantsAt(tiles, cell))
+                {
+                    int clearRays = request.Shape == GridPublic.AreaShape.Burst
+                        ? GridTargeting.CountClearRaysFromPoint(tiles, sourcePoint, cell)
+                        : GridTargeting.CountClearRays(tiles, actorCell, cell);
+                    GridPublic.StrikeLineOfEffect lineOfEffect = clearRays > 0
+                        ? GridPublic.StrikeLineOfEffect.Clear
+                        : GridPublic.StrikeLineOfEffect.Blocked;
+                    GridPublic.StrikeCover cover = clearRays > 0 && clearRays < 16
+                        ? GridPublic.StrikeCover.Standard
+                        : GridPublic.StrikeCover.None;
+
+                    creatures.Add(new GridPublic.AreaAffectedCreature
+                    {
+                        Creature = occupant,
+                        Cell = cell,
+                        ClearRays = clearRays,
+                        Cover = cover,
+                        LineOfEffect = request.RequiresLineOfEffect ? lineOfEffect : GridPublic.StrikeLineOfEffect.Clear
+                    });
+                }
+            }
+            return creatures;
+        }
+
+        private static bool IsTemplateCell(Tile[,] tiles, Vector3Int cell)
+        {
+            return GridTargeting.IsInBounds(tiles, cell) && tiles[cell.x, cell.z] != null;
+        }
+
+        private static int DistanceCellToCornerFeet(Vector3Int cell, Vector2Int corner)
+        {
+            int best = int.MaxValue;
+            foreach (Vector2Int cellCorner in CellCorners(cell))
+                best = Mathf.Min(best, GridTargeting.MeasureGridDistanceFeet(corner.x - cellCorner.x, corner.y - cellCorner.y));
+            return best;
+        }
+
+        private static int DistanceCornerToCellFeet(Vector2Int corner, Vector3Int cell)
+        {
+            int best = int.MaxValue;
+            foreach (Vector2Int cellCorner in CellCorners(cell))
+                best = Mathf.Min(best, GridTargeting.MeasureGridDistanceFeet(corner.x - cellCorner.x, corner.y - cellCorner.y));
+            return best;
+        }
+
+        private static IEnumerable<Vector2Int> CellCorners(Vector3Int cell)
+        {
+            yield return new Vector2Int(cell.x, cell.z);
+            yield return new Vector2Int(cell.x + 1, cell.z);
+            yield return new Vector2Int(cell.x, cell.z + 1);
+            yield return new Vector2Int(cell.x + 1, cell.z + 1);
+        }
+
+        private static Vector2 ToVector2(Vector3Int value)
+        {
+            return new Vector2(value.x, value.z);
+        }
+    }
+}

--- a/Assets/Scripts/Grid/AreaTargeting.cs.meta
+++ b/Assets/Scripts/Grid/AreaTargeting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c0024a3e88cdcc40b569d9e9ea912d1

--- a/Assets/Scripts/Grid/GridBase.cs
+++ b/Assets/Scripts/Grid/GridBase.cs
@@ -27,7 +27,7 @@ namespace GridPrivate
             GridData = map.GetMapData();
             Tiles = new Tile[GridData.GetLength(0), GridData.GetLength(1)];
 
-            for(int x = 0; x < GridData.GetLength(0); x++) 
+            for(int x = 0; x < GridData.GetLength(0); x++)
             {
                 for (int y = 0; y < GridData.GetLength(1); y++)
                 {
@@ -85,6 +85,13 @@ namespace GridPrivate
         public override IEnumerator GetStrikeTarget(GameObject attacker, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> target)
         {
             if (Fsm.ChangeState(new StateStrike(attacker, request, target, Fsm)))
+                yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
+        }
+
+
+        public override IEnumerator GetAreaTarget(GameObject actor, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target)
+        {
+            if (Fsm.ChangeState(new StateAreaTarget(actor, request, target, Fsm)))
                 yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
         }
 

--- a/Assets/Scripts/Grid/GridBase.cs
+++ b/Assets/Scripts/Grid/GridBase.cs
@@ -89,9 +89,9 @@ namespace GridPrivate
         }
 
 
-        public override IEnumerator GetAreaTarget(GameObject actor, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target)
+        public override IEnumerator GetAreaTarget(AreaTargetSource source, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target)
         {
-            if (Fsm.ChangeState(new StateAreaTarget(actor, request, target, Fsm)))
+            if (Fsm.ChangeState(new StateAreaTarget(source, request, target, Fsm)))
                 yield return new WaitUntil(() => Fsm.CurrentState is StateIdle);
         }
 

--- a/Assets/Scripts/Grid/GridEvents.cs
+++ b/Assets/Scripts/Grid/GridEvents.cs
@@ -8,6 +8,8 @@ namespace GridPrivate
     /// Example: attacks with spash effects.
     /// </summary>
     public class OnHover : StaticUnityEvent<OnHover, List<Vector3Int>> { }
+    /// <summary>Triggered on hover with exact grid hit details for area templates.</summary>
+    public class OnGridHover : StaticUnityEvent<OnGridHover, GridPublic.GridHoverInfo> { }
     /// <summary>Triggered on no hover</summary>
     public class OnHoverEnd : StaticUnityEvent<OnHoverEnd> { }
     /// <summary>Triggered to highlight range</summary>
@@ -20,4 +22,9 @@ namespace GridPrivate
 
     /// <summary>Triggered on previewing a path</summary>
     public class OnPreviewPath : StaticUnityEvent<OnPreviewPath, List<Vector3Int>> { }
+
+    /// <summary>Triggered on previewing an area template.</summary>
+    public class OnPreviewArea : StaticUnityEvent<OnPreviewArea, List<Vector3Int>> { }
+    /// <summary>Triggered when area template preview should be hidden.</summary>
+    public class OnPreviewAreaEnd : StaticUnityEvent<OnPreviewAreaEnd> { }
 }

--- a/Assets/Scripts/Grid/GridTargeting.cs
+++ b/Assets/Scripts/Grid/GridTargeting.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GridPrivate
+{
+    public static class GridTargeting
+    {
+        private const float CornerOffset = 0.4f;
+        private const int SamplesPerCell = 8;
+
+        private static readonly Vector2[] CornerOffsets = new[]
+        {
+            new Vector2(-CornerOffset, -CornerOffset),
+            new Vector2(CornerOffset, -CornerOffset),
+            new Vector2(-CornerOffset, CornerOffset),
+            new Vector2(CornerOffset, CornerOffset)
+        };
+
+        public static int MeasureGridDistanceFeet(Vector3Int start, Vector3Int target)
+        {
+            return MeasureGridDistanceFeet(Mathf.Abs(target.x - start.x), Mathf.Abs(target.z - start.z));
+        }
+
+        public static int MeasureGridDistanceFeet(int dx, int dz)
+        {
+            int diagonals = Mathf.Min(Mathf.Abs(dx), Mathf.Abs(dz));
+            int straight = Mathf.Max(Mathf.Abs(dx), Mathf.Abs(dz)) - diagonals;
+            int diagonalFeet = (diagonals / 2) * 15 + (diagonals % 2) * 5;
+            return diagonalFeet + straight * 5;
+        }
+
+        public static bool IsInBounds(Tile[,] tiles, Vector3Int cell)
+        {
+            return tiles != null
+                && cell.x >= 0
+                && cell.z >= 0
+                && cell.x < tiles.GetLength(0)
+                && cell.z < tiles.GetLength(1);
+        }
+
+        public static bool IsBlocking(Tile[,] tiles, Vector3Int cell)
+        {
+            return !IsInBounds(tiles, cell) || tiles[cell.x, cell.z] == null;
+        }
+
+        public static bool BlocksDiagonalCorner(Tile[,] tiles, Vector3Int start, Vector3Int target)
+        {
+            int dx = target.x - start.x;
+            int dz = target.z - start.z;
+            if (Mathf.Abs(dx) != 1 || Mathf.Abs(dz) != 1)
+                return false;
+
+            int stepX = dx > 0 ? 1 : -1;
+            int stepZ = dz > 0 ? 1 : -1;
+            Vector3Int sideX = new(start.x + stepX, start.y, start.z);
+            Vector3Int sideZ = new(start.x, start.y, start.z + stepZ);
+            return IsBlocking(tiles, sideX) && IsBlocking(tiles, sideZ);
+        }
+
+        public static int CountClearRays(Tile[,] tiles, Vector3Int start, Vector3Int target)
+        {
+            int clear = 0;
+            foreach (Vector2 startOffset in CornerOffsets)
+            {
+                foreach (Vector2 targetOffset in CornerOffsets)
+                {
+                    if (!IsRayBlocked(tiles, CellPoint(start, startOffset), CellPoint(target, targetOffset), start, target))
+                        clear++;
+                }
+            }
+            return clear;
+        }
+
+        public static int CountClearRaysFromPoint(Tile[,] tiles, Vector2 startPoint, Vector3Int target)
+        {
+            int clear = 0;
+            foreach (Vector2 targetOffset in CornerOffsets)
+            {
+                if (!IsRayBlocked(tiles, startPoint, CellPoint(target, targetOffset), null, target))
+                    clear++;
+            }
+            return clear;
+        }
+
+        public static List<GameObject> OccupantsAt(Tile[,] tiles, Vector3Int cell)
+        {
+            if (!IsInBounds(tiles, cell) || tiles[cell.x, cell.z] == null)
+                return new List<GameObject>();
+
+            return new List<GameObject>(tiles[cell.x, cell.z].Occupants);
+        }
+
+        private static Vector2 CellPoint(Vector3Int cell, Vector2 offset)
+        {
+            return new Vector2(cell.x + 0.5f + offset.x, cell.z + 0.5f + offset.y);
+        }
+
+        private static bool IsRayBlocked(Tile[,] tiles, Vector2 rayStart, Vector2 rayEnd, Vector3Int? startCell, Vector3Int targetCell)
+        {
+            Vector2 delta = rayEnd - rayStart;
+            float distance = delta.magnitude;
+            if (distance <= Mathf.Epsilon)
+                return false;
+
+            int samples = Mathf.Max(1, Mathf.CeilToInt(distance * SamplesPerCell));
+            for (int i = 1; i < samples; i++)
+            {
+                Vector2 sample = rayStart + delta * (i / (float)samples);
+                Vector3Int cell = new(Mathf.FloorToInt(sample.x), targetCell.y, Mathf.FloorToInt(sample.y));
+                if ((startCell.HasValue && cell == startCell.Value) || cell == targetCell)
+                    continue;
+
+                if (IsBlocking(tiles, cell))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Grid/GridTargeting.cs.meta
+++ b/Assets/Scripts/Grid/GridTargeting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b0cc767699880b4294564a5b7d8f4bd

--- a/Assets/Scripts/Grid/GridVisuals.cs
+++ b/Assets/Scripts/Grid/GridVisuals.cs
@@ -58,6 +58,8 @@ namespace GridPrivate
             LineRenderer.useWorldSpace = true;
 
             OnPreviewPath.AddListener(ShowPath);
+            OnPreviewArea.AddListener((List<Vector3Int> locations) => ClearAndShow(locations, RangePool, RangeOffset));
+            OnPreviewAreaEnd.AddListener(() => RangePool.Clear());
         }
 
         protected void Show(List<Vector3Int> locations, GameObjectPool pool, float offset)

--- a/Assets/Scripts/Grid/Input/GridInput.cs
+++ b/Assets/Scripts/Grid/Input/GridInput.cs
@@ -58,6 +58,12 @@ namespace GridPrivate
                 ) {
                     Hover = cell;
                     OnHover.Invoke(new List<Vector3Int> { cell });
+                    OnGridHover.Invoke(new GridPublic.GridHoverInfo
+                    {
+                        Cell = cell,
+                        WorldPosition = hit,
+                        NearestCorner = AreaTargeting.NearestCorner(cell, hit)
+                    });
                     return;
                 }
             }

--- a/Assets/Scripts/Grid/States/StateAreaTarget.cs
+++ b/Assets/Scripts/Grid/States/StateAreaTarget.cs
@@ -7,7 +7,7 @@ namespace GridPrivate
 {
     public class StateAreaTarget : GridFSMState
     {
-        private readonly GameObject Character;
+        private readonly AreaTargetSource Source;
         private readonly AreaTargetRequest Request;
         private readonly CoroutineResult<AreaTargetResult> Selection;
         private readonly GridFSM Fsm;
@@ -17,13 +17,18 @@ namespace GridPrivate
         private AreaTargetResult PendingResult;
 
         public StateAreaTarget(GameObject character, AreaTargetRequest request, CoroutineResult<AreaTargetResult> selection, GridFSM fsm)
+            : this(new AreaTargetSource(character), request, selection, fsm)
         {
-            Character = character;
+        }
+
+        public StateAreaTarget(AreaTargetSource source, AreaTargetRequest request, CoroutineResult<AreaTargetResult> selection, GridFSM fsm)
+        {
+            Source = source ?? new AreaTargetSource();
             Request = request ?? new AreaTargetRequest();
             Selection = selection;
             Fsm = fsm;
             Tiles = GridAPI.GetTiles();
-            StartPosition = Character == null ? Vector3Int.zero : Vector3Int.RoundToInt(Character.transform.position);
+            StartPosition = Source.OriginCell;
         }
 
         public override void Enter(FiniteStateMachine<GridFSMState> fsm)
@@ -31,14 +36,7 @@ namespace GridPrivate
             base.Enter(fsm);
             canCancel = true;
 
-            if (Character == null)
-            {
-                Debug.LogWarning("Area targeting requires an actor.");
-                CoroutineRunner.Run(ChangeToIdle());
-                return;
-            }
-
-            if (Character.GetComponent<AIActionController>() != null)
+            if (Source.SourceObject != null && Source.SourceObject.GetComponent<AIActionController>() != null)
             {
                 Debug.LogWarning("AI area targeting is not implemented in this grid state.");
                 CoroutineRunner.Run(ChangeToIdle());
@@ -93,7 +91,7 @@ namespace GridPrivate
 
         private void HandleGridHover(GridHoverInfo hover)
         {
-            AreaPlacement placement = AreaTargeting.PlacementFromHover(Character, Request, hover);
+            AreaPlacement placement = AreaTargeting.PlacementFromHover(Source, Request, hover);
             Preview(placement);
         }
 
@@ -117,7 +115,7 @@ namespace GridPrivate
 
         private void Preview(AreaPlacement placement)
         {
-            PendingResult = AreaTargeting.Evaluate(Character, Tiles, Request, placement);
+            PendingResult = AreaTargeting.Evaluate(Source, Tiles, Request, placement);
             if (PendingResult == null)
             {
                 OnPreviewAreaEnd.Invoke();

--- a/Assets/Scripts/Grid/States/StateAreaTarget.cs
+++ b/Assets/Scripts/Grid/States/StateAreaTarget.cs
@@ -1,0 +1,141 @@
+using System.Collections;
+using System.Collections.Generic;
+using GridPublic;
+using UnityEngine;
+
+namespace GridPrivate
+{
+    public class StateAreaTarget : GridFSMState
+    {
+        private readonly GameObject Character;
+        private readonly AreaTargetRequest Request;
+        private readonly CoroutineResult<AreaTargetResult> Selection;
+        private readonly GridFSM Fsm;
+        private readonly GridAPIPrivate GridAPI = (GridAPIPrivate)GridPublic.GridAPI.GetInstance();
+        private readonly Tile[,] Tiles;
+        private readonly Vector3Int StartPosition;
+        private AreaTargetResult PendingResult;
+
+        public StateAreaTarget(GameObject character, AreaTargetRequest request, CoroutineResult<AreaTargetResult> selection, GridFSM fsm)
+        {
+            Character = character;
+            Request = request ?? new AreaTargetRequest();
+            Selection = selection;
+            Fsm = fsm;
+            Tiles = GridAPI.GetTiles();
+            StartPosition = Character == null ? Vector3Int.zero : Vector3Int.RoundToInt(Character.transform.position);
+        }
+
+        public override void Enter(FiniteStateMachine<GridFSMState> fsm)
+        {
+            base.Enter(fsm);
+            canCancel = true;
+
+            if (Character == null)
+            {
+                Debug.LogWarning("Area targeting requires an actor.");
+                CoroutineRunner.Run(ChangeToIdle());
+                return;
+            }
+
+            if (Character.GetComponent<AIActionController>() != null)
+            {
+                Debug.LogWarning("AI area targeting is not implemented in this grid state.");
+                CoroutineRunner.Run(ChangeToIdle());
+                return;
+            }
+
+            if (Request.Shape == AreaShape.Emanation)
+            {
+                AreaPlacement placement = new()
+                {
+                    Shape = Request.Shape,
+                    OriginCell = StartPosition,
+                    OriginCorner = new Vector2Int(StartPosition.x, StartPosition.z),
+                    Direction = AreaDirection.East
+                };
+                Preview(placement);
+                return;
+            }
+
+            OnHighlightRange.Invoke(AreaTargeting.CellsInPlacementRange(Tiles, StartPosition, Request));
+            OnGridHover.AddListener(HandleGridHover);
+            OnHover.AddListener(HandleLegacyHover);
+            OnHoverEnd.AddListener(ClearPreview);
+        }
+
+        public override void Exit()
+        {
+            OnGridHover.RemoveListener(HandleGridHover);
+            OnHover.RemoveListener(HandleLegacyHover);
+            OnHoverEnd.RemoveListener(ClearPreview);
+            OnPreviewAreaEnd.Invoke();
+            OnHighlightRangeEnd.Invoke();
+            OnActionComplete.Invoke();
+        }
+
+        public override void Leftclick()
+        {
+            if (PendingResult == null || !PendingResult.IsLegal)
+                return;
+
+            if (Selection != null)
+                Selection.Value = PendingResult;
+            OnActionConfirm.Invoke();
+            fsm.ChangeState(fsm.IdleState);
+        }
+
+        public override void Rightclick()
+        {
+            if (!canCancel) return;
+            UniversalEvents.OnCancel.Invoke();
+        }
+
+        private void HandleGridHover(GridHoverInfo hover)
+        {
+            AreaPlacement placement = AreaTargeting.PlacementFromHover(Character, Request, hover);
+            Preview(placement);
+        }
+
+        private void HandleLegacyHover(List<Vector3Int> hover)
+        {
+            if (hover == null || hover.Count == 0)
+            {
+                ClearPreview();
+                return;
+            }
+
+            Vector3Int cell = hover[0];
+            GridHoverInfo info = new()
+            {
+                Cell = cell,
+                WorldPosition = new Vector3(cell.x, cell.y, cell.z),
+                NearestCorner = new Vector2Int(cell.x, cell.z)
+            };
+            HandleGridHover(info);
+        }
+
+        private void Preview(AreaPlacement placement)
+        {
+            PendingResult = AreaTargeting.Evaluate(Character, Tiles, Request, placement);
+            if (PendingResult == null)
+            {
+                OnPreviewAreaEnd.Invoke();
+                return;
+            }
+            OnPreviewArea.Invoke(PendingResult.Cells);
+        }
+
+        private void ClearPreview()
+        {
+            PendingResult = null;
+            OnPreviewAreaEnd.Invoke();
+        }
+
+        private IEnumerator ChangeToIdle()
+        {
+            yield return null;
+            Fsm.ChangeState(Fsm.IdleState);
+        }
+    }
+}

--- a/Assets/Scripts/Grid/States/StateAreaTarget.cs.meta
+++ b/Assets/Scripts/Grid/States/StateAreaTarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c3236718ffb996c4d8184abc90b4c29c

--- a/Assets/Scripts/Grid/StrikeTargeting.cs
+++ b/Assets/Scripts/Grid/StrikeTargeting.cs
@@ -122,7 +122,7 @@ namespace GridPrivate
                 for (int z = start.z - maxCells; z <= start.z + maxCells; z++)
                 {
                     Vector3Int cell = new(x, start.y, z);
-                    if (!IsInBounds(tiles, cell) || cell == start)
+                    if (!GridTargeting.IsInBounds(tiles, cell) || cell == start)
                         continue;
 
                     if (IsWithinStrikeRange(start, cell, request))
@@ -143,7 +143,7 @@ namespace GridPrivate
             if (!IsWithinStrikeRange(start, targetCell, request))
                 return null;
 
-            int clearRays = BlocksDiagonalCorner(tiles, start, targetCell) ? 0 : CountClearRays(tiles, start, targetCell);
+            int clearRays = GridTargeting.BlocksDiagonalCorner(tiles, start, targetCell) ? 0 : CountClearRays(tiles, start, targetCell);
             GridPublic.StrikeLineOfEffect lineOfEffect = clearRays > 0
                 ? GridPublic.StrikeLineOfEffect.Clear
                 : GridPublic.StrikeLineOfEffect.Blocked;

--- a/Assets/Scripts/Interfaces/GridAPI.cs
+++ b/Assets/Scripts/Interfaces/GridAPI.cs
@@ -29,7 +29,19 @@ namespace GridPublic
         /// <param name="request">area targeting constraints</param>
         /// <param name="target">selected area result, null if canceled or illegal</param>
         /// <returns></returns>
-        public abstract IEnumerator GetAreaTarget(GameObject actor, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target);
+        public virtual IEnumerator GetAreaTarget(GameObject actor, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target)
+        {
+            return GetAreaTarget(new AreaTargetSource(actor), request, target);
+        }
+
+        /// <summary>
+        /// Selects or confirms an area template placement from a grid source, such as a trap or environmental effect.
+        /// </summary>
+        /// <param name="source">source object or source cell placing the area</param>
+        /// <param name="request">area targeting constraints</param>
+        /// <param name="target">selected area result, null if canceled or illegal</param>
+        /// <returns></returns>
+        public abstract IEnumerator GetAreaTarget(AreaTargetSource source, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target);
 
         /// <summary>
         /// Destroys a gameobject from the grid

--- a/Assets/Scripts/Interfaces/GridAPI.cs
+++ b/Assets/Scripts/Interfaces/GridAPI.cs
@@ -12,7 +12,7 @@ namespace GridPublic
         /// <param name="character"></param>
         /// <returns></returns>
         public abstract IEnumerator Stride(GameObject character);
-        
+
         /// <summary>
         /// The given character selects a target for a Strike-style action.
         /// </summary>
@@ -21,6 +21,15 @@ namespace GridPublic
         /// <param name="target">selected target result, null if canceled or illegal</param>
         /// <returns></returns>
         public abstract IEnumerator GetStrikeTarget(GameObject attacker, StrikeTargetRequest request, CoroutineResult<StrikeTargetResult> target);
+
+        /// <summary>
+        /// The given character selects or confirms an area template placement.
+        /// </summary>
+        /// <param name="actor">character placing the area</param>
+        /// <param name="request">area targeting constraints</param>
+        /// <param name="target">selected area result, null if canceled or illegal</param>
+        /// <returns></returns>
+        public abstract IEnumerator GetAreaTarget(GameObject actor, AreaTargetRequest request, CoroutineResult<AreaTargetResult> target);
 
         /// <summary>
         /// Destroys a gameobject from the grid

--- a/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs
+++ b/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs
@@ -70,6 +70,28 @@ namespace TestsCombat
         }
 
         [Test]
+        public void AreaTargetingSupportsSourceCellWithoutActorObject()
+        {
+            Tile[,] tiles = BuildTiles(8, 8);
+            AreaTargetSource source = new(Cell(2, 2));
+            AreaTargetRequest request = new()
+            {
+                Shape = AreaShape.Line,
+                SizeFeet = 15
+            };
+
+            AreaTargetResult result = AreaTargeting.Evaluate(source, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Line,
+                Direction = AreaDirection.East
+            });
+
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(new[] { Cell(3, 2), Cell(4, 2), Cell(5, 2) }, result.Cells);
+            Assert.AreEqual(Cell(2, 2), result.Placement.OriginCell);
+        }
+
+        [Test]
         public void ConeUsesAimedQuarterCircleAndExcludesCasterCell()
         {
             Tile[,] tiles = BuildTiles(8, 8);

--- a/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs
+++ b/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using System.Linq;
+using GridPrivate;
+using GridPublic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestsCombat
+{
+    public class Pf2eAreaTargetingTests
+    {
+        [Test]
+        public void EmanationUsesAlternatingDiagonalDistanceAndIncludeCenterPolicy()
+        {
+            Tile[,] tiles = BuildTiles(8, 8);
+            GameObject actor = CreateToken("actor", 3, 3);
+            AreaTargetRequest request = new()
+            {
+                Shape = AreaShape.Emanation,
+                SizeFeet = 10,
+                IncludeCenter = false
+            };
+            AreaPlacement placement = new() { Shape = AreaShape.Emanation, OriginCell = new Vector3Int(3, 0, 3) };
+
+            AreaTargetResult result = AreaTargeting.Evaluate(actor, tiles, request, placement);
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                Cell(1, 2), Cell(1, 3), Cell(1, 4),
+                Cell(2, 1), Cell(2, 2), Cell(2, 3), Cell(2, 4), Cell(2, 5),
+                Cell(3, 1), Cell(3, 2),             Cell(3, 4), Cell(3, 5),
+                Cell(4, 1), Cell(4, 2), Cell(4, 3), Cell(4, 4), Cell(4, 5),
+                Cell(5, 2), Cell(5, 3), Cell(5, 4)
+            }, result.Cells);
+            Assert.IsFalse(result.Cells.Contains(Cell(3, 3)));
+
+            request.IncludeCenter = true;
+            result = AreaTargeting.Evaluate(actor, tiles, request, placement);
+            Assert.Contains(Cell(3, 3), result.Cells);
+
+            Object.DestroyImmediate(actor);
+        }
+
+        [Test]
+        public void LineDefaultsToFiveFootWidthAndSupportsDiagonalDistance()
+        {
+            Tile[,] tiles = BuildTiles(10, 10);
+            GameObject actor = CreateToken("actor", 1, 1);
+            AreaTargetRequest request = new()
+            {
+                Shape = AreaShape.Line,
+                SizeFeet = 30
+            };
+
+            AreaTargetResult east = AreaTargeting.Evaluate(actor, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Line,
+                Direction = AreaDirection.East
+            });
+            CollectionAssert.AreEqual(new[] { Cell(2, 1), Cell(3, 1), Cell(4, 1), Cell(5, 1), Cell(6, 1), Cell(7, 1) }, east.Cells);
+
+            AreaTargetResult diagonal = AreaTargeting.Evaluate(actor, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Line,
+                Direction = AreaDirection.NorthEast
+            });
+            CollectionAssert.AreEqual(new[] { Cell(2, 2), Cell(3, 3), Cell(4, 4), Cell(5, 5) }, diagonal.Cells);
+
+            Object.DestroyImmediate(actor);
+        }
+
+        [Test]
+        public void ConeUsesAimedQuarterCircleAndExcludesCasterCell()
+        {
+            Tile[,] tiles = BuildTiles(8, 8);
+            GameObject actor = CreateToken("actor", 3, 3);
+            AreaTargetRequest request = new()
+            {
+                Shape = AreaShape.Cone,
+                SizeFeet = 15
+            };
+
+            AreaTargetResult result = AreaTargeting.Evaluate(actor, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Cone,
+                Direction = AreaDirection.East
+            });
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                Cell(4, 2), Cell(4, 3), Cell(4, 4),
+                Cell(5, 1), Cell(5, 2), Cell(5, 3), Cell(5, 4), Cell(5, 5),
+                Cell(6, 2), Cell(6, 3), Cell(6, 4)
+            }, result.Cells);
+            Assert.IsFalse(result.Cells.Contains(Cell(3, 3)));
+
+            Object.DestroyImmediate(actor);
+        }
+
+        [Test]
+        public void BurstOriginMustBeInRangeAndAffectedCellsAreTrimmedToGrid()
+        {
+            Tile[,] tiles = BuildTiles(5, 5);
+            GameObject actor = CreateToken("actor", 0, 0);
+            AreaTargetRequest request = new()
+            {
+                Shape = AreaShape.Burst,
+                SizeFeet = 10,
+                RangeFeet = 10
+            };
+
+            AreaTargetResult legal = AreaTargeting.Evaluate(actor, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Burst,
+                OriginCorner = new Vector2Int(1, 1)
+            });
+            Assert.IsNotNull(legal);
+            Assert.Contains(Cell(0, 0), legal.Cells);
+            Assert.Contains(Cell(2, 2), legal.Cells);
+            Assert.IsTrue(legal.Cells.All(cell => cell.x >= 0 && cell.z >= 0 && cell.x < 5 && cell.z < 5));
+
+            AreaTargetResult tooFar = AreaTargeting.Evaluate(actor, tiles, request, new AreaPlacement
+            {
+                Shape = AreaShape.Burst,
+                OriginCorner = new Vector2Int(5, 5)
+            });
+            Assert.IsNull(tooFar);
+
+            Object.DestroyImmediate(actor);
+        }
+
+        [Test]
+        public void AreaResultReportsOccupantsAlliesLineOfEffectAndCover()
+        {
+            Tile[,] tiles = BuildTiles(5, 3);
+            GameObject actor = CreateToken("actor", 0, 1);
+            GameObject ally = CreateToken("ally", 1, 1);
+            GameObject blocked = CreateToken("blocked", 4, 1);
+            tiles[1, 1].Occupants.Add(ally);
+            tiles[4, 1].Occupants.Add(blocked);
+            tiles[2, 1] = null;
+
+            AreaTargetRequest line = new()
+            {
+                Shape = AreaShape.Line,
+                SizeFeet = 20
+            };
+            AreaTargetResult result = AreaTargeting.Evaluate(actor, tiles, line, new AreaPlacement
+            {
+                Shape = AreaShape.Line,
+                Direction = AreaDirection.East
+            });
+
+            AreaAffectedCreature allyResult = result.Creatures.Single(creature => creature.Creature == ally);
+            AreaAffectedCreature blockedResult = result.Creatures.Single(creature => creature.Creature == blocked);
+            Assert.AreEqual(StrikeLineOfEffect.Clear, allyResult.LineOfEffect);
+            Assert.AreEqual(StrikeLineOfEffect.Blocked, blockedResult.LineOfEffect);
+            Assert.IsTrue(allyResult.IsAffected);
+            Assert.IsFalse(blockedResult.IsAffected);
+
+            tiles[2, 1] = new Tile();
+            tiles[1, 2] = null;
+            GameObject covered = CreateToken("covered", 2, 2);
+            tiles[2, 2].Occupants.Add(covered);
+            AreaTargetResult cone = AreaTargeting.Evaluate(actor, tiles, new AreaTargetRequest
+            {
+                Shape = AreaShape.Cone,
+                SizeFeet = 15
+            }, new AreaPlacement
+            {
+                Shape = AreaShape.Cone,
+                Direction = AreaDirection.NorthEast
+            });
+
+            AreaAffectedCreature coveredResult = cone.Creatures.Single(creature => creature.Creature == covered);
+            Assert.AreEqual(StrikeLineOfEffect.Clear, coveredResult.LineOfEffect);
+            Assert.AreEqual(StrikeCover.Standard, coveredResult.Cover);
+
+            Object.DestroyImmediate(actor);
+            Object.DestroyImmediate(ally);
+            Object.DestroyImmediate(blocked);
+            Object.DestroyImmediate(covered);
+        }
+
+        private static Tile[,] BuildTiles(int width, int height)
+        {
+            Tile[,] tiles = new Tile[width, height];
+            for (int x = 0; x < width; x++)
+            {
+                for (int z = 0; z < height; z++)
+                    tiles[x, z] = new Tile();
+            }
+            return tiles;
+        }
+
+        private static GameObject CreateToken(string name, int x, int z)
+        {
+            GameObject token = new(name);
+            token.transform.position = new Vector3(x, 0, z);
+            return token;
+        }
+
+        private static Vector3Int Cell(int x, int z)
+        {
+            return new Vector3Int(x, 0, z);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs.meta
+++ b/Assets/Tests/EditMode/Pf2eAreaTargetingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28746b643de9a094c9769863495f0f4b

--- a/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs
@@ -1,0 +1,151 @@
+using System.Collections;
+using System.Collections.Generic;
+using GridPrivate;
+using GridPublic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.TestTools;
+
+namespace TestsState
+{
+    public class AreaTargetingStateTests : PlayModeBase
+    {
+        [UnityTest]
+        public IEnumerator GridApiAreaTargetPreviewsAndConfirmsLinePlacement()
+        {
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+            FindClearHorizontalRun(tiles, 4, out Vector3Int start);
+            GameObject player = CreateToken("area target actor");
+            MoveCombatant(tiles, player, start);
+
+            CoroutineResult<AreaTargetResult> result = new();
+            List<Vector3Int> preview = null;
+            UnityAction<List<Vector3Int>> previewListener = cells => preview = new List<Vector3Int>(cells);
+            OnPreviewArea.AddListener(previewListener);
+
+            try
+            {
+                grid.StartCoroutine(GridAPI.GetInstance().GetAreaTarget(player, new AreaTargetRequest
+                {
+                    Shape = AreaShape.Line,
+                    SizeFeet = 10
+                }, result));
+
+                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateAreaTarget);
+                Assert.IsTrue(grid.Fsm.CurrentState is StateAreaTarget, "GridAPI should enter StateAreaTarget.");
+
+                Vector3Int hoverCell = start + new Vector3Int(1, 0, 0);
+                OnGridHover.Invoke(new GridHoverInfo
+                {
+                    Cell = hoverCell,
+                    WorldPosition = new Vector3(hoverCell.x, hoverCell.y, hoverCell.z),
+                    NearestCorner = new Vector2Int(hoverCell.x, hoverCell.z)
+                });
+                yield return null;
+
+                CollectionAssert.AreEqual(new[] { start + new Vector3Int(1, 0, 0), start + new Vector3Int(2, 0, 0) }, preview);
+
+                grid.Fsm.CurrentState.Leftclick();
+                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateIdle);
+
+                Assert.IsTrue(grid.Fsm.CurrentState is StateIdle);
+                Assert.IsNotNull(result.Value);
+                CollectionAssert.AreEqual(preview, result.Value.Cells);
+            }
+            finally
+            {
+                OnPreviewArea.RemoveListener(previewListener);
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator GridApiAreaTargetCancelReturnsIdleWithoutResult()
+        {
+            yield return base.Setup();
+
+            GridBase grid = Object.FindFirstObjectByType<GridBase>();
+            Assert.IsNotNull(grid);
+            Tile[,] tiles = grid.GetTiles();
+            FindClearHorizontalRun(tiles, 1, out Vector3Int start);
+            GameObject player = CreateToken("area target actor");
+            MoveCombatant(tiles, player, start);
+            CoroutineResult<AreaTargetResult> result = new();
+
+            try
+            {
+                grid.StartCoroutine(GridAPI.GetInstance().GetAreaTarget(player, new AreaTargetRequest
+                {
+                    Shape = AreaShape.Emanation,
+                    SizeFeet = 10,
+                    IncludeCenter = true
+                }, result));
+
+                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateAreaTarget);
+                Assert.IsTrue(grid.Fsm.CurrentState is StateAreaTarget);
+
+                grid.Fsm.CurrentState.Rightclick();
+                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateIdle);
+
+                Assert.IsTrue(grid.Fsm.CurrentState is StateIdle);
+                Assert.IsNull(result.Value);
+            }
+            finally
+            {
+                Object.DestroyImmediate(player);
+            }
+        }
+
+        private static void FindClearHorizontalRun(Tile[,] tiles, int length, out Vector3Int start)
+        {
+            for (int z = 0; z < tiles.GetLength(1); z++)
+            {
+                for (int x = 0; x <= tiles.GetLength(0) - length; x++)
+                {
+                    bool clear = true;
+                    for (int offset = 0; offset < length; offset++)
+                    {
+                        Tile tile = tiles[x + offset, z];
+                        if (tile == null || tile.Occupants.Count > 0)
+                        {
+                            clear = false;
+                            break;
+                        }
+                    }
+
+                    if (clear)
+                    {
+                        start = new Vector3Int(x, 0, z);
+                        return;
+                    }
+                }
+            }
+
+            Assert.Fail("Could not find a clear horizontal run in UnitTestingScene.");
+            start = Vector3Int.zero;
+        }
+
+        private static GameObject CreateToken(string name)
+        {
+            return new GameObject(name);
+        }
+
+        private static void MoveCombatant(Tile[,] tiles, GameObject combatant, Vector3Int cell)
+        {
+            for (int z = 0; z < tiles.GetLength(1); z++)
+            {
+                for (int x = 0; x < tiles.GetLength(0); x++)
+                    tiles[x, z]?.Occupants.Remove(combatant);
+            }
+
+            Assert.IsNotNull(tiles[cell.x, cell.z]);
+            combatant.transform.position = new Vector3(cell.x, cell.y, cell.z);
+            tiles[cell.x, cell.z].Occupants.Add(combatant);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs
@@ -65,7 +65,7 @@ namespace TestsState
         }
 
         [UnityTest]
-        public IEnumerator GridApiAreaTargetCancelReturnsIdleWithoutResult()
+        public IEnumerator GridApiAreaTargetSupportsSourceCellWithoutActorObject()
         {
             yield return base.Setup();
 
@@ -73,32 +73,23 @@ namespace TestsState
             Assert.IsNotNull(grid);
             Tile[,] tiles = grid.GetTiles();
             FindClearHorizontalRun(tiles, 1, out Vector3Int start);
-            GameObject player = CreateToken("area target actor");
-            MoveCombatant(tiles, player, start);
             CoroutineResult<AreaTargetResult> result = new();
 
-            try
+            grid.StartCoroutine(GridAPI.GetInstance().GetAreaTarget(new AreaTargetSource(start), new AreaTargetRequest
             {
-                grid.StartCoroutine(GridAPI.GetInstance().GetAreaTarget(player, new AreaTargetRequest
-                {
-                    Shape = AreaShape.Emanation,
-                    SizeFeet = 10,
-                    IncludeCenter = true
-                }, result));
+                Shape = AreaShape.Emanation,
+                SizeFeet = 10,
+                IncludeCenter = true
+            }, result));
 
-                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateAreaTarget);
-                Assert.IsTrue(grid.Fsm.CurrentState is StateAreaTarget);
+            yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateAreaTarget);
+            Assert.IsTrue(grid.Fsm.CurrentState is StateAreaTarget);
 
-                grid.Fsm.CurrentState.Rightclick();
-                yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateIdle);
+            grid.Fsm.CurrentState.Rightclick();
+            yield return WaitUntilWithTimeout(timeout, () => grid.Fsm.CurrentState is StateIdle);
 
-                Assert.IsTrue(grid.Fsm.CurrentState is StateIdle);
-                Assert.IsNull(result.Value);
-            }
-            finally
-            {
-                Object.DestroyImmediate(player);
-            }
+            Assert.IsTrue(grid.Fsm.CurrentState is StateIdle);
+            Assert.IsNull(result.Value);
         }
 
         private static void FindClearHorizontalRun(Tile[,] tiles, int length, out Vector3Int start)

--- a/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs.meta
+++ b/Assets/Tests/PlayMode/TestsState/AreaTargetingStateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e419a5a8f0b7dc548a7c734cd22507e7


### PR DESCRIPTION
## Summary

- Adds reusable grid area targeting data types and evaluation for bursts, cones, emanations, and lines.
- Adds `GridAPI.GetAreaTarget(...)` and a `StateAreaTarget` FSM path for player preview, confirm, and cancel behavior.
- Supports both creature-backed area sources and raw grid-cell sources for future traps/environmental effects.
- Adds hover metadata and area preview events using the existing grid visual range indicator path.
- Extracts shared grid targeting helpers so strike and future area mechanics use the same diagonal distance and line-of-effect ray sampling.

## Scope Notes

This intentionally implements only the area targeting/grid mechanics from issue #77. It does not add Fireball, Breathe Fire, damage, saves, DC resolution, or AI area action selection. The result model exposes affected creatures plus line-of-effect/cover metadata so future spell/action resolution can consume the selected area without redoing grid geometry.

## Tests

- `Unity.exe -batchmode -runTests -projectPath . -testPlatform editmode -testResults TestResults/EditModeResults.xml -logFile TestResults/EditMode.log`
  - 56 passed, 0 failed
- `Unity.exe -batchmode -runTests -projectPath . -testPlatform playmode -testResults TestResults/PlayModeResults.xml -logFile TestResults/PlayMode.log`
  - 42 passed, 0 failed