### PR TITLE
Refactor Strike resolution into pipeline

### DIFF
--- a/Assets/Scripts/Combat/AIActionController.cs
+++ b/Assets/Scripts/Combat/AIActionController.cs
@@ -92,14 +92,14 @@ public abstract class AIActionController : ActionController
             if (action is Unarmed)
             {
                 Unarmed unarmedAction = action as Unarmed;
-                damage = unarmedAction.GetStrike().GetAvgDmg();
+                damage = unarmedAction.GetStrikeProfile().GetAverageDamage();
             }
             else if (action is StrikeWeapon)
             {
                 StrikeWeapon strikeWeaponAction = action as StrikeWeapon;
                 if (!strikeWeaponAction.IsUsableBy(gameObject))
                     continue;
-                damage = strikeWeaponAction.GetStrike().GetAvgDmg();
+                damage = strikeWeaponAction.GetStrikeProfile().GetAverageDamage();
             }
             if (damage > bestDamage)
             {

--- a/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
@@ -1,240 +1,293 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Game.Combat.Rules;
 using Game.Creature;
-using GridPublic;
+using Game.Creature.Rules;
+using Game.Rules;
 
 /// <summary>
-/// Describes the non-statistical source of an attack, such as its weapon name, group, category, and traits.
-/// This keeps attack result effects independent from equipment-only data so later natural or spell attacks can provide the same metadata.
+/// Resolves Strikes through deterministic phases. The invoking action owns target selection, resource checks, action cost, and MAP increment.
 /// </summary>
-public class AttackSourceInfo
+public static class StrikeResolutionPipeline
 {
-    public static readonly AttackSourceInfo Unspecified = new AttackSourceInfo(string.Empty, string.Empty, string.Empty);
-
-    public string Name { get; }
-    public string Group { get; }
-    public string Category { get; }
-    public IReadOnlyList<string> Traits { get; }
-    public EquipmentWeapon EquipmentWeapon { get; }
-
-    public AttackSourceInfo(string name, string group, string category, IEnumerable<string> traits = null, EquipmentWeapon equipmentWeapon = null)
+    public static StrikeResolutionResult Resolve(StrikeResolutionRequest request)
     {
-        Name = name ?? string.Empty;
-        Group = group ?? string.Empty;
-        Category = category ?? string.Empty;
-        Traits = traits == null ? new List<string>() : new List<string>(traits);
-        EquipmentWeapon = equipmentWeapon;
-    }
-
-    public AttackSourceInfo(AttackSourceInfo sourceInfo)
-        : this(sourceInfo?.Name, sourceInfo?.Group, sourceInfo?.Category, sourceInfo?.Traits, sourceInfo?.EquipmentWeapon)
-    {
-    }
-
-    public static AttackSourceInfo FromWeapon(EquipmentWeapon weapon)
-    {
-        if (weapon == null)
-            return Unspecified;
-
-        return new AttackSourceInfo(weapon.name, weapon.group, weapon.category, weapon.traits, weapon);
-    }
-}
-
-/// <summary>
-/// Ordered extension points for attack-result effects. The order separates dice changes before rolling, critical-only dice after doubling, defense adjustments, and reactions after damage is applied.
-/// </summary>
-public enum AttackResultEffectPhase
-{
-    BeforeDamageRoll = 0,
-    AfterCriticalDoubling = 1,
-    BeforeDefenseAdjustments = 2,
-    AfterDamageApplied = 3
-}
-
-/// <summary>
-/// Pure C# rule hook that can inspect and mutate an attack result context at a single deterministic phase.
-/// </summary>
-public interface IAttackResultEffect
-{
-    AttackResultEffectPhase Phase { get; }
-    void Apply(AttackResultContext context);
-}
-
-/// <summary>
-/// Optional Unity component contract for attacker- or defender-owned rule hooks without adding global registries or Strike-specific dependencies.
-/// </summary>
-public interface IAttackResultEffectProvider
-{
-    IEnumerable<IAttackResultEffect> GetAttackResultEffects(AttackResultContext context);
-}
-
-/// <summary>
-/// Mutable state for a resolved hit as it moves through the attack-result pipeline.
-/// GameObjects identify Unity owners for component/provider lookup; CreatureComponents cache gameplay stats and mutable creature state.
-/// </summary>
-public class AttackResultContext
-{
-    private List<string> explicitTraits = new();
-    private List<string> traits = new();
-    private AttackSourceInfo sourceInfo = AttackSourceInfo.Unspecified;
-
-    public GameObject AttackerObject { get; set; }
-    public GameObject TargetObject { get; set; }
-    public CreatureComponent AttackerCreature { get; set; }
-    public CreatureComponent TargetCreature { get; set; }
-    public Strike Strike { get; set; }
-    public AttackSourceInfo SourceInfo
-    {
-        get => sourceInfo;
-        set
-        {
-            sourceInfo = value ?? AttackSourceInfo.Unspecified;
-            RefreshTraits();
-        }
-    }
-    public List<string> Traits
-    {
-        get => traits;
-        set
-        {
-            explicitTraits = value == null ? new List<string>() : new List<string>(value);
-            RefreshTraits();
-        }
-    }
-    public D20Result D20Result { get; set; }
-    public DegreeOfSuccess Degree { get; set; }
-    public List<Dice> DamageDice { get; set; } = new();
-    public List<DamageValue> FlatDamages { get; set; } = new();
-    public List<DamageValue> DamageValues { get; set; } = new();
-    public StrikeTargetResult TargetingResult { get; set; }
-    public int BaseArmorClass { get; set; }
-    public int TargetArmorClass { get; set; }
-    public int AttackBonus { get; set; }
-    public int TotalAttackModifier { get; set; }
-    public int MultipleAttackPenalty { get; set; }
-    public int RangePenalty { get; set; }
-    public int CoverAcBonus { get; set; }
-    public uint FinalAppliedDamage { get; set; }
-
-    private void RefreshTraits()
-    {
-        List<string> merged = explicitTraits == null ? new List<string>() : new List<string>(explicitTraits);
-        if (sourceInfo?.Traits != null)
-        {
-            foreach (string trait in sourceInfo.Traits)
-            {
-                if (!ContainsTrait(merged, trait))
-                    merged.Add(trait);
-            }
-        }
-        traits = merged;
-    }
-
-    private static bool ContainsTrait(List<string> traits, string candidate)
-    {
-        foreach (string trait in traits)
-        {
-            if (string.Equals(trait, candidate, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        return false;
-    }
-}
-
-/// <summary>
-/// Applies built-in attack traits and discovered effect providers in deterministic phase order for a resolved hit.
-/// It currently serves Strikes but is separate from Strike so future spell or ability attacks can reuse the same result flow.
-/// </summary>
-public static class AttackResultPipeline
-{
-    public static void ProcessHit(AttackResultContext context)
-    {
-        if (context == null)
-            throw new ArgumentNullException(nameof(context));
+        StrikeResolutionContext context = StrikeResolutionContext.FromRequest(request);
+        if (context.AttackerCreature == null)
+            throw new ArgumentException("Strike resolution requires an attacker CreatureComponent.", nameof(request));
         if (context.TargetCreature == null)
-            throw new ArgumentException("Attack result context must include a target creature.", nameof(context));
+            throw new ArgumentException("Strike resolution requires a target CreatureComponent.", nameof(request));
 
-        context.DamageDice ??= new List<Dice>();
-        context.FlatDamages ??= new List<DamageValue>();
-        context.DamageValues = new List<DamageValue>();
+        List<IStrikeAdjustment> adjustments = BuildAdjustments(context);
 
-        List<IAttackResultEffect> effects = BuildEffects(context);
-        ApplyPhase(effects, AttackResultEffectPhase.BeforeDamageRoll, context);
+        ApplyPhase(adjustments, StrikeAdjustmentPhase.PrepareProfile, context);
+        OnStrikePreparedEvent.Invoke(context);
 
-        if (context.DamageDice.Count > 0)
-            OnDamageDealt.Invoke(context.DamageDice[0].damageType);
+        ApplyPhase(adjustments, StrikeAdjustmentPhase.BeforeAttackRoll, context);
+        ApplyPhase(adjustments, StrikeAdjustmentPhase.BeforeArmorClassResolution, context);
+        ApplyPhase(adjustments, StrikeAdjustmentPhase.ResolveAttackRoll, context);
+        ApplyPhase(adjustments, StrikeAdjustmentPhase.AfterAttackRoll, context);
 
-        context.DamageValues = DamageRoller.RollDamage(context.DamageDice, context.FlatDamages);
-        DamageRoller.EvaluateCriticalDamage(context.Degree, context.DamageValues);
-        ApplyPhase(effects, AttackResultEffectPhase.AfterCriticalDoubling, context);
-        ApplyPhase(effects, AttackResultEffectPhase.BeforeDefenseAdjustments, context);
-        DamageRoller.ApplyWeaknessAndResistance(context.DamageValues, context.TargetCreature.weaknesses, context.TargetCreature.resistances);
-        int totalDamage = DamageRoller.SumDamage(context.DamageValues);
-        context.FinalAppliedDamage = (uint)Mathf.Max(0, totalDamage);
-        context.TargetCreature.TakeDamage(context.FinalAppliedDamage);
-        ApplyPhase(effects, AttackResultEffectPhase.AfterDamageApplied, context);
+        if (context.IsHit)
+        {
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.BeforeDamageRoll, context);
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.RollDamage, context);
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.AfterCriticalDoubling, context);
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.BeforeDefenseAdjustments, context);
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.ApplyDefenseAndDamage, context);
+            ApplyPhase(adjustments, StrikeAdjustmentPhase.AfterDamageApplied, context);
+        }
+
+        return new StrikeResolutionResult(context);
     }
 
-    private static List<IAttackResultEffect> BuildEffects(AttackResultContext context)
+    private static List<IStrikeAdjustment> BuildAdjustments(StrikeResolutionContext context)
     {
-        List<IAttackResultEffect> effects = new();
-        effects.AddRange(AttackTraitEffectResolver.Resolve(context));
-        AddProviderEffects(effects, context.AttackerObject, context);
-        AddProviderEffects(effects, context.TargetObject, context);
-        return effects;
+        List<IStrikeAdjustment> adjustments = new()
+        {
+            new PreparedCharacterStrikeAdjustment(),
+            new MultipleAttackAndRangePenaltyAdjustment(),
+            new ArmorClassContextAdjustment(),
+            new ResolveAttackRollAdjustment(),
+            new AttackOutcomeLogAdjustment(),
+            new RollDamageAdjustment(),
+            new CriticalDoublingAdjustment(),
+            new ApplyDefenseAndDamageAdjustment()
+        };
+
+        adjustments.AddRange(AttackTraitStrikeAdjustmentResolver.Resolve(context));
+        AddProviderAdjustments(adjustments, context.AttackerObject, context);
+        AddProviderAdjustments(adjustments, context.TargetObject, context);
+        return adjustments
+            .OrderBy(adjustment => adjustment.Phase)
+            .ThenBy(adjustment => adjustment.Order)
+            .ThenBy(adjustment => adjustment.Source, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
-    private static void AddProviderEffects(List<IAttackResultEffect> effects, GameObject owner, AttackResultContext context)
+    private static void AddProviderAdjustments(List<IStrikeAdjustment> adjustments, GameObject owner, StrikeResolutionContext context)
     {
         if (owner == null)
             return;
 
         foreach (MonoBehaviour component in owner.GetComponents<MonoBehaviour>())
         {
-            if (component is not IAttackResultEffectProvider provider)
+            if (component is not IStrikeAdjustmentProvider provider)
                 continue;
 
-            IEnumerable<IAttackResultEffect> provided = provider.GetAttackResultEffects(context);
+            IEnumerable<IStrikeAdjustment> provided = provider.GetStrikeAdjustments(context);
             if (provided == null)
                 continue;
 
-            foreach (IAttackResultEffect effect in provided)
+            foreach (IStrikeAdjustment adjustment in provided)
             {
-                if (effect != null)
-                    effects.Add(effect);
+                if (adjustment != null)
+                    adjustments.Add(adjustment);
             }
         }
     }
 
-    private static void ApplyPhase(List<IAttackResultEffect> effects, AttackResultEffectPhase phase, AttackResultContext context)
+    private static void ApplyPhase(List<IStrikeAdjustment> adjustments, StrikeAdjustmentPhase phase, StrikeResolutionContext context)
     {
-        foreach (IAttackResultEffect effect in effects)
+        foreach (IStrikeAdjustment adjustment in adjustments)
+            if (adjustment.Phase == phase)
+                adjustment.Apply(context);
+    }
+}
+
+public abstract class StrikeAdjustmentBase : IStrikeAdjustment
+{
+    protected StrikeAdjustmentBase(StrikeAdjustmentPhase phase, int order, string source)
+    {
+        Phase = phase;
+        Order = order;
+        Source = string.IsNullOrWhiteSpace(source) ? "Unknown" : source;
+    }
+
+    public StrikeAdjustmentPhase Phase { get; }
+    public int Order { get; }
+    public string Source { get; }
+    public abstract void Apply(StrikeResolutionContext context);
+}
+
+internal sealed class PreparedCharacterStrikeAdjustment : StrikeAdjustmentBase
+{
+    public PreparedCharacterStrikeAdjustment() : base(StrikeAdjustmentPhase.PrepareProfile, 0, "Prepared character rules") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        Pf2eRulesEngine.ApplyPreparedStrikeAdjustments(context);
+    }
+}
+
+internal sealed class MultipleAttackAndRangePenaltyAdjustment : StrikeAdjustmentBase
+{
+    public MultipleAttackAndRangePenaltyAdjustment() : base(StrikeAdjustmentPhase.BeforeAttackRoll, 0, "Strike penalties") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        uint strikePenaltyCount = context.AttackerObject.GetComponent<ActionController>()?.StrikePenalty ?? 0;
+        context.MultipleAttackPenalty = CalculateMultipleAttackPenalty(context, strikePenaltyCount);
+        context.RangePenalty = context.TargetingResult?.RangePenalty ?? 0;
+
+        if (context.MultipleAttackPenalty != 0)
+            context.AttackModifiers.Add(new Pf2eModifier(-context.MultipleAttackPenalty, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll));
+        if (context.RangePenalty != 0)
+            context.AttackModifiers.Add(new Pf2eModifier(context.RangePenalty, Pf2eModifierType.Untyped, "Range penalty", Pf2eStatistic.AttackRoll));
+    }
+
+    private static int CalculateMultipleAttackPenalty(StrikeResolutionContext context, uint strikePenaltyCount)
+    {
+        if (strikePenaltyCount == 0)
+            return 0;
+
+        bool agile = context.Traits.Any(trait => string.Equals(trait, "agile", StringComparison.OrdinalIgnoreCase));
+        if (strikePenaltyCount == 1)
+            return agile ? 4 : 5;
+        return agile ? 8 : 10;
+    }
+}
+
+internal sealed class ArmorClassContextAdjustment : StrikeAdjustmentBase
+{
+    public ArmorClassContextAdjustment() : base(StrikeAdjustmentPhase.BeforeArmorClassResolution, 0, "Strike target defenses") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        context.CoverAcBonus = context.TargetingResult?.CoverAcBonus ?? 0;
+        context.FlankedOffGuard = FlankingRule.GrantsOffGuardToMeleeAttack(context.AttackerObject, context.TargetObject, context.Profile);
+
+        if (context.CoverAcBonus != 0)
+            context.ArmorClassModifiers.Add(new Pf2eModifier(context.CoverAcBonus, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass));
+        if (context.FlankedOffGuard)
+            context.ArmorClassModifiers.Add(new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass));
+    }
+}
+
+internal sealed class ResolveAttackRollAdjustment : StrikeAdjustmentBase
+{
+    public ResolveAttackRollAdjustment() : base(StrikeAdjustmentPhase.ResolveAttackRoll, 0, "Attack roll") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        context.AttackBonus = context.Profile.AttackModifierOverride ?? context.AttackerCreature.attackBonus;
+        context.AttackResolution = context.AttackerCreature.ResolveAttackRoll(context.Profile.AttackModifierOverride, context.AttackModifiers);
+        context.BaseArmorClassResolution = context.TargetCreature.ResolveArmorClass();
+        context.TargetArmorClassResolution = context.TargetCreature.ResolveArmorClass(context.ArmorClassModifiers);
+        context.BaseArmorClass = context.BaseArmorClassResolution.Total;
+        context.TargetArmorClass = context.TargetArmorClassResolution.Total;
+        context.TotalAttackModifier = context.AttackResolution.Total;
+        context.D20Result = D20.Roll(context.TotalAttackModifier, context.TargetArmorClass);
+        context.Degree = context.D20Result.degree;
+        context.IsHit = context.Degree == DegreeOfSuccess.Success || context.Degree == DegreeOfSuccess.CriticalSuccess;
+    }
+}
+
+internal sealed class AttackOutcomeLogAdjustment : StrikeAdjustmentBase
+{
+    public AttackOutcomeLogAdjustment() : base(StrikeAdjustmentPhase.AfterAttackRoll, 0, "Attack outcome log") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        string log = "Attack:\n  AC: " + context.TargetArmorClass;
+        if (context.CoverAcBonus != 0)
+            log += " (" + context.BaseArmorClass + " + " + context.CoverAcBonus + " cover)";
+        log += "\n  Attack Roll: " + context.D20Result.total
+            + " (" + context.D20Result.roll + " + " + context.AttackBonus + " - " + context.MultipleAttackPenalty;
+        if (context.RangePenalty != 0)
+            log += " " + context.RangePenalty;
+        log += ")\n  Result: " + context.Degree;
+        log += "\n  Attack Modifiers: " + FormatResolution(context.AttackResolution);
+        log += "\n  AC Modifiers: " + FormatResolution(context.TargetArmorClassResolution);
+
+        if (context.IsHit)
         {
-            if (effect.Phase == phase)
-                effect.Apply(context);
+            CombatLog.GetInstance().Log(log);
         }
+        else
+        {
+            OnAttackMiss.Invoke(context.AttackerObject);
+            log += "\nAttack Missed!";
+            CombatLog.GetInstance().Log(log);
+        }
+    }
+
+    private static string FormatResolution(Pf2eModifierResolution resolution)
+    {
+        return "total " + resolution.Total + "; applied [" + FormatModifiers(resolution.AppliedModifiers) + "]; suppressed [" + FormatModifiers(resolution.SuppressedModifiers) + "]";
+    }
+
+    private static string FormatModifiers(IReadOnlyList<Pf2eModifier> modifiers)
+    {
+        if (modifiers == null || modifiers.Count == 0)
+            return "none";
+
+        List<string> parts = new();
+        foreach (Pf2eModifier modifier in modifiers)
+            parts.Add(modifier.Source + " " + FormatSigned(modifier.Value) + " " + modifier.Type);
+        return string.Join(", ", parts);
+    }
+
+    private static string FormatSigned(int value)
+    {
+        return value >= 0 ? "+" + value : value.ToString();
+    }
+}
+
+internal sealed class RollDamageAdjustment : StrikeAdjustmentBase
+{
+    public RollDamageAdjustment() : base(StrikeAdjustmentPhase.RollDamage, 0, "Damage roll") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        if (context.DamageDice.Count > 0)
+            OnDamageDealt.Invoke(context.DamageDice[0].damageType);
+
+        context.DamageValues = DamageRoller.RollDamage(context.DamageDice, context.FlatDamages);
+    }
+}
+
+internal sealed class CriticalDoublingAdjustment : StrikeAdjustmentBase
+{
+    public CriticalDoublingAdjustment() : base(StrikeAdjustmentPhase.AfterCriticalDoubling, 0, "Critical damage") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        DamageRoller.EvaluateCriticalDamage(context.Degree, context.DamageValues);
+    }
+}
+
+internal sealed class ApplyDefenseAndDamageAdjustment : StrikeAdjustmentBase
+{
+    public ApplyDefenseAndDamageAdjustment() : base(StrikeAdjustmentPhase.ApplyDefenseAndDamage, 0, "Defense and damage") { }
+
+    public override void Apply(StrikeResolutionContext context)
+    {
+        DamageRoller.ApplyWeaknessAndResistance(context.DamageValues, context.TargetCreature.weaknesses, context.TargetCreature.resistances);
+        int totalDamage = DamageRoller.SumDamage(context.DamageValues);
+        context.FinalAppliedDamage = (uint)Mathf.Max(0, totalDamage);
+        context.TargetCreature.TakeDamage(context.FinalAppliedDamage);
     }
 }
 
 /// <summary>
 /// Testable critical-specialization adapter that runs caller-supplied behavior only for matching weapon groups on critical hits.
-/// Full PF2e group effects can plug in here later without hardcoding group rules in Strike.
 /// </summary>
-public sealed class CriticalSpecializationAttackResultEffect : IAttackResultEffect
+public sealed class CriticalSpecializationStrikeAdjustment : StrikeAdjustmentBase
 {
     private readonly string group;
-    private readonly Action<AttackResultContext> apply;
+    private readonly Action<StrikeResolutionContext> apply;
 
-    public CriticalSpecializationAttackResultEffect(string group, Action<AttackResultContext> apply)
+    public CriticalSpecializationStrikeAdjustment(string group, Action<StrikeResolutionContext> apply)
+        : base(StrikeAdjustmentPhase.AfterDamageApplied, 0, "Critical specialization")
     {
         this.group = group ?? string.Empty;
         this.apply = apply;
     }
 
-    public AttackResultEffectPhase Phase => AttackResultEffectPhase.AfterDamageApplied;
-
-    public void Apply(AttackResultContext context)
+    public override void Apply(StrikeResolutionContext context)
     {
         if (context == null || context.Degree != DegreeOfSuccess.CriticalSuccess || apply == null)
             return;
@@ -245,9 +298,9 @@ public sealed class CriticalSpecializationAttackResultEffect : IAttackResultEffe
     }
 }
 
-internal static class AttackTraitEffectResolver
+internal static class AttackTraitStrikeAdjustmentResolver
 {
-    public static IEnumerable<IAttackResultEffect> Resolve(AttackResultContext context)
+    public static IEnumerable<IStrikeAdjustment> Resolve(StrikeResolutionContext context)
     {
         if (context?.Traits == null)
             yield break;
@@ -255,11 +308,11 @@ internal static class AttackTraitEffectResolver
         foreach (string trait in context.Traits)
         {
             if (TryParseTraitDie(trait, "deadly-d", out int deadlySides))
-                yield return new DeadlyAttackResultEffect(trait, deadlySides);
+                yield return new DeadlyStrikeAdjustment(trait, deadlySides);
             else if (TryParseTraitDie(trait, "fatal-d", out int fatalSides))
             {
-                yield return new FatalDamageDieUpgradeEffect(trait, fatalSides);
-                yield return new FatalExtraDieEffect(trait, fatalSides);
+                yield return new FatalDamageDieUpgradeStrikeAdjustment(trait, fatalSides);
+                yield return new FatalExtraDieStrikeAdjustment(trait, fatalSides);
             }
         }
     }
@@ -274,20 +327,19 @@ internal static class AttackTraitEffectResolver
     }
 }
 
-internal sealed class DeadlyAttackResultEffect : IAttackResultEffect
+internal sealed class DeadlyStrikeAdjustment : StrikeAdjustmentBase
 {
     private readonly string trait;
     private readonly int sides;
 
-    public DeadlyAttackResultEffect(string trait, int sides)
+    public DeadlyStrikeAdjustment(string trait, int sides)
+        : base(StrikeAdjustmentPhase.AfterCriticalDoubling, 100, trait)
     {
         this.trait = trait;
         this.sides = sides;
     }
 
-    public AttackResultEffectPhase Phase => AttackResultEffectPhase.AfterCriticalDoubling;
-
-    public void Apply(AttackResultContext context)
+    public override void Apply(StrikeResolutionContext context)
     {
         if (context.Degree != DegreeOfSuccess.CriticalSuccess || context.DamageDice == null || context.DamageDice.Count == 0)
             return;
@@ -295,7 +347,7 @@ internal sealed class DeadlyAttackResultEffect : IAttackResultEffect
         AddCriticalTraitDamage(context, trait, sides);
     }
 
-    internal static void AddCriticalTraitDamage(AttackResultContext context, string trait, int sides)
+    internal static void AddCriticalTraitDamage(StrikeResolutionContext context, string trait, int sides)
     {
         string damageType = context.DamageDice[0].damageType;
         DamageValue extraDamage = new DamageValue(damageType, UnityEngine.Random.Range(1, sides + 1));
@@ -304,20 +356,19 @@ internal sealed class DeadlyAttackResultEffect : IAttackResultEffect
     }
 }
 
-internal sealed class FatalDamageDieUpgradeEffect : IAttackResultEffect
+internal sealed class FatalDamageDieUpgradeStrikeAdjustment : StrikeAdjustmentBase
 {
     private readonly string trait;
     private readonly int sides;
 
-    public FatalDamageDieUpgradeEffect(string trait, int sides)
+    public FatalDamageDieUpgradeStrikeAdjustment(string trait, int sides)
+        : base(StrikeAdjustmentPhase.BeforeDamageRoll, 0, trait)
     {
         this.trait = trait;
         this.sides = sides;
     }
 
-    public AttackResultEffectPhase Phase => AttackResultEffectPhase.BeforeDamageRoll;
-
-    public void Apply(AttackResultContext context)
+    public override void Apply(StrikeResolutionContext context)
     {
         if (context.Degree != DegreeOfSuccess.CriticalSuccess || context.DamageDice == null || context.DamageDice.Count == 0)
             return;
@@ -331,24 +382,23 @@ internal sealed class FatalDamageDieUpgradeEffect : IAttackResultEffect
     }
 }
 
-internal sealed class FatalExtraDieEffect : IAttackResultEffect
+internal sealed class FatalExtraDieStrikeAdjustment : StrikeAdjustmentBase
 {
     private readonly string trait;
     private readonly int sides;
 
-    public FatalExtraDieEffect(string trait, int sides)
+    public FatalExtraDieStrikeAdjustment(string trait, int sides)
+        : base(StrikeAdjustmentPhase.AfterCriticalDoubling, 100, trait)
     {
         this.trait = trait;
         this.sides = sides;
     }
 
-    public AttackResultEffectPhase Phase => AttackResultEffectPhase.AfterCriticalDoubling;
-
-    public void Apply(AttackResultContext context)
+    public override void Apply(StrikeResolutionContext context)
     {
         if (context.Degree != DegreeOfSuccess.CriticalSuccess || context.DamageDice == null || context.DamageDice.Count == 0)
             return;
 
-        DeadlyAttackResultEffect.AddCriticalTraitDamage(context, trait, sides);
+        DeadlyStrikeAdjustment.AddCriticalTraitDamage(context, trait, sides);
     }
 }

--- a/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/AttackResultPipeline.cs
@@ -59,13 +59,23 @@ public static class StrikeResolutionPipeline
         };
 
         adjustments.AddRange(AttackTraitStrikeAdjustmentResolver.Resolve(context));
-        AddProviderAdjustments(adjustments, context.AttackerObject, context);
-        AddProviderAdjustments(adjustments, context.TargetObject, context);
+        AddAttackerProviderAdjustments(adjustments, context);
+        AddTargetProviderAdjustments(adjustments, context);
         return adjustments
             .OrderBy(adjustment => adjustment.Phase)
             .ThenBy(adjustment => adjustment.Order)
             .ThenBy(adjustment => adjustment.Source, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static void AddAttackerProviderAdjustments(List<IStrikeAdjustment> adjustments, StrikeResolutionContext context)
+    {
+        AddProviderAdjustments(adjustments, context.AttackerObject, context);
+    }
+
+    private static void AddTargetProviderAdjustments(List<IStrikeAdjustment> adjustments, StrikeResolutionContext context)
+    {
+        AddProviderAdjustments(adjustments, context.TargetObject, context);
     }
 
     private static void AddProviderAdjustments(List<IStrikeAdjustment> adjustments, GameObject owner, StrikeResolutionContext context)
@@ -78,6 +88,7 @@ public static class StrikeResolutionPipeline
             if (component is not IStrikeAdjustmentProvider provider)
                 continue;
 
+            // Providers are discovered from a specific owner, then use the full context to decide whether they apply as attacker, target, weapon, feat, condition, or another rule source.
             IEnumerable<IStrikeAdjustment> provided = provider.GetStrikeAdjustments(context);
             if (provided == null)
                 continue;
@@ -473,3 +484,4 @@ internal sealed class FatalExtraDieStrikeAdjustment : StrikeAdjustmentBase
         DeadlyStrikeAdjustment.AddCriticalTraitDamage(context, trait, sides);
     }
 }
+

--- a/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Strike.cs
@@ -1,18 +1,58 @@
 using UnityEngine;
+using System;
 using System.Collections.Generic;
 using Game.Creature;
-using Game.Creature.Rules;
-using Game.Combat.Rules;
 using Game.Rules;
-using System;
 using GridPublic;
 
-public class Strike
+/// <summary>
+/// Describes the non-statistical source of an attack, such as its weapon name, group, category, and traits.
+/// This keeps strike resolution independent from equipment-only data so natural, spell, and item attacks can share provenance.
+/// </summary>
+public class AttackSourceInfo
 {
-    public List<Dice> Damages;
-    public List<DamageValue> FlatDamages;
-    public List<string> Traits = new List<string>();
+    public static readonly AttackSourceInfo Unspecified = new AttackSourceInfo(string.Empty, string.Empty, string.Empty);
+
+    public string Name { get; }
+    public string Group { get; }
+    public string Category { get; }
+    public IReadOnlyList<string> Traits { get; }
+    public EquipmentWeapon EquipmentWeapon { get; }
+
+    public AttackSourceInfo(string name, string group, string category, IEnumerable<string> traits = null, EquipmentWeapon equipmentWeapon = null)
+    {
+        Name = name ?? string.Empty;
+        Group = group ?? string.Empty;
+        Category = category ?? string.Empty;
+        Traits = traits == null ? new List<string>() : new List<string>(traits);
+        EquipmentWeapon = equipmentWeapon;
+    }
+
+    public AttackSourceInfo(AttackSourceInfo sourceInfo)
+        : this(sourceInfo?.Name, sourceInfo?.Group, sourceInfo?.Category, sourceInfo?.Traits, sourceInfo?.EquipmentWeapon)
+    {
+    }
+
+    public static AttackSourceInfo FromWeapon(EquipmentWeapon weapon)
+    {
+        if (weapon == null)
+            return Unspecified;
+
+        return new AttackSourceInfo(weapon.name, weapon.group, weapon.category, weapon.traits, weapon);
+    }
+}
+
+/// <summary>
+/// Reusable Strike data supplied by a weapon, unarmed attack, or later Strike-like source.
+/// Runtime resolution clones this profile so per-Strike adjustments never mutate action-owned data.
+/// </summary>
+public class StrikeProfile
+{
     private AttackSourceInfo sourceInfo = AttackSourceInfo.Unspecified;
+
+    public List<Dice> DamageDice { get; set; }
+    public List<DamageValue> FlatDamages { get; set; }
+    public List<string> Traits { get; set; } = new();
     public AttackSourceInfo SourceInfo
     {
         get => sourceInfo;
@@ -23,115 +63,51 @@ public class Strike
     public string WeaponCategory { get; set; }
     public bool IsRangedAttack { get; set; }
     public int ReachFeet { get; set; } = 5;
-    public GameObject From = null;
-    public GameObject To = null;
-    private StrikeTargetResult TargetingResult = null;
 
-    public Strike(List<Dice> damages, List<DamageValue> flatDamages)
+    public StrikeProfile(List<Dice> damageDice, List<DamageValue> flatDamages)
     {
-        Damages = damages ?? new();
-        FlatDamages = flatDamages ?? new();
+        DamageDice = CloneDice(damageDice);
+        FlatDamages = flatDamages == null ? new List<DamageValue>() : new List<DamageValue>(flatDamages);
     }
 
-    public Strike(Strike strike)
+    public StrikeProfile(StrikeProfile profile)
     {
-        this.Damages = new List<Dice>();
-        foreach (Dice dice in strike.Damages)
-            this.Damages.Add(new Dice(dice.numberOfDice, dice.sidesPerDie, dice.damageType));
-        this.FlatDamages = new List<DamageValue>(strike.FlatDamages);
-        this.Traits = new List<string>(strike.Traits);
-        this.SourceInfo = new AttackSourceInfo(strike.SourceInfo);
-        this.AttackModifierOverride = strike.AttackModifierOverride;
-        this.ItemSlug = strike.ItemSlug;
-        this.WeaponCategory = strike.WeaponCategory;
-        this.IsRangedAttack = strike.IsRangedAttack;
-        this.ReachFeet = strike.ReachFeet;
-    }
-
-    public void Damage(GameObject from_go, GameObject to_go)
-    {
-        Damage(from_go, to_go, null);
-    }
-
-    public void Damage(GameObject from_go, GameObject to_go, StrikeTargetResult targetingResult)
-    {
-        Strike evaluated = new Strike(this);
-        evaluated.From = from_go;
-        evaluated.To = to_go;
-        evaluated.TargetingResult = targetingResult;
-
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(from_go.GetComponent<CreatureComponent>(), evaluated, to_go.GetComponent<CreatureComponent>());
-        OnStrikeEvent.Invoke(new(evaluated, from_go));
-        evaluated.DamageEvaluate();
-    }
-
-    protected void DamageEvaluate()
-    {
-        CreatureComponent from = From.GetComponent<CreatureComponent>();
-        CreatureComponent to = To.GetComponent<CreatureComponent>();
-        uint strikePenaltyCount = From.GetComponent<ActionController>()?.StrikePenalty ?? 0;
-        int mapPenalty = CalculateMultipleAttackPenalty(strikePenaltyCount);
-        int rangePenalty = TargetingResult?.RangePenalty ?? 0;
-        int coverBonus = TargetingResult?.CoverAcBonus ?? 0;
-        bool flankedOffGuard = FlankingRule.GrantsOffGuardToMeleeAttack(From, To, this);
-
-        int attackBonus = AttackModifierOverride ?? from.attackBonus;
-        Pf2eModifierResolution attackResolution = from.ResolveAttackRoll(AttackModifierOverride, BuildStrikeAttackModifiers(mapPenalty, rangePenalty));
-        Pf2eModifierResolution baseAcResolution = to.ResolveArmorClass();
-        Pf2eModifierResolution targetAcResolution = to.ResolveArmorClass(BuildStrikeAcModifiers(coverBonus, flankedOffGuard));
-        int targetAc = targetAcResolution.Total;
-        int totalModifier = attackResolution.Total;
-
-        D20Result attackRoll = D20.Roll(totalModifier, targetAc);
-
-        string log = "Attack:\n  AC: " + targetAc;
-        if (coverBonus != 0)
-            log += " (" + baseAcResolution.Total + " + " + coverBonus + " cover)";
-        log += "\n  Attack Roll: " + attackRoll.total
-            + " (" + attackRoll.roll + " + " + attackBonus + " - " + mapPenalty;
-        if (rangePenalty != 0)
-            log += " " + rangePenalty;
-        log += ")\n  Result: " + attackRoll.degree;
-        log += "\n  Attack Modifiers: " + FormatResolution(attackResolution);
-        log += "\n  AC Modifiers: " + FormatResolution(targetAcResolution);
-
-        if (attackRoll.degree == DegreeOfSuccess.Success || attackRoll.degree == DegreeOfSuccess.CriticalSuccess)
+        if (profile == null)
         {
-            CombatLog.GetInstance().Log(log);
-            AttackResultContext context = new AttackResultContext
-            {
-                AttackerObject = From,
-                TargetObject = To,
-                AttackerCreature = from,
-                TargetCreature = to,
-                Strike = this,
-                SourceInfo = SourceInfo,
-                Traits = Traits,
-                D20Result = attackRoll,
-                Degree = attackRoll.degree,
-                DamageDice = CloneDamageDice(Damages),
-                FlatDamages = new List<DamageValue>(FlatDamages),
-                DamageValues = new List<DamageValue>(),
-                TargetingResult = TargetingResult,
-                BaseArmorClass = baseAcResolution.Total,
-                TargetArmorClass = targetAc,
-                AttackBonus = attackBonus,
-                TotalAttackModifier = totalModifier,
-                MultipleAttackPenalty = mapPenalty,
-                RangePenalty = rangePenalty,
-                CoverAcBonus = coverBonus
-            };
-            AttackResultPipeline.ProcessHit(context);
+            DamageDice = new List<Dice>();
+            FlatDamages = new List<DamageValue>();
+            SourceInfo = AttackSourceInfo.Unspecified;
+            return;
         }
-        else
-        {
-            OnAttackMiss.Invoke(From);
-            log += "\nAttack Missed!";
-            CombatLog.GetInstance().Log(log);
-        }
+
+        DamageDice = CloneDice(profile.DamageDice);
+        FlatDamages = new List<DamageValue>(profile.FlatDamages ?? new List<DamageValue>());
+        Traits = new List<string>(profile.Traits ?? new List<string>());
+        SourceInfo = new AttackSourceInfo(profile.SourceInfo);
+        AttackModifierOverride = profile.AttackModifierOverride;
+        ItemSlug = profile.ItemSlug;
+        WeaponCategory = profile.WeaponCategory;
+        IsRangedAttack = profile.IsRangedAttack;
+        ReachFeet = profile.ReachFeet;
     }
 
-    private static List<Dice> CloneDamageDice(List<Dice> diceList)
+    public float GetAverageDamage()
+    {
+        float average = 0;
+        foreach (Dice dice in DamageDice ?? new List<Dice>())
+            average += dice.numberOfDice * ((float)dice.sidesPerDie + 1) / 2;
+        foreach (DamageValue damageValue in FlatDamages ?? new List<DamageValue>())
+            average += damageValue.DamageAmount;
+        return average;
+    }
+
+    public override string ToString()
+    {
+        string traits = string.Join(" ", Traits ?? new List<string>());
+        return "Strike Profile: " + (DamageDice?.Count ?? 0) + " damage rolls, " + (FlatDamages?.Count ?? 0) + " flat damages, Traits: " + traits;
+    }
+
+    internal static List<Dice> CloneDice(IEnumerable<Dice> diceList)
     {
         List<Dice> clone = new();
         if (diceList == null)
@@ -141,87 +117,177 @@ public class Strike
             clone.Add(new Dice(dice.numberOfDice, dice.sidesPerDie, dice.damageType));
         return clone;
     }
+}
 
-    private static IEnumerable<Pf2eModifier> BuildStrikeAttackModifiers(int mapPenalty, int rangePenalty)
+/// <summary>
+/// Immutable request data for resolving one selected Strike.
+/// Target selection, ammo checks, action cost, and MAP increment remain owned by the invoking action.
+/// </summary>
+public class StrikeResolutionRequest
+{
+    public GameObject Attacker { get; set; }
+    public GameObject Target { get; set; }
+    public StrikeProfile Profile { get; set; }
+    public StrikeTargetResult TargetingResult { get; set; }
+}
+
+/// <summary>
+/// Ordered extension points for Strike resolution. Phases are intentionally broad so rule sources can plug in without growing Strike action classes.
+/// </summary>
+public enum StrikeAdjustmentPhase
+{
+    PrepareProfile = 0,
+    BeforeAttackRoll = 100,
+    BeforeArmorClassResolution = 200,
+    ResolveAttackRoll = 300,
+    AfterAttackRoll = 400,
+    BeforeDamageRoll = 500,
+    RollDamage = 600,
+    AfterCriticalDoubling = 700,
+    BeforeDefenseAdjustments = 800,
+    ApplyDefenseAndDamage = 900,
+    AfterDamageApplied = 1000
+}
+
+/// <summary>
+/// Mutable state for a Strike as it moves through resolution.
+/// </summary>
+public class StrikeResolutionContext
+{
+    private List<string> explicitTraits = new();
+    private List<string> traits = new();
+    private AttackSourceInfo sourceInfo = AttackSourceInfo.Unspecified;
+
+    public GameObject AttackerObject { get; set; }
+    public GameObject TargetObject { get; set; }
+    public CreatureComponent AttackerCreature { get; set; }
+    public CreatureComponent TargetCreature { get; set; }
+    public StrikeProfile Profile { get; set; }
+    public AttackSourceInfo SourceInfo
     {
-        if (mapPenalty != 0)
-            // Multiple attack penalty source: https://2e.aonprd.com/Rules.aspx?ID=2288
-            yield return new Pf2eModifier(-mapPenalty, Pf2eModifierType.Untyped, "Multiple attack penalty", Pf2eStatistic.AttackRoll);
-        if (rangePenalty != 0)
-            // Range penalty source: https://2e.aonprd.com/Rules.aspx?ID=2288
-            yield return new Pf2eModifier(rangePenalty, Pf2eModifierType.Untyped, "Range penalty", Pf2eStatistic.AttackRoll);
-    }
-
-    private static IEnumerable<Pf2eModifier> BuildStrikeAcModifiers(int coverBonus, bool flankedOffGuard)
-    {
-        if (coverBonus != 0)
-            // Cover source: https://2e.aonprd.com/Rules.aspx?ID=2372
-            yield return new Pf2eModifier(coverBonus, Pf2eModifierType.Circumstance, "Cover", Pf2eStatistic.ArmorClass);
-        if (flankedOffGuard)
-            // Flanking source: https://2e.aonprd.com/Rules.aspx?ID=2375
-            yield return new Pf2eModifier(-2, Pf2eModifierType.Circumstance, "Off-Guard", Pf2eStatistic.ArmorClass);
-    }
-
-    private static string FormatResolution(Pf2eModifierResolution resolution)
-    {
-        return "total " + resolution.Total + "; applied [" + FormatModifiers(resolution.AppliedModifiers) + "]; suppressed [" + FormatModifiers(resolution.SuppressedModifiers) + "]";
-    }
-
-    private static string FormatModifiers(IReadOnlyList<Pf2eModifier> modifiers)
-    {
-        if (modifiers == null || modifiers.Count == 0)
-            return "none";
-
-        List<string> parts = new();
-        foreach (Pf2eModifier modifier in modifiers)
-            parts.Add(modifier.Source + " " + FormatSigned(modifier.Value) + " " + modifier.Type);
-        return string.Join(", ", parts);
-    }
-
-    private static string FormatSigned(int value)
-    {
-        return value >= 0 ? "+" + value : value.ToString();
-    }
-
-    private int CalculateMultipleAttackPenalty(uint strikePenaltyCount)
-    {
-        if (strikePenaltyCount == 0)
-            return 0;
-
-        bool agile = Traits.Contains("agile");
-        if (strikePenaltyCount == 1)
-            return agile ? 4 : 5;
-        return agile ? 8 : 10;
-    }
-
-    public List<string> getTraits()
-    {
-        return Traits;
-    }
-
-    public override string ToString()
-    {
-        string traits = "";
-        foreach (string trait in Traits)
+        get => sourceInfo;
+        set
         {
-            traits += trait + " ";
+            sourceInfo = value ?? AttackSourceInfo.Unspecified;
+            RefreshTraits();
         }
-        return "Strike Action: " + Damages.Count + " damage rolls, " + FlatDamages.Count + " flat damages, Traits: " + traits;
+    }
+    public List<string> Traits
+    {
+        get => traits;
+        set
+        {
+            explicitTraits = value == null ? new List<string>() : new List<string>(value);
+            RefreshTraits();
+        }
+    }
+    public List<string> ItemOptions { get; set; } = new();
+    public List<Dice> DamageDice { get; set; } = new();
+    public List<DamageValue> FlatDamages { get; set; } = new();
+    public List<DamageValue> DamageValues { get; set; } = new();
+    public List<Pf2eModifier> AttackModifiers { get; } = new();
+    public List<Pf2eModifier> ArmorClassModifiers { get; } = new();
+    public StrikeTargetResult TargetingResult { get; set; }
+    public Pf2eModifierResolution AttackResolution { get; set; }
+    public Pf2eModifierResolution BaseArmorClassResolution { get; set; }
+    public Pf2eModifierResolution TargetArmorClassResolution { get; set; }
+    public D20Result D20Result { get; set; }
+    public DegreeOfSuccess Degree { get; set; }
+    public int BaseArmorClass { get; set; }
+    public int TargetArmorClass { get; set; }
+    public int AttackBonus { get; set; }
+    public int TotalAttackModifier { get; set; }
+    public int MultipleAttackPenalty { get; set; }
+    public int RangePenalty { get; set; }
+    public int CoverAcBonus { get; set; }
+    public bool FlankedOffGuard { get; set; }
+    public bool IsHit { get; set; }
+    public uint FinalAppliedDamage { get; set; }
+
+    public static StrikeResolutionContext FromRequest(StrikeResolutionRequest request)
+    {
+        if (request == null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Attacker == null)
+            throw new ArgumentException("Strike resolution requires an attacker.", nameof(request));
+        if (request.Target == null)
+            throw new ArgumentException("Strike resolution requires a target.", nameof(request));
+        if (request.Profile == null)
+            throw new ArgumentException("Strike resolution requires a Strike profile.", nameof(request));
+
+        StrikeProfile profile = new(request.Profile);
+        return new StrikeResolutionContext
+        {
+            AttackerObject = request.Attacker,
+            TargetObject = request.Target,
+            AttackerCreature = request.Attacker.GetComponent<CreatureComponent>(),
+            TargetCreature = request.Target.GetComponent<CreatureComponent>(),
+            Profile = profile,
+            SourceInfo = profile.SourceInfo,
+            Traits = profile.Traits,
+            DamageDice = StrikeProfile.CloneDice(profile.DamageDice),
+            FlatDamages = new List<DamageValue>(profile.FlatDamages ?? new List<DamageValue>()),
+            DamageValues = new List<DamageValue>(),
+            TargetingResult = request.TargetingResult
+        };
     }
 
-    public float GetAvgDmg()
+    private void RefreshTraits()
     {
-        float avg = 0;
-        foreach (Dice dice in Damages)
+        List<string> merged = explicitTraits == null ? new List<string>() : new List<string>(explicitTraits);
+        if (sourceInfo?.Traits != null)
         {
-            avg += dice.numberOfDice * ((float)dice.sidesPerDie + 1) / 2;
+            foreach (string trait in sourceInfo.Traits)
+            {
+                if (!ContainsTrait(merged, trait))
+                    merged.Add(trait);
+            }
         }
-        foreach (DamageValue damageValue in FlatDamages)
-        {
-            avg += damageValue.DamageAmount;
-        }
-        return avg;
+        traits = merged;
+    }
+
+    private static bool ContainsTrait(List<string> traits, string candidate)
+    {
+        foreach (string trait in traits)
+            if (string.Equals(trait, candidate, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
     }
 }
 
-public class OnStrikeEvent : StaticUnityEvent<OnStrikeEvent, Tuple<Strike, GameObject>>{ }
+/// <summary>
+/// Final outcome of a resolved Strike.
+/// </summary>
+public class StrikeResolutionResult
+{
+    public StrikeResolutionContext Context { get; }
+    public bool Hit => Context?.IsHit ?? false;
+    public bool CriticalHit => Context?.Degree == DegreeOfSuccess.CriticalSuccess;
+    public uint FinalAppliedDamage => Context?.FinalAppliedDamage ?? 0;
+
+    public StrikeResolutionResult(StrikeResolutionContext context)
+    {
+        Context = context;
+    }
+}
+
+/// <summary>
+/// A deterministic rule hook that can inspect and mutate Strike resolution state at one phase.
+/// </summary>
+public interface IStrikeAdjustment
+{
+    StrikeAdjustmentPhase Phase { get; }
+    int Order { get; }
+    string Source { get; }
+    void Apply(StrikeResolutionContext context);
+}
+
+/// <summary>
+/// Optional Unity component contract for attacker- or defender-owned Strike rule hooks.
+/// </summary>
+public interface IStrikeAdjustmentProvider
+{
+    IEnumerable<IStrikeAdjustment> GetStrikeAdjustments(StrikeResolutionContext context);
+}
+
+public class OnStrikePreparedEvent : StaticUnityEvent<OnStrikePreparedEvent, StrikeResolutionContext> { }

--- a/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/StrikeWeapon.cs
@@ -16,7 +16,7 @@ public class StrikeWeapon : MultiFrameEntityAction
     private const string ReachTrait = "reach";
 
     public override string ActionName => GetWeaponName();
-    private Strike Strike;
+    private StrikeProfile Profile;
     private EquipmentWeapon Weapon;
     public string weaponName;
 
@@ -110,9 +110,9 @@ public class StrikeWeapon : MultiFrameEntityAction
         return Weapon;
     }
 
-    public Strike GetStrike()
+    public StrikeProfile GetStrikeProfile()
     {
-        return Strike;
+        return Profile;
     }
 
     public int GetRange()
@@ -160,14 +160,14 @@ public class StrikeWeapon : MultiFrameEntityAction
         if (!IsRangedWeapon() || string.IsNullOrWhiteSpace(Weapon.ammo))
             flatDamageList.Add(new DamageValue(Weapon.damage.damageType, cc.damageBonus));
 
-        Strike = new Strike(damageList, flatDamageList);
-        Strike.Traits = Weapon.traits ?? new List<string>();
-        Strike.SourceInfo = AttackSourceInfo.FromWeapon(Weapon);
-        Strike.ItemSlug = Pf2eSlug.FromName(Weapon.name);
-        Strike.WeaponCategory = Weapon.category;
-        Strike.IsRangedAttack = IsRangedWeapon();
-        Strike.ReachFeet = GetTargetRequest().ReachFeet;
-        Strike.AttackModifierOverride = cc.GetAttackBonusForWeapon(weapon);
+        Profile = new StrikeProfile(damageList, flatDamageList);
+        Profile.Traits = Weapon.traits ?? new List<string>();
+        Profile.SourceInfo = AttackSourceInfo.FromWeapon(Weapon);
+        Profile.ItemSlug = Pf2eSlug.FromName(Weapon.name);
+        Profile.WeaponCategory = Weapon.category;
+        Profile.IsRangedAttack = IsRangedWeapon();
+        Profile.ReachFeet = GetTargetRequest().ReachFeet;
+        Profile.AttackModifierOverride = cc.GetAttackBonusForWeapon(weapon);
     }
 
     protected override IEnumerator MFInvoke(GameObject attacker)
@@ -196,7 +196,13 @@ public class StrikeWeapon : MultiFrameEntityAction
             }
 
             CombatLog.GetInstance().Log("- " + attacker.name + " strikes " + target.Value.Target.name + " with " + weaponName + ".");
-            Strike.Damage(attacker, target.Value.Target, target.Value);
+            StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
+            {
+                Attacker = attacker,
+                Target = target.Value.Target,
+                Profile = Profile,
+                TargetingResult = target.Value
+            });
             cc?.MarkWeaponFired(Weapon);
             if (ac)
             {

--- a/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
@@ -14,7 +14,7 @@ public class Unarmed : MultiFrameEntityAction
     public override string ActionName => "Unarmed Strike";
     private StrikeProfile Profile;
     private int range = 1; // default range of 1 tile
-    
+
     public Unarmed(uint cost, List<Dice> damages, List<DamageValue> flatDamages) : base(cost)
     {
         Profile = new StrikeProfile(damages, flatDamages);
@@ -42,7 +42,7 @@ public class Unarmed : MultiFrameEntityAction
             RequiresLineOfEffect = true
         };
         yield return GridAPI.GetInstance().GetStrikeTarget(attacker, request, target);
-            
+
         // null target value equates to canceled action
         if(target.Value != null && target.Value.Target != null)
         {
@@ -80,5 +80,4 @@ public class Unarmed : MultiFrameEntityAction
 }
 
 }
-
 

--- a/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
+++ b/Assets/Scripts/Combat/Actions/Attacks/Unarmed.cs
@@ -12,22 +12,22 @@ public class Unarmed : MultiFrameEntityAction
 {
     // Done by Ryan Meyer 04/07/2026
     public override string ActionName => "Unarmed Strike";
-    private Strike Strike;
+    private StrikeProfile Profile;
     private int range = 1; // default range of 1 tile
     
     public Unarmed(uint cost, List<Dice> damages, List<DamageValue> flatDamages) : base(cost)
     {
-        Strike = new Strike(damages, flatDamages);
+        Profile = new StrikeProfile(damages, flatDamages);
         // Unarmed strike traits based on PF2e rules
-        Strike.Traits = new List<string>() {"agile", "finesse", "nonlethal", "unarmed"};
-        Strike.ItemSlug = "unarmed";
-        Strike.WeaponCategory = "unarmed";
-        Strike.ReachFeet = range * 5;
+        Profile.Traits = new List<string>() {"agile", "finesse", "nonlethal", "unarmed"};
+        Profile.ItemSlug = "unarmed";
+        Profile.WeaponCategory = "unarmed";
+        Profile.ReachFeet = range * 5;
     }
 
-    public Strike GetStrike()
+    public StrikeProfile GetStrikeProfile()
     {
-        return Strike;
+        return Profile;
     }
 
     protected override IEnumerator MFInvoke(GameObject attacker)
@@ -47,7 +47,13 @@ public class Unarmed : MultiFrameEntityAction
         {
             CombatLog.GetInstance().Log("- " + attacker.name + " attacks " + target.Value.Target.name + " with unarmed strike.");
             Debug.Log(attacker + " Striking " + target.Value.Target);
-            Strike.Damage(attacker, target.Value.Target, target.Value);
+            StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
+            {
+                Attacker = attacker,
+                Target = target.Value.Target,
+                Profile = Profile,
+                TargetingResult = target.Value
+            });
             if (ac)
             {
                 PayCost(ac);

--- a/Assets/Scripts/Combat/MindlessController.cs
+++ b/Assets/Scripts/Combat/MindlessController.cs
@@ -195,7 +195,7 @@ public class MindlessController : AIActionController
                 if (!strikeWeapon.CanStrikeTarget(gameObject, target, Tiles))
                     continue;
 
-                float damage = strikeWeapon.GetStrike().GetAvgDmg();
+                float damage = strikeWeapon.GetStrikeProfile().GetAverageDamage();
                 if (damage > bestDamage)
                 {
                     bestDamage = damage;

--- a/Assets/Scripts/Combat/Rules/FlankingRule.cs
+++ b/Assets/Scripts/Combat/Rules/FlankingRule.cs
@@ -12,7 +12,7 @@ namespace Game.Combat.Rules
     {
         private const int DefaultUnarmedReachFeet = 5;
 
-        public static bool GrantsOffGuardToMeleeAttack(GameObject attacker, GameObject target, Strike strike)
+        public static bool GrantsOffGuardToMeleeAttack(GameObject attacker, GameObject target, StrikeProfile strike)
         {
             if (attacker == null || target == null || strike == null || strike.IsRangedAttack)
                 return false;

--- a/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eRulesEngine.cs
@@ -14,20 +14,20 @@ namespace Game.Creature.Rules
     public static class Pf2eRulesEngine
     {
         /// <summary>
-        /// Applies prepared strike-damage modifiers, damage dice, and adjustments to a Strike before damage is resolved.
+        /// Applies prepared strike damage modifiers, damage dice, and adjustments to a Strike resolution context before the attack roll.
         /// </summary>
-        /// <param name="attacker">The creature making the Strike and owning the prepared rule state.</param>
-        /// <param name="strike">The Strike being modified by matching PF2e rule elements.</param>
-        /// <param name="target">Optional target creature for target-scoped predicates.</param>
-        public static void ApplyStrikeDamageModifiers(CreatureComponent attacker, Strike strike, CreatureComponent target = null)
+        public static void ApplyPreparedStrikeAdjustments(StrikeResolutionContext context)
         {
-            PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(attacker);
-            List<string> itemOptions = BuildStrikeItemOptions(prepared, strike, target);
-            ApplyAbilityDamageModifiers(attacker, strike, prepared, itemOptions);
-            ApplyFlatStrikeDamageModifiers(strike, prepared, itemOptions);
-            ApplyStrikeDamageDice(strike, prepared, itemOptions);
-        }
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
+            PreparedCharacter prepared = Pf2eCharacterPreparer.EnsurePrepared(context.AttackerCreature);
+            List<string> itemOptions = BuildStrikeItemOptions(prepared, context);
+            context.ItemOptions = itemOptions;
+            ApplyAbilityDamageModifiers(context, prepared, itemOptions);
+            ApplyFlatStrikeDamageModifiers(context, prepared, itemOptions);
+            ApplyStrikeDamageDice(context, prepared, itemOptions);
+        }
 
         /// <summary>
         /// Runs encounter-cleanup rule hooks for each combatant; action-specific details stay in their own rule classes.
@@ -108,7 +108,7 @@ namespace Game.Creature.Rules
             return traits;
         }
 
-        private static void ApplyFlatStrikeDamageModifiers(Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        private static void ApplyFlatStrikeDamageModifiers(StrikeResolutionContext context, PreparedCharacter prepared, List<string> itemOptions)
         {
             List<RuleModifier> modifiers = prepared.Modifiers
                 .Where(m => string.Equals(m.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
@@ -137,14 +137,14 @@ namespace Game.Creature.Rules
                 if (modifier.Value == 0)
                     continue;
 
-                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
-                strike.FlatDamages.Add(new DamageValue(damageType, modifier.Value));
+                string damageType = context.FlatDamages.Count > 0 ? context.FlatDamages[0].DamageType : context.DamageDice.FirstOrDefault()?.damageType ?? "Untyped";
+                context.FlatDamages.Add(new DamageValue(damageType, modifier.Value));
             }
         }
 
-        private static void ApplyAbilityDamageModifiers(CreatureComponent attacker, Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        private static void ApplyAbilityDamageModifiers(StrikeResolutionContext context, PreparedCharacter prepared, List<string> itemOptions)
         {
-            if (attacker == null || strike == null || strike.IsRangedAttack)
+            if (context.AttackerCreature == null || context.Profile == null || context.Profile.IsRangedAttack)
                 return;
 
             foreach (RuleModifier modifier in prepared.Modifiers
@@ -152,32 +152,32 @@ namespace Game.Creature.Rules
                 .Where(m => !string.IsNullOrWhiteSpace(m.Ability))
                 .Where(m => Pf2ePredicate.Evaluate(m.Predicate, prepared, itemOptions)))
             {
-                int abilityModifier = GetAbilityModifier(attacker, modifier.Ability);
-                string damageType = strike.FlatDamages.Count > 0 ? strike.FlatDamages[0].DamageType : strike.Damages.FirstOrDefault()?.damageType ?? "Untyped";
-                if (strike.FlatDamages.Count == 0)
-                    strike.FlatDamages.Add(new DamageValue(damageType, abilityModifier));
+                int abilityModifier = GetAbilityModifier(context.AttackerCreature, modifier.Ability);
+                string damageType = context.FlatDamages.Count > 0 ? context.FlatDamages[0].DamageType : context.DamageDice.FirstOrDefault()?.damageType ?? "Untyped";
+                if (context.FlatDamages.Count == 0)
+                    context.FlatDamages.Add(new DamageValue(damageType, abilityModifier));
                 else
-                    strike.FlatDamages[0] = new DamageValue(damageType, abilityModifier);
+                    context.FlatDamages[0] = new DamageValue(damageType, abilityModifier);
             }
         }
 
-        private static void ApplyStrikeDamageDice(Strike strike, PreparedCharacter prepared, List<string> itemOptions)
+        private static void ApplyStrikeDamageDice(StrikeResolutionContext context, PreparedCharacter prepared, List<string> itemOptions)
         {
             foreach (RuleDamageDice damageDice in prepared.DamageDice
                 .Where(d => string.Equals(d.Selector, "strike-damage", StringComparison.OrdinalIgnoreCase))
                 .Where(d => d.DiceNumber > 0 && d.DieSize > 0)
                 .Where(d => Pf2ePredicate.Evaluate(d.Predicate, prepared, itemOptions)))
             {
-                strike.Damages.Add(new Dice(damageDice.DiceNumber, damageDice.DieSize, damageDice.Category ?? "precision"));
+                context.DamageDice.Add(new Dice(damageDice.DiceNumber, damageDice.DieSize, damageDice.Category ?? "precision"));
             }
         }
 
-        private static List<string> BuildStrikeItemOptions(PreparedCharacter prepared, Strike strike, CreatureComponent target)
+        private static List<string> BuildStrikeItemOptions(PreparedCharacter prepared, StrikeResolutionContext context)
         {
-            List<string> options = BuildItemOptions(strike?.ItemSlug, strike?.WeaponCategory, strike?.IsRangedAttack ?? false, strike?.Traits, strike?.Damages.FirstOrDefault());
+            List<string> options = BuildItemOptions(context.Profile?.ItemSlug, context.Profile?.WeaponCategory, context.Profile?.IsRangedAttack ?? false, context.Traits, context.DamageDice.FirstOrDefault());
             AddAlteredItemTags(prepared, options);
-            AddTargetConditionOptions(target, options);
-            AddFlankingTargetConditionOption(strike, options);
+            AddTargetConditionOptions(context.TargetCreature, options);
+            AddFlankingTargetConditionOption(context, options);
             return options;
         }
 
@@ -228,9 +228,9 @@ namespace Game.Creature.Rules
             }
         }
 
-        private static void AddFlankingTargetConditionOption(Strike strike, List<string> options)
+        private static void AddFlankingTargetConditionOption(StrikeResolutionContext context, List<string> options)
         {
-            if (FlankingRule.GrantsOffGuardToMeleeAttack(strike?.From, strike?.To, strike))
+            if (FlankingRule.GrantsOffGuardToMeleeAttack(context?.AttackerObject, context?.TargetObject, context?.Profile))
                 AddOption(options, "target:condition:off-guard");
         }
 
@@ -282,6 +282,5 @@ namespace Game.Creature.Rules
                 _ => 0
             };
         }
-
     }
 }

--- a/Assets/Tests/EditMode/Pf2eCriticalEffectPipelineTests.cs
+++ b/Assets/Tests/EditMode/Pf2eCriticalEffectPipelineTests.cs
@@ -13,11 +13,11 @@ namespace TestsCombat
     public class Pf2eCriticalEffectPipelineTests
     {
         [Test]
-        public void StrikeDefaultsSourceInfoToUnspecified()
+        public void StrikeProfileDefaultsSourceInfoToUnspecified()
         {
-            Strike strike = new Strike(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>());
+            StrikeProfile profile = new StrikeProfile(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>());
 
-            Assert.AreSame(AttackSourceInfo.Unspecified, strike.SourceInfo);
+            Assert.AreSame(AttackSourceInfo.Unspecified, profile.SourceInfo);
         }
 
         [Test]
@@ -33,14 +33,12 @@ namespace TestsCombat
             GameObject attacker = CreateCreature("attacker", 100);
             GameObject target = CreateCreature("target", 100);
 
-            AttackResultContext normal = BuildPipelineContext(attacker, target, DegreeOfSuccess.Success, new List<string> { "deadly-d10" });
-            AttackResultPipeline.ProcessHit(normal);
+            StrikeResolutionResult normal = ResolveForcedStrike(attacker, target, DegreeOfSuccess.Success, new List<string> { "deadly-d10" });
 
             Assert.AreEqual(1u, normal.FinalAppliedDamage);
             Assert.IsFalse(log.Messages.Any(message => message.Contains("deadly-d10 critical damage")));
 
-            AttackResultContext critical = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, new List<string> { "deadly-d10" });
-            AttackResultPipeline.ProcessHit(critical);
+            StrikeResolutionResult critical = ResolveForcedStrike(attacker, target, DegreeOfSuccess.CriticalSuccess, new List<string> { "deadly-d10" });
 
             Assert.Greater(critical.FinalAppliedDamage, 2u);
             Assert.LessOrEqual(critical.FinalAppliedDamage, 12u);
@@ -65,17 +63,15 @@ namespace TestsCombat
             GameObject attacker = CreateCreature("attacker", 100);
             GameObject target = CreateCreature("target", 100);
 
-            AttackResultContext normal = BuildPipelineContext(attacker, target, DegreeOfSuccess.Success, new List<string> { "fatal-d12" }, null, new List<Dice> { new Dice(1, 6, "piercing") });
-            AttackResultPipeline.ProcessHit(normal);
+            StrikeResolutionResult normal = ResolveForcedStrike(attacker, target, DegreeOfSuccess.Success, new List<string> { "fatal-d12" }, null, new List<Dice> { new Dice(1, 6, "piercing") });
 
-            Assert.AreEqual(6, normal.DamageDice[0].sidesPerDie);
+            Assert.AreEqual(6, normal.Context.DamageDice[0].sidesPerDie);
             Assert.GreaterOrEqual(normal.FinalAppliedDamage, 1u);
             Assert.LessOrEqual(normal.FinalAppliedDamage, 6u);
 
-            AttackResultContext critical = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, new List<string> { "fatal-d12" }, null, new List<Dice> { new Dice(1, 6, "piercing") });
-            AttackResultPipeline.ProcessHit(critical);
+            StrikeResolutionResult critical = ResolveForcedStrike(attacker, target, DegreeOfSuccess.CriticalSuccess, new List<string> { "fatal-d12" }, null, new List<Dice> { new Dice(1, 6, "piercing") });
 
-            Assert.AreEqual(12, critical.DamageDice[0].sidesPerDie);
+            Assert.AreEqual(12, critical.Context.DamageDice[0].sidesPerDie);
             Assert.GreaterOrEqual(critical.FinalAppliedDamage, 3u);
             Assert.LessOrEqual(critical.FinalAppliedDamage, 36u);
             Assert.IsTrue(log.Messages.Any(message => message.Contains("fatal-d12 upgrades critical damage dice")));
@@ -96,22 +92,22 @@ namespace TestsCombat
             GameObject target = CreateCreature("target", 100);
             target.GetComponent<CreatureComponent>().resistances = new List<DamageValue> { new DamageValue("piercing", 3) };
             List<string> events = new();
-            TestAttackResultEffectProvider provider = attacker.AddComponent<TestAttackResultEffectProvider>();
-            provider.Effects.Add(new RecordingAttackResultEffect(AttackResultEffectPhase.BeforeDamageRoll, context =>
+            TestStrikeAdjustmentProvider provider = attacker.AddComponent<TestStrikeAdjustmentProvider>();
+            provider.Effects.Add(new ForceDegreeStrikeAdjustment(DegreeOfSuccess.CriticalSuccess));
+            provider.Effects.Add(new RecordingStrikeAdjustment(StrikeAdjustmentPhase.BeforeDamageRoll, 0, context =>
             {
                 events.Add("before-roll");
                 context.FlatDamages.Add(new DamageValue("piercing", 4));
             }));
-            provider.Effects.Add(new RecordingAttackResultEffect(AttackResultEffectPhase.AfterCriticalDoubling, context =>
+            provider.Effects.Add(new RecordingStrikeAdjustment(StrikeAdjustmentPhase.AfterCriticalDoubling, 50, context =>
             {
                 events.Add("after-critical:" + context.DamageValues[0].DamageAmount);
                 context.DamageValues = DamageRoller.AddOrMergeDamage(context.DamageValues, new DamageValue("piercing", 2));
             }));
-            provider.Effects.Add(new RecordingAttackResultEffect(AttackResultEffectPhase.BeforeDefenseAdjustments, context => events.Add("before-defense:" + context.DamageValues[0].DamageAmount)));
-            provider.Effects.Add(new RecordingAttackResultEffect(AttackResultEffectPhase.AfterDamageApplied, context => events.Add("after-damage:" + context.FinalAppliedDamage)));
+            provider.Effects.Add(new RecordingStrikeAdjustment(StrikeAdjustmentPhase.BeforeDefenseAdjustments, 0, context => events.Add("before-defense:" + context.DamageValues[0].DamageAmount)));
+            provider.Effects.Add(new RecordingStrikeAdjustment(StrikeAdjustmentPhase.AfterDamageApplied, 0, context => events.Add("after-damage:" + context.FinalAppliedDamage)));
 
-            AttackResultContext result = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, null, null, new List<Dice>(), new List<DamageValue> { new DamageValue("piercing", 6) });
-            AttackResultPipeline.ProcessHit(result);
+            StrikeResolutionResult result = ResolveStrike(attacker, target, null, null, new List<Dice>(), new List<DamageValue> { new DamageValue("piercing", 6) });
 
             CollectionAssert.AreEqual(new[] { "before-roll", "after-critical:20", "before-defense:22", "after-damage:19" }, events);
             Assert.AreEqual(19u, result.FinalAppliedDamage);
@@ -123,7 +119,7 @@ namespace TestsCombat
         }
 
         [Test]
-        public void WeaponStrikePopulatesAttackResultContextSourceInfo()
+        public void WeaponStrikePopulatesStrikeResolutionContextSourceInfo()
         {
             GameObject attacker = CreateCreature("attacker", 100);
             GameObject target = CreateCreature("target", 100);
@@ -140,7 +136,7 @@ namespace TestsCombat
             };
 
             StrikeWeapon action = new StrikeWeapon(1, shortbow, attacker);
-            AttackResultContext context = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, action.GetStrike().Traits, action.GetStrike().SourceInfo);
+            StrikeResolutionContext context = BuildContext(attacker, target, action.GetStrikeProfile().Traits, action.GetStrikeProfile().SourceInfo);
 
             Assert.AreSame(attacker, context.AttackerObject);
             Assert.AreSame(target, context.TargetObject);
@@ -151,7 +147,6 @@ namespace TestsCombat
             Assert.AreEqual("martial", context.SourceInfo.Category);
             Assert.AreSame(shortbow, context.SourceInfo.EquipmentWeapon);
             Assert.Contains("deadly-d10", context.Traits);
-            Assert.AreEqual(DegreeOfSuccess.CriticalSuccess, context.Degree);
             Assert.AreEqual(target, context.TargetingResult.Target);
 
             UnityEngine.Object.DestroyImmediate(attacker);
@@ -165,23 +160,22 @@ namespace TestsCombat
             InstallTestCombatLog(logObject);
             GameObject attacker = CreateCreature("attacker", 100);
             GameObject target = CreateCreature("target", 100);
-            TestAttackResultEffectProvider provider = target.AddComponent<TestAttackResultEffectProvider>();
-            provider.Effects.Add(new CriticalSpecializationAttackResultEffect("bow", context =>
+            TestStrikeAdjustmentProvider provider = target.AddComponent<TestStrikeAdjustmentProvider>();
+            provider.Effects.Add(new CriticalSpecializationStrikeAdjustment("bow", context =>
             {
                 provider.Calls += 1;
                 provider.LastContext = context;
             }));
             AttackSourceInfo source = new AttackSourceInfo("Shortbow", "bow", "martial", new List<string> { "deadly-d10" });
 
-            AttackResultContext normal = BuildPipelineContext(attacker, target, DegreeOfSuccess.Success, null, source);
-            AttackResultPipeline.ProcessHit(normal);
+            StrikeResolutionResult normal = ResolveForcedStrike(attacker, target, DegreeOfSuccess.Success, null, source);
             Assert.AreEqual(0, provider.Calls);
 
-            AttackResultContext critical = BuildPipelineContext(attacker, target, DegreeOfSuccess.CriticalSuccess, null, source);
-            AttackResultPipeline.ProcessHit(critical);
+            StrikeResolutionResult critical = ResolveForcedStrike(attacker, target, DegreeOfSuccess.CriticalSuccess, null, source);
             Assert.AreEqual(1, provider.Calls);
-            Assert.AreSame(critical, provider.LastContext);
+            Assert.AreSame(critical.Context, provider.LastContext);
             Assert.Greater(critical.FinalAppliedDamage, 0u);
+            Assert.IsTrue(normal.Hit);
 
             UnityEngine.Object.DestroyImmediate(attacker);
             UnityEngine.Object.DestroyImmediate(target);
@@ -204,14 +198,17 @@ namespace TestsCombat
         {
             GameObject creature = new GameObject(name);
             CreatureComponent component = creature.AddComponent<CreatureComponent>();
+            creature.AddComponent<TestActionController>();
             component.hp = hp;
             component.maxHp = hp;
+            component.ac = 10;
+            component.attackBonus = 10;
             component.weaknesses = new List<DamageValue>();
             component.resistances = new List<DamageValue>();
             return creature;
         }
 
-        private static AttackResultContext BuildPipelineContext(
+        private static StrikeResolutionResult ResolveForcedStrike(
             GameObject attacker,
             GameObject target,
             DegreeOfSuccess degree,
@@ -220,38 +217,64 @@ namespace TestsCombat
             List<Dice> damageDice = null,
             List<DamageValue> flatDamages = null)
         {
-            List<Dice> dice = damageDice ?? new List<Dice> { new Dice(1, 1, "piercing") };
-            List<DamageValue> flats = flatDamages ?? new List<DamageValue>();
-            Strike strike = new Strike(dice, flats)
-            {
-                Traits = traits ?? new List<string>(),
-                SourceInfo = sourceInfo
-            };
+            TestStrikeAdjustmentProvider provider = attacker.GetComponent<TestStrikeAdjustmentProvider>() ?? attacker.AddComponent<TestStrikeAdjustmentProvider>();
+            provider.Effects.Add(new ForceDegreeStrikeAdjustment(degree));
+            return ResolveStrike(attacker, target, traits, sourceInfo, damageDice, flatDamages);
+        }
 
-            return new AttackResultContext
+        private static StrikeResolutionResult ResolveStrike(
+            GameObject attacker,
+            GameObject target,
+            List<string> traits = null,
+            AttackSourceInfo sourceInfo = null,
+            List<Dice> damageDice = null,
+            List<DamageValue> flatDamages = null)
+        {
+            StrikeProfile profile = BuildProfile(traits, sourceInfo, damageDice, flatDamages);
+            return StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
             {
-                AttackerObject = attacker,
-                TargetObject = target,
-                AttackerCreature = attacker.GetComponent<CreatureComponent>(),
-                TargetCreature = target.GetComponent<CreatureComponent>(),
-                Strike = strike,
-                SourceInfo = sourceInfo,
-                Traits = traits,
-                D20Result = new D20Result { roll = degree == DegreeOfSuccess.CriticalSuccess ? 20 : 10, total = 30, degree = degree },
-                Degree = degree,
-                DamageDice = dice,
-                FlatDamages = flats,
-                DamageValues = new List<DamageValue>(),
+                Attacker = attacker,
+                Target = target,
+                Profile = profile,
                 TargetingResult = new StrikeTargetResult
                 {
                     Target = target,
                     LineOfEffect = StrikeLineOfEffect.Clear,
                     Cover = StrikeCover.None
-                },
-                BaseArmorClass = 20,
-                TargetArmorClass = 20,
-                AttackBonus = 10,
-                TotalAttackModifier = 10
+                }
+            });
+        }
+
+        private static StrikeResolutionContext BuildContext(
+            GameObject attacker,
+            GameObject target,
+            List<string> traits = null,
+            AttackSourceInfo sourceInfo = null,
+            List<Dice> damageDice = null,
+            List<DamageValue> flatDamages = null)
+        {
+            return StrikeResolutionContext.FromRequest(new StrikeResolutionRequest
+            {
+                Attacker = attacker,
+                Target = target,
+                Profile = BuildProfile(traits, sourceInfo, damageDice, flatDamages),
+                TargetingResult = new StrikeTargetResult
+                {
+                    Target = target,
+                    LineOfEffect = StrikeLineOfEffect.Clear,
+                    Cover = StrikeCover.None
+                }
+            });
+        }
+
+        private static StrikeProfile BuildProfile(List<string> traits, AttackSourceInfo sourceInfo, List<Dice> damageDice, List<DamageValue> flatDamages)
+        {
+            List<Dice> dice = damageDice ?? new List<Dice> { new Dice(1, 1, "piercing") };
+            List<DamageValue> flats = flatDamages ?? new List<DamageValue>();
+            return new StrikeProfile(dice, flats)
+            {
+                Traits = traits ?? new List<string>(),
+                SourceInfo = sourceInfo
             };
         }
 
@@ -264,31 +287,52 @@ namespace TestsCombat
             return log;
         }
 
-        private class TestAttackResultEffectProvider : MonoBehaviour, IAttackResultEffectProvider
+        private class TestActionController : ActionController
         {
-            public readonly List<IAttackResultEffect> Effects = new();
-            public int Calls;
-            public AttackResultContext LastContext;
+            public override void EndTurn() { }
+        }
 
-            public IEnumerable<IAttackResultEffect> GetAttackResultEffects(AttackResultContext context)
+        private class TestStrikeAdjustmentProvider : MonoBehaviour, IStrikeAdjustmentProvider
+        {
+            public readonly List<IStrikeAdjustment> Effects = new();
+            public int Calls;
+            public StrikeResolutionContext LastContext;
+
+            public IEnumerable<IStrikeAdjustment> GetStrikeAdjustments(StrikeResolutionContext context)
             {
                 return Effects;
             }
         }
 
-        private class RecordingAttackResultEffect : IAttackResultEffect
+        private class ForceDegreeStrikeAdjustment : StrikeAdjustmentBase
         {
-            private readonly Action<AttackResultContext> apply;
+            private readonly DegreeOfSuccess degree;
 
-            public RecordingAttackResultEffect(AttackResultEffectPhase phase, Action<AttackResultContext> apply)
+            public ForceDegreeStrikeAdjustment(DegreeOfSuccess degree)
+                : base(StrikeAdjustmentPhase.AfterAttackRoll, -100, "Force degree")
             {
-                Phase = phase;
+                this.degree = degree;
+            }
+
+            public override void Apply(StrikeResolutionContext context)
+            {
+                context.Degree = degree;
+                context.D20Result = new D20Result { roll = degree == DegreeOfSuccess.CriticalSuccess ? 20 : 10, total = 30, degree = degree };
+                context.IsHit = degree == DegreeOfSuccess.Success || degree == DegreeOfSuccess.CriticalSuccess;
+            }
+        }
+
+        private class RecordingStrikeAdjustment : StrikeAdjustmentBase
+        {
+            private readonly Action<StrikeResolutionContext> apply;
+
+            public RecordingStrikeAdjustment(StrikeAdjustmentPhase phase, int order, Action<StrikeResolutionContext> apply)
+                : base(phase, order, "Recording")
+            {
                 this.apply = apply;
             }
 
-            public AttackResultEffectPhase Phase { get; }
-
-            public void Apply(AttackResultContext context)
+            public override void Apply(StrikeResolutionContext context)
             {
                 apply?.Invoke(context);
             }

--- a/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRangedStrikeTests.cs
@@ -182,20 +182,32 @@ namespace TestsCombat
         public void MultipleAttackPenaltyUsesAgileValues()
         {
             // PF2e source: https://2e.aonprd.com/Rules.aspx?ID=2288
-            MethodInfo method = typeof(Strike).GetMethod("CalculateMultipleAttackPenalty", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.IsNotNull(method);
+            GameObject logObject = new GameObject("test-combat-log");
+            InstallTestCombatLog(logObject);
+            GameObject attacker = CreateCombatCreature("attacker", 100);
+            GameObject target = CreateCombatCreature("target", 100);
+            TestActionController controller = attacker.GetComponent<TestActionController>();
 
-            Strike normal = new Strike(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>());
-            Strike agile = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+            StrikeProfile normal = new StrikeProfile(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>());
+            StrikeProfile agile = new StrikeProfile(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
             {
                 Traits = new List<string> { "agile" }
             };
 
-            Assert.AreEqual(0, (int)method.Invoke(normal, new object[] { 0u }));
-            Assert.AreEqual(5, (int)method.Invoke(normal, new object[] { 1u }));
-            Assert.AreEqual(10, (int)method.Invoke(normal, new object[] { 2u }));
-            Assert.AreEqual(4, (int)method.Invoke(agile, new object[] { 1u }));
-            Assert.AreEqual(8, (int)method.Invoke(agile, new object[] { 2u }));
+            controller.StrikePenalty = 0;
+            Assert.AreEqual(0, ResolveForContext(attacker, target, normal).MultipleAttackPenalty);
+            controller.StrikePenalty = 1;
+            Assert.AreEqual(5, ResolveForContext(attacker, target, normal).MultipleAttackPenalty);
+            controller.StrikePenalty = 2;
+            Assert.AreEqual(10, ResolveForContext(attacker, target, normal).MultipleAttackPenalty);
+            controller.StrikePenalty = 1;
+            Assert.AreEqual(4, ResolveForContext(attacker, target, agile).MultipleAttackPenalty);
+            controller.StrikePenalty = 2;
+            Assert.AreEqual(8, ResolveForContext(attacker, target, agile).MultipleAttackPenalty);
+
+            UnityEngine.Object.DestroyImmediate(attacker);
+            UnityEngine.Object.DestroyImmediate(target);
+            UnityEngine.Object.DestroyImmediate(logObject);
         }
 
         [Test]
@@ -206,22 +218,28 @@ namespace TestsCombat
             // Cover AC bonus: https://2e.aonprd.com/Rules.aspx?ID=2372
             GameObject logObject = new GameObject("test-combat-log");
             TestCombatLog log = InstallTestCombatLog(logObject);
-            GameObject attacker = new GameObject("attacker");
-            GameObject target = new GameObject("target");
-            attacker.AddComponent<TestActionController>().StrikePenalty = 1;
-            CreatureComponent attackerCreature = attacker.AddComponent<CreatureComponent>();
-            CreatureComponent targetCreature = target.AddComponent<CreatureComponent>();
+            GameObject attacker = CreateCombatCreature("attacker", 100);
+            GameObject target = CreateCombatCreature("target", 100);
+            attacker.GetComponent<TestActionController>().StrikePenalty = 1;
+            CreatureComponent attackerCreature = attacker.GetComponent<CreatureComponent>();
+            CreatureComponent targetCreature = target.GetComponent<CreatureComponent>();
             attackerCreature.attackBonus = 7;
             targetCreature.ac = 100;
             targetCreature.hp = 100;
 
-            Strike strike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
-            strike.Damage(attacker, target, new StrikeTargetResult
+            StrikeProfile profile = new StrikeProfile(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
+            StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
             {
+                Attacker = attacker,
                 Target = target,
-                LineOfEffect = StrikeLineOfEffect.Clear,
-                Cover = StrikeCover.Standard,
-                RangePenalty = -2
+                Profile = profile,
+                TargetingResult = new StrikeTargetResult
+                {
+                    Target = target,
+                    LineOfEffect = StrikeLineOfEffect.Clear,
+                    Cover = StrikeCover.Standard,
+                    RangePenalty = -2
+                }
             });
 
             string attackLog = log.Messages.FirstOrDefault(message => message.StartsWith("Attack:", StringComparison.Ordinal));
@@ -235,7 +253,6 @@ namespace TestsCombat
             UnityEngine.Object.DestroyImmediate(target);
             UnityEngine.Object.DestroyImmediate(logObject);
         }
-
         [Test]
         public void AmmoAndReloadStateAreEnforced()
         {
@@ -311,8 +328,8 @@ namespace TestsCombat
 
             StrikeWeapon action = new StrikeWeapon(1, shortbow, creature);
 
-            Assert.AreEqual(0, action.GetStrike().FlatDamages.Count);
-            Assert.AreEqual(3.5f, action.GetStrike().GetAvgDmg());
+            Assert.AreEqual(0, action.GetStrikeProfile().FlatDamages.Count);
+            Assert.AreEqual(3.5f, action.GetStrikeProfile().GetAverageDamage());
             UnityEngine.Object.DestroyImmediate(creature);
         }
 
@@ -336,11 +353,24 @@ namespace TestsCombat
                 creature.Prepared = Pf2eCharacterPreparer.Prepare(creature, creature.Build);
                 Assert.IsTrue(new Rage(0).UseRage(creatureObject));
 
-                Strike projectileStrike = new Strike(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>());
-                projectileStrike.Traits.Add("ranged");
+                StrikeProfile projectileStrike = new StrikeProfile(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+                {
+                    Traits = new List<string> { "ranged" },
+                    IsRangedAttack = true
+                };
+                GameObject target = new GameObject("target");
+                target.AddComponent<CreatureComponent>();
 
-                Assert.DoesNotThrow(() => Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, projectileStrike));
-                Assert.AreEqual(0, projectileStrike.FlatDamages.Count);
+                StrikeResolutionContext context = StrikeResolutionContext.FromRequest(new StrikeResolutionRequest
+                {
+                    Attacker = creatureObject,
+                    Target = target,
+                    Profile = projectileStrike,
+                    TargetingResult = new StrikeTargetResult { Target = target, LineOfEffect = StrikeLineOfEffect.Clear, Cover = StrikeCover.None }
+                });
+                Assert.DoesNotThrow(() => Pf2eRulesEngine.ApplyPreparedStrikeAdjustments(context));
+                Assert.AreEqual(0, context.FlatDamages.Count);
+                UnityEngine.Object.DestroyImmediate(target);
             }
             finally
             {
@@ -349,6 +379,35 @@ namespace TestsCombat
             }
         }
 
+        private static GameObject CreateCombatCreature(string name, int hp)
+        {
+            GameObject creature = new GameObject(name);
+            CreatureComponent component = creature.AddComponent<CreatureComponent>();
+            creature.AddComponent<TestActionController>();
+            component.hp = hp;
+            component.maxHp = hp;
+            component.ac = 10;
+            component.attackBonus = 10;
+            component.weaknesses = new List<DamageValue>();
+            component.resistances = new List<DamageValue>();
+            return creature;
+        }
+
+        private static StrikeResolutionContext ResolveForContext(GameObject attacker, GameObject target, StrikeProfile profile)
+        {
+            return StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
+            {
+                Attacker = attacker,
+                Target = target,
+                Profile = profile,
+                TargetingResult = new StrikeTargetResult
+                {
+                    Target = target,
+                    LineOfEffect = StrikeLineOfEffect.Clear,
+                    Cover = StrikeCover.None
+                }
+            }).Context;
+        }
         private static Tile[,] BuildTiles(int width, int height)
         {
             Tile[,] tiles = new Tile[width, height];

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs
@@ -1,6 +1,7 @@
 using Game.AbilityActions;
 using Game.Creature;
 using Game.Creature.Rules;
+using GridPublic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -189,19 +190,19 @@ public class Pf2eRulesTests
         CreatureComponent creature = CreatePreparedBarbarian();
         Assert.That(new Rage(0).UseRage(creature.gameObject), Is.True);
 
-        Strike greataxe = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, greataxe);
-        Assert.That(greataxe.FlatDamages.Last().DamageAmount, Is.EqualTo(3));
+        StrikeProfile greataxe = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
+        StrikeResolutionContext greataxeContext = PrepareStrike(creature, greataxe);
+        Assert.That(greataxeContext.FlatDamages.Last().DamageAmount, Is.EqualTo(3));
 
-        Strike agile = new(new List<Dice> { new Dice(1, 4, "Bludgeoning") }, new List<DamageValue> { new DamageValue("Bludgeoning", 4) });
+        StrikeProfile agile = new(new List<Dice> { new Dice(1, 4, "Bludgeoning") }, new List<DamageValue> { new DamageValue("Bludgeoning", 4) });
         agile.Traits.Add("agile");
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, agile);
-        Assert.That(agile.FlatDamages.Last().DamageAmount, Is.EqualTo(1));
+        StrikeResolutionContext agileContext = PrepareStrike(creature, agile);
+        Assert.That(agileContext.FlatDamages.Last().DamageAmount, Is.EqualTo(1));
 
         new Rage(0).EndRage(creature.gameObject);
-        Strike notRaging = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, notRaging);
-        Assert.That(notRaging.FlatDamages.Count, Is.EqualTo(1));
+        StrikeProfile notRaging = new(new List<Dice> { new Dice(1, 12, "Slashing") }, new List<DamageValue> { new DamageValue("Slashing", 4) });
+        StrikeResolutionContext notRagingContext = PrepareStrike(creature, notRaging);
+        Assert.That(notRagingContext.FlatDamages.Count, Is.EqualTo(1));
     }
 
     [Test]
@@ -252,23 +253,23 @@ public class Pf2eRulesTests
     {
         CreatureComponent creature = CreatePreparedRogue();
 
-        Strike finesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
+        StrikeProfile finesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
         {
             Traits = new List<string> { "agile", "finesse" },
             ItemSlug = "dogslicer",
             WeaponCategory = "martial"
         };
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, finesseStrike);
-        Assert.That(finesseStrike.FlatDamages[0].DamageAmount, Is.EqualTo(creature.dexMod));
+        StrikeResolutionContext finesseContext = PrepareStrike(creature, finesseStrike);
+        Assert.That(finesseContext.FlatDamages[0].DamageAmount, Is.EqualTo(creature.dexMod));
 
-        Strike nonFinesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
+        StrikeProfile nonFinesseStrike = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", creature.strMod) })
         {
             Traits = new List<string> { "forceful" },
             ItemSlug = "scimitar",
             WeaponCategory = "martial"
         };
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(creature, nonFinesseStrike);
-        Assert.That(nonFinesseStrike.FlatDamages[0].DamageAmount, Is.EqualTo(creature.strMod));
+        StrikeResolutionContext nonFinesseContext = PrepareStrike(creature, nonFinesseStrike);
+        Assert.That(nonFinesseContext.FlatDamages[0].DamageAmount, Is.EqualTo(creature.strMod));
     }
 
     [Test]
@@ -277,26 +278,26 @@ public class Pf2eRulesTests
         CreatureComponent rogue = CreatePreparedRogue();
         CreatureComponent target = CreateTarget("Target");
 
-        Strike normalTarget = CreateDogslicerStrike(rogue);
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, normalTarget, target);
-        Assert.That(normalTarget.Damages.Count, Is.EqualTo(1));
+        StrikeProfile normalTarget = CreateDogslicerStrike(rogue);
+        StrikeResolutionContext normalContext = PrepareStrike(rogue, normalTarget, target);
+        Assert.That(normalContext.DamageDice.Count, Is.EqualTo(1));
 
         target.GetComponent<Conditions>().Add("Off-Guard", new ConditionSource());
-        Strike offGuardTarget = CreateDogslicerStrike(rogue);
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, offGuardTarget, target);
-        Assert.That(offGuardTarget.Damages.Count, Is.EqualTo(2));
-        Assert.That(offGuardTarget.Damages.Last().numberOfDice, Is.EqualTo(1));
-        Assert.That(offGuardTarget.Damages.Last().sidesPerDie, Is.EqualTo(6));
-        Assert.That(offGuardTarget.Damages.Last().damageType, Is.EqualTo("precision"));
+        StrikeProfile offGuardTarget = CreateDogslicerStrike(rogue);
+        StrikeResolutionContext offGuardContext = PrepareStrike(rogue, offGuardTarget, target);
+        Assert.That(offGuardContext.DamageDice.Count, Is.EqualTo(2));
+        Assert.That(offGuardContext.DamageDice.Last().numberOfDice, Is.EqualTo(1));
+        Assert.That(offGuardContext.DamageDice.Last().sidesPerDie, Is.EqualTo(6));
+        Assert.That(offGuardContext.DamageDice.Last().damageType, Is.EqualTo("precision"));
 
-        Strike ineligibleWeapon = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
+        StrikeProfile ineligibleWeapon = new(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
         {
             Traits = new List<string> { "forceful" },
             ItemSlug = "scimitar",
             WeaponCategory = "martial"
         };
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, ineligibleWeapon, target);
-        Assert.That(ineligibleWeapon.Damages.Count, Is.EqualTo(1));
+        StrikeResolutionContext ineligibleContext = PrepareStrike(rogue, ineligibleWeapon, target);
+        Assert.That(ineligibleContext.DamageDice.Count, Is.EqualTo(1));
     }
 
     [Test]
@@ -306,7 +307,7 @@ public class Pf2eRulesTests
         CreatureComponent target = CreateTarget("Flat-Footed Target");
         target.GetComponent<Conditions>().Add("Flat-Footed", new ConditionSource());
 
-        Strike shortbowStrike = new(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
+        StrikeProfile shortbowStrike = new(new List<Dice> { new Dice(1, 6, "piercing") }, new List<DamageValue>())
         {
             Traits = new List<string> { "deadly-d10" },
             ItemSlug = "shortbow",
@@ -314,14 +315,13 @@ public class Pf2eRulesTests
             IsRangedAttack = true
         };
 
-        Pf2eRulesEngine.ApplyStrikeDamageModifiers(rogue, shortbowStrike, target);
+        StrikeResolutionContext shortbowContext = PrepareStrike(rogue, shortbowStrike, target);
 
-        Assert.That(shortbowStrike.Damages.Count, Is.EqualTo(2));
-        Assert.That(shortbowStrike.Damages.Last().numberOfDice, Is.EqualTo(1));
-        Assert.That(shortbowStrike.Damages.Last().sidesPerDie, Is.EqualTo(6));
-        Assert.That(shortbowStrike.Damages.Last().damageType, Is.EqualTo("precision"));
+        Assert.That(shortbowContext.DamageDice.Count, Is.EqualTo(2));
+        Assert.That(shortbowContext.DamageDice.Last().numberOfDice, Is.EqualTo(1));
+        Assert.That(shortbowContext.DamageDice.Last().sidesPerDie, Is.EqualTo(6));
+        Assert.That(shortbowContext.DamageDice.Last().damageType, Is.EqualTo("precision"));
     }
-
     private CreatureComponent CreatePreparedBarbarian()
     {
         GameObject go = new("Prepared Barbarian");
@@ -372,9 +372,27 @@ public class Pf2eRulesTests
         return creature;
     }
 
-    private static Strike CreateDogslicerStrike(CreatureComponent rogue)
+    private StrikeResolutionContext PrepareStrike(CreatureComponent attacker, StrikeProfile profile, CreatureComponent target = null)
     {
-        return new Strike(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
+        CreatureComponent resolvedTarget = target ?? CreateTarget("Prepared Strike Target");
+        StrikeResolutionContext context = StrikeResolutionContext.FromRequest(new StrikeResolutionRequest
+        {
+            Attacker = attacker.gameObject,
+            Target = resolvedTarget.gameObject,
+            Profile = profile,
+            TargetingResult = new StrikeTargetResult
+            {
+                Target = resolvedTarget.gameObject,
+                LineOfEffect = StrikeLineOfEffect.Clear,
+                Cover = StrikeCover.None
+            }
+        });
+        Pf2eRulesEngine.ApplyPreparedStrikeAdjustments(context);
+        return context;
+    }
+    private static StrikeProfile CreateDogslicerStrike(CreatureComponent rogue)
+    {
+        return new StrikeProfile(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue> { new DamageValue("slashing", rogue.strMod) })
         {
             Traits = new List<string> { "agile", "finesse" },
             ItemSlug = "dogslicer",

--- a/Assets/Tests/PlayMode/TestsState/LenaRoguePlayModeTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/LenaRoguePlayModeTests.cs
@@ -49,12 +49,12 @@ namespace TestsState
             PrepareTarget(target, -10, 100);
             yield return ForceTurnAndClickAction(lena, "DogslicerButton");
 
-            Strike observed = null;
+            StrikeResolutionContext observed = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => observed = value);
 
             CreatureComponent creature = lena.GetComponent<CreatureComponent>();
             Assert.IsNotNull(observed);
-            Assert.That(observed.ItemSlug, Is.EqualTo("dogslicer"));
+            Assert.That(observed.Profile.ItemSlug, Is.EqualTo("dogslicer"));
             Assert.That(observed.Traits, Does.Contain("finesse"));
             Assert.That(observed.FlatDamages[0].DamageAmount, Is.EqualTo(creature.dexMod));
             Assert.That(lena.GetComponent<ActionController>().ActionPoints, Is.EqualTo(2u));
@@ -76,20 +76,20 @@ namespace TestsState
             PrepareTarget(target, -10, 100);
 
             yield return ForceTurnAndClickAction(lena, "DogslicerButton");
-            Strike normalStrike = null;
+            StrikeResolutionContext normalStrike = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => normalStrike = value);
-            Assert.That(normalStrike.Damages.Count, Is.EqualTo(1));
+            Assert.That(normalStrike.DamageDice.Count, Is.EqualTo(1));
 
             target.GetComponent<CreatureComponent>().hp = 100;
             target.GetComponent<Conditions>().Add("Off-Guard", new ConditionSource());
             yield return ForceTurnAndClickAction(lena, "DogslicerButton");
-            Strike offGuardStrike = null;
+            StrikeResolutionContext offGuardStrike = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => offGuardStrike = value);
 
-            Assert.That(offGuardStrike.Damages.Count, Is.EqualTo(2));
-            Assert.That(offGuardStrike.Damages[1].numberOfDice, Is.EqualTo(1));
-            Assert.That(offGuardStrike.Damages[1].sidesPerDie, Is.EqualTo(6));
-            Assert.That(offGuardStrike.Damages[1].damageType, Is.EqualTo("precision"));
+            Assert.That(offGuardStrike.DamageDice.Count, Is.EqualTo(2));
+            Assert.That(offGuardStrike.DamageDice[1].numberOfDice, Is.EqualTo(1));
+            Assert.That(offGuardStrike.DamageDice[1].sidesPerDie, Is.EqualTo(6));
+            Assert.That(offGuardStrike.DamageDice[1].damageType, Is.EqualTo("precision"));
         }
 
         [UnityTest]
@@ -109,12 +109,12 @@ namespace TestsState
             PrepareTarget(target, -10, 100);
 
             yield return ForceTurnAndClickAction(lena, "DogslicerButton");
-            Strike observed = null;
+            StrikeResolutionContext observed = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => observed = value);
 
             Assert.IsFalse(target.GetComponent<Conditions>().Contains("Off-Guard"), "Flanking should be contextual to the flankers, not a global target condition.");
-            Assert.That(observed.Damages.Count, Is.EqualTo(2));
-            Assert.That(observed.Damages[1].damageType, Is.EqualTo("precision"));
+            Assert.That(observed.DamageDice.Count, Is.EqualTo(2));
+            Assert.That(observed.DamageDice[1].damageType, Is.EqualTo("precision"));
             Assert.Less(target.GetComponent<CreatureComponent>().hp, 100);
         }
 
@@ -135,10 +135,10 @@ namespace TestsState
             PrepareTarget(target, -10, 100);
 
             yield return ForceTurnAndClickAction(lena, "DogslicerButton");
-            Strike observed = null;
+            StrikeResolutionContext observed = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => observed = value);
 
-            Assert.That(observed.Damages.Count, Is.EqualTo(1));
+            Assert.That(observed.DamageDice.Count, Is.EqualTo(1));
             Assert.IsFalse(target.GetComponent<Conditions>().Contains("Off-Guard"));
         }
 
@@ -159,11 +159,11 @@ namespace TestsState
             PrepareTarget(target, -10, 100);
 
             yield return ForceTurnAndClickAction(lena, "ShortbowButton");
-            Strike observed = null;
+            StrikeResolutionContext observed = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => observed = value);
 
-            Assert.That(observed.IsRangedAttack, Is.True);
-            Assert.That(observed.Damages.Count, Is.EqualTo(1));
+            Assert.That(observed.Profile.IsRangedAttack, Is.True);
+            Assert.That(observed.DamageDice.Count, Is.EqualTo(1));
             Assert.IsFalse(target.GetComponent<Conditions>().Contains("Off-Guard"));
         }
 
@@ -184,15 +184,15 @@ namespace TestsState
             CreatureComponent creature = lena.GetComponent<CreatureComponent>();
             int startingAmmo = creature.GetAmmoQuantity("arrows");
             yield return ForceTurnAndClickAction(lena, "ShortbowButton");
-            Strike observed = null;
+            StrikeResolutionContext observed = null;
             yield return ExecuteSelectedStrike(lena, targetCell, value => observed = value);
 
             Assert.IsNotNull(observed);
-            Assert.That(observed.ItemSlug, Is.EqualTo("shortbow"));
-            Assert.That(observed.IsRangedAttack, Is.True);
+            Assert.That(observed.Profile.ItemSlug, Is.EqualTo("shortbow"));
+            Assert.That(observed.Profile.IsRangedAttack, Is.True);
             Assert.That(observed.FlatDamages, Is.Empty);
-            Assert.That(observed.Damages.Count, Is.EqualTo(2));
-            Assert.That(observed.Damages[1].damageType, Is.EqualTo("precision"));
+            Assert.That(observed.DamageDice.Count, Is.EqualTo(2));
+            Assert.That(observed.DamageDice[1].damageType, Is.EqualTo("precision"));
             Assert.That(creature.GetAmmoQuantity("arrows"), Is.EqualTo(startingAmmo - 1));
             Assert.That(lena.GetComponent<ActionController>().ActionPoints, Is.EqualTo(2u));
             Assert.Less(target.GetComponent<CreatureComponent>().hp, 100);
@@ -273,26 +273,26 @@ namespace TestsState
             Assert.IsTrue(grid.Fsm.CurrentState is StateStrike);
         }
 
-        private IEnumerator ExecuteSelectedStrike(GameObject actor, Vector3Int targetCell, Action<Strike> assignObservedStrike)
+        private IEnumerator ExecuteSelectedStrike(GameObject actor, Vector3Int targetCell, Action<StrikeResolutionContext> assignObservedStrike)
         {
             GridBase grid = UnityEngine.Object.FindFirstObjectByType<GridBase>();
-            Strike observed = null;
-            UnityAction<Tuple<Strike, GameObject>> listener = evt =>
+            StrikeResolutionContext observed = null;
+            UnityAction<StrikeResolutionContext> listener = context =>
             {
-                if (evt.Item2 == actor)
-                    observed = evt.Item1;
+                if (context.AttackerObject == actor)
+                    observed = context;
             };
 
-            OnStrikeEvent.AddListener(listener);
+            OnStrikePreparedEvent.AddListener(listener);
             UnityEngine.Random.State randomState = UnityEngine.Random.state;
             UnityEngine.Random.InitState(7604);
             OnHover.Invoke(new List<Vector3Int> { targetCell });
             grid.Fsm.CurrentState.Leftclick();
             yield return WaitUntilWithTimeout(timeout, () => observed != null && !actor.GetComponent<ActionController>().IsTakingAction);
             UnityEngine.Random.state = randomState;
-            OnStrikeEvent.RemoveListener(listener);
+            OnStrikePreparedEvent.RemoveListener(listener);
 
-            Assert.IsNotNull(observed, "Expected Lena's Strike to execute through OnStrikeEvent.");
+            Assert.IsNotNull(observed, "Expected Lena's Strike to execute through OnStrikePreparedEvent.");
             assignObservedStrike(observed);
         }
 


### PR DESCRIPTION
## Summary
- Refactors Strike into a profile/context-driven resolution pipeline with ordered adjustment phases.
- Migrates weapon, unarmed, AI estimate, flanking, prepared-character damage, critical, fatal, deadly, and critical specialization behavior onto the pipeline.
- Integrates the pipeline with main's structured combat log and damage-resolution model while preserving the new area-targeting/logging changes from main.
- Updates Strike-related EditMode and PlayMode tests to assert the new pipeline APIs and parity behavior.

## Validation
- EditMode: 61/61 passed
- PlayMode: 42/42 passed
- `git diff --check` passed

## Notes
- This intentionally switches existing Strike callers to the new approach without preserving the old Strike damage API.
