### PR TITLE
[Rules] Add Cleric spellcasting foundation

### DIFF
--- a/Assets/Resources/Data/class.json
+++ b/Assets/Resources/Data/class.json
@@ -49,8 +49,8 @@
         "allArmor": "Untrained"
       },
       "spells": "available",
-      "subclass": ["Cloistered", "Warpriest"],
-      "classFeat": ["Deadly Simplicity", "Divine Castigation", "Domain Initiate", "Harming Hands", "Healing Hands", "Premonition of Avoidance", "Reach Spell"]
+      "subclass": ["Cloistered Cleric"],
+      "classFeat": ["Domain Initiate"]
     },
     {
       "id": "Rogue",

--- a/Assets/Resources/DataFiles/classes/cleric.json
+++ b/Assets/Resources/DataFiles/classes/cleric.json
@@ -1,0 +1,213 @@
+{
+    "_id": "EizrWvUPMS67Pahd",
+    "img": "systems/pf2e/icons/classes/cleric.webp",
+    "name": "Cleric",
+    "system": {
+        "ancestryFeatLevels": {
+            "value": [
+                1,
+                5,
+                9,
+                13,
+                17
+            ]
+        },
+        "attacks": {
+            "advanced": 0,
+            "martial": 0,
+            "other": {
+                "name": "Deity's favored weapon",
+                "rank": 1
+            },
+            "simple": 1,
+            "unarmed": 1
+        },
+        "classFeatLevels": {
+            "value": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20
+            ]
+        },
+        "defenses": {
+            "heavy": 0,
+            "light": 0,
+            "medium": 0,
+            "unarmored": 1
+        },
+        "description": {
+            "value": "<p><em>Deities work their will upon the world in infinite ways, and you serve as one of their most stalwart mortal servants. Blessed with divine magic, you live the ideals of your faith, adorn yourself with the symbols of your church, and train diligently to wield your deity's favored weapon. Your spells might protect and heal your allies, or they might punish foes and enemies of your faith, as your deity wills. Yours is a life of devotion, spreading the teachings of your faith through both word and deed.</em></p>\n<p><em>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.N4ABcd6CcCbqmw3x]{Cleric}</em></p>"
+        },
+        "generalFeatLevels": {
+            "value": [
+                3,
+                7,
+                11,
+                15,
+                19
+            ]
+        },
+        "hp": 8,
+        "items": {
+            "365ut": {
+                "img": "systems/pf2e/icons/features/classes/deity.webp",
+                "level": 1,
+                "name": "Deity",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Deity (Cleric)"
+            },
+            "4eQbl": {
+                "img": "icons/weapons/axes/axe-double-gold.webp",
+                "level": 1,
+                "name": "Cleric Spellcasting",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Cleric Spellcasting"
+            },
+            "5lsvf": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 1,
+                "name": "Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Doctrine"
+            },
+            "6j8f7": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 1,
+                "name": "First Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.First Doctrine"
+            },
+            "7gkd0": {
+                "img": "icons/magic/fire/flame-burning-hand-white.webp",
+                "level": 1,
+                "name": "Divine Font",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Divine Font"
+            },
+            "Awo2e": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 3,
+                "name": "Second Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Second Doctrine"
+            },
+            "BhM5T": {
+                "img": "icons/creatures/eyes/human-single-blue.webp",
+                "level": 5,
+                "name": "Perception Expertise",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Perception Expertise"
+            },
+            "Czcka": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 7,
+                "name": "Third Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Third Doctrine"
+            },
+            "GUa4t": {
+                "img": "icons/magic/holy/chalice-glowing-gold.webp",
+                "level": 9,
+                "name": "Resolute Faith",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Resolute Faith"
+            },
+            "abLjR": {
+                "img": "icons/magic/symbols/symbol-lightning-bolt.webp",
+                "level": 11,
+                "name": "Reflex Expertise",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
+            },
+            "ckmdj": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 11,
+                "name": "Fourth Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Fourth Doctrine"
+            },
+            "de44z": {
+                "img": "icons/creatures/abilities/wings-birdlike-blue.webp",
+                "level": 13,
+                "name": "Divine Defense",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Divine Defense"
+            },
+            "r47we": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 15,
+                "name": "Fifth Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Fifth Doctrine"
+            },
+            "vrd25": {
+                "img": "systems/pf2e/icons/features/classes/weapon-specialization.webp",
+                "level": 13,
+                "name": "Weapon Specialization",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Specialization"
+            },
+            "x2puy": {
+                "img": "icons/magic/symbols/question-stone-yellow.webp",
+                "level": 19,
+                "name": "Final Doctrine",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Final Doctrine"
+            },
+            "zmpzh": {
+                "img": "icons/magic/symbols/star-rising-purple.webp",
+                "level": 19,
+                "name": "Miraculous Spell",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Miraculous Spell"
+            }
+        },
+        "keyAbility": {
+            "value": [
+                "wis"
+            ]
+        },
+        "perception": 1,
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [],
+        "savingThrows": {
+            "fortitude": 1,
+            "reflex": 1,
+            "will": 2
+        },
+        "skillFeatLevels": {
+            "value": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20
+            ]
+        },
+        "skillIncreaseLevels": {
+            "value": [
+                3,
+                5,
+                7,
+                9,
+                11,
+                13,
+                15,
+                17,
+                19
+            ]
+        },
+        "spellcasting": 1,
+        "trainedSkills": {
+            "additional": 2,
+            "value": [
+                "religion"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "class"
+}

--- a/Assets/Resources/DataFiles/classes/cleric.json.meta
+++ b/Assets/Resources/DataFiles/classes/cleric.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aef23066ea17446c94e7577cfa232e30
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/cleric-spellcasting.json
+++ b/Assets/Resources/DataFiles/classfeatures/cleric-spellcasting.json
@@ -1,0 +1,36 @@
+{
+    "_id": "AvNbdGSOTWNRgcxs",
+    "img": "icons/weapons/axes/axe-double-gold.webp",
+    "name": "Cleric Spellcasting",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your deity bestows on you the power to cast divine spells. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As a cleric, your chants generally invoke your deity and their powerful servants by name or title, while your gestures are followed by sacred symbols or other representations of your deity.</p>\n<p>At 1st level, you can prepare two 1st-rank spells and five cantrips each morning from the common spells on the divine spell list or from other divine spells to which you gain access and learn via Learn a Spell. Prepared spells remain available to you until you cast them or until you prepare your spells again. The number of spells you can prepare each day is called your spell slots.</p>\n<p>As you increase in level as a cleric, the number of spells you can prepare each day increases, as does the highest rank of spell you can cast, as shown in Cleric Spells per Day table above.</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are or for your enemies to roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Wisdom, your spell attack modifier and spell DC use your Wisdom modifier.</p>\n<h2>Heightening Spells</h2>\n<p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. Many spells have specific improvements when they are heightened to certain ranks.</p>\n<h2>Cantrips</h2>\n<p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is always automatically heightened to half your level rounded up—this is usually equal to the highest rank of cleric spell slot you have. For example, as a 1st-level cleric, your cantrips are 1st-rank spells, and as a 5th-level cleric, your cantrips are 3rd-rank spells.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/cleric-spellcasting.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/cleric-spellcasting.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e146a3133f644b65bcd5520af0d16860
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/cloistered-cleric.json
+++ b/Assets/Resources/DataFiles/classfeatures/cloistered-cleric.json
@@ -1,0 +1,53 @@
+{
+    "_id": "ZZzLMOUAtBVgV1DF",
+    "img": "icons/magic/light/orb-hands-humanoid-yellow.webp",
+    "name": "Cloistered Cleric",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You are a cleric of the cloth, focusing on divine magic and your connection to your deity's domains.</p>\n<p><strong>First Doctrine (1st):</strong> You gain the @UUID[Compendium.pf2e.feats-srd.Item.Domain Initiate] cleric feat.</p>\n<p><strong>Second Doctrine (3rd):</strong> Your proficiency rank for Fortitude saves increases to expert.</p>\n<p><strong>Third Doctrine (7th):</strong> Your proficiency ranks for the spell attack modifier and spell DC statistics increase to expert.</p>\n<p><strong>Fourth Doctrine (11th):</strong> You gain expert proficiency with your deity's favored weapon, simple weapons, and unarmed attacks. When you critically succeed at an attack roll using your deity's favored weapon, you apply the weapon's critical specialization effect; you can use your spell DC in place of your class DC.</p>\n<p><strong>Fifth Doctrine (15th):</strong> Your proficiency ranks for the spell attack modifier and spell DC statistics increase to master.</p>\n<p><strong>Final Doctrine (19th):</strong> Your proficiency ranks for the spell attack modifier and spell DC statistics increase to legendary.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.system.cleric",
+                "value": {
+                    "fifthDoctrine": "Compendium.pf2e.classfeatures.Item.Fifth Doctrine (Cloistered Cleric)",
+                    "finalDoctrine": "Compendium.pf2e.classfeatures.Item.Final Doctrine (Cloistered Cleric)",
+                    "firstDoctrine": "Compendium.pf2e.classfeatures.Item.First Doctrine (Cloistered Cleric)",
+                    "fourthDoctrine": "Compendium.pf2e.classfeatures.Item.Fourth Doctrine (Cloistered Cleric)",
+                    "secondDoctrine": "Compendium.pf2e.classfeatures.Item.Second Doctrine (Cloistered Cleric)",
+                    "thirdDoctrine": "Compendium.pf2e.classfeatures.Item.Third Doctrine (Cloistered Cleric)"
+                }
+            }
+        ],
+        "traits": {
+            "otherTags": [
+                "cleric-doctrine"
+            ],
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/cloistered-cleric.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/cloistered-cleric.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0d256e87cf6646d1bdd3fcbc613215c1
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/deity-cleric.json
+++ b/Assets/Resources/DataFiles/classfeatures/deity-cleric.json
@@ -1,0 +1,162 @@
+{
+    "_id": "DutW12WMFPHBoLTH",
+    "img": "systems/pf2e/icons/features/classes/deity.webp",
+    "name": "Deity (Cleric)",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>As a cleric, you are a mortal servitor of a deity you revere above all others. Your deity grants you the trained proficiency rank in one skill and with the deity's favored weapon. If the favored weapon is uncommon, you also get access to that weapon.</p>\n<p>Your deity also adds spells to your spell list. You can prepare these just like you can any spell on the divine spell list once you can prepare spells of their rank as a cleric. Any of these spells that aren't normally on the divine list are still divine spells if you prepare them this way.</p>\n<h2>Sanctification</h2>\n<p>Depending on your deity, their sanctification can make you holy or unholy. This gives you the holy or unholy trait, which commits you to one side of a struggle over the souls of the planes and may be referenced in other abilities. If you \"can be\" holy or unholy according to your deity, you make that choice, and if you \"must be\" holy or unholy you gain the trait automatically. If you gain the opposing trait in some way, you lose the previous trait until you complete an atone ritual.</p>\n<h2>Anathema</h2>\n<p>Acts fundamentally opposed to your deity's ideals are anathema to your faith. Learning or casting spells, committing acts, and using items that are anathema to your deity remove you from your deity's good graces.</p>\n<p>Casting spells with the unholy trait is almost always anathema to deities who don't allow unholy sanctification, and casting holy spells is likewise anathema to those who don't allow holy sanctification. Similarly, casting spells that are anathema to the tenets or goals of your faith could interfere with your connection to your deity. For example, casting a spell to create undead would be anathema to Pharasma, the goddess of death. Many actions that are anathema don't appear in any deity's formal list. For borderline cases, you and your GM determine which acts are anathema.</p>\n<p>If you perform enough acts that are anathema to your deity, you lose the magical abilities that come from your connection to your deity. The class features that you lose are determined by the GM, but they likely include your divine font and all cleric spellcasting. These abilities can be regained only if you repent by conducting an atone ritual.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": {
+                    "filter": [
+                        {
+                            "or": [
+                                "item:category:deity",
+                                "item:category:pantheon",
+                                "item:category:covenant"
+                            ]
+                        }
+                    ],
+                    "itemType": "deity"
+                },
+                "flag": "deity",
+                "key": "ChoiceSet",
+                "predicate": [
+                    {
+                        "not": "deity"
+                    }
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Deity"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    {
+                        "not": "deity"
+                    }
+                ],
+                "uuid": "{item|flags.system.rulesSelections.deity}"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.TraitHoly",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "deity:primary:sanctification:can:holy",
+                                    "deity:primary:sanctification:must:holy"
+                                ]
+                            }
+                        ],
+                        "value": "holy"
+                    },
+                    {
+                        "label": "PF2E.TraitUnholy",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "deity:primary:sanctification:can:unholy",
+                                    "deity:primary:sanctification:must:unholy"
+                                ]
+                            }
+                        ],
+                        "value": "unholy"
+                    },
+                    {
+                        "label": "PF2E.NoneOption",
+                        "predicate": [
+                            {
+                                "nor": [
+                                    "deity:primary:sanctification:must:holy",
+                                    "deity:primary:sanctification:must:unholy"
+                                ]
+                            }
+                        ],
+                        "value": "none"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "predicate": [
+                    {
+                        "nor": [
+                            "sanctification:none",
+                            "sanctification:holy",
+                            "sanctification:unholy"
+                        ]
+                    }
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Sanctification",
+                "rollOption": "sanctification",
+                "slug": "sanctification"
+            },
+            {
+                "add": [
+                    "holy"
+                ],
+                "key": "ActorTraits",
+                "predicate": [
+                    "sanctification:holy"
+                ]
+            },
+            {
+                "add": [
+                    "unholy"
+                ],
+                "key": "ActorTraits",
+                "predicate": [
+                    "sanctification:unholy"
+                ]
+            },
+            {
+                "fist": true,
+                "key": "Strike",
+                "predicate": [
+                    "deity:primary:favored-weapon:fist"
+                ]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.system.favoredWeaponRank",
+                "predicate": [
+                    "class:cleric"
+                ],
+                "value": 1
+            }
+        ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/deity-cleric.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/deity-cleric.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95b8110d7ee848cb8973d63976c60ed2
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/divine-font.json
+++ b/Assets/Resources/DataFiles/classfeatures/divine-font.json
@@ -1,0 +1,61 @@
+{
+    "_id": "gblTFUOgolqFS9v4",
+    "img": "icons/magic/fire/flame-burning-hand-white.webp",
+    "name": "Divine Font",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Through your deity's blessing, you gain additional spells that channel either the life force called vitality or its counterforce, the void. When you prepare your spells each day, you can prepare additional @UUID[Compendium.pf2e.spells-srd.Item.Heal] or @UUID[Compendium.pf2e.spells-srd.Item.Harm] spells, depending on your deity. The divine font spell your deity provides is listed in the Divine Font entry for your deity; if both are listed, you can choose between <em>heal</em> or <em>harm</em>. Once you choose, you can't change your choice short of divine intervention.</p>\n<p><strong>Healing Font:</strong> You gain 4 additional spell slots each day at your highest rank of cleric spell slots. You can prepare only <em>heal</em> spells in these slots. At 5th level, the number of additional slots increases to 5, and at 15th level, the total number of additional slots increases to 6.</p>\n<p><strong>Harmful Font:</strong> You gain 4 additional spell slots each day at your highest rank of cleric spell slots. You can prepare only <em>harm</em> spells in these slots. At 5th level, the number of additional slots increases to 5, and at 15th level, the total number of additional slots increases to 6.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "img": "icons/magic/life/cross-worn-green.webp",
+                        "label": "PF2E.SpecificRule.Cleric.DivineFont.Healing",
+                        "predicate": [
+                            "deity:primary:font:heal"
+                        ],
+                        "value": "heal"
+                    },
+                    {
+                        "img": "systems/pf2e/icons/spells/harm.webp",
+                        "label": "PF2E.SpecificRule.Cleric.DivineFont.Harmful",
+                        "predicate": [
+                            "deity:primary:font:harm"
+                        ],
+                        "value": "harm"
+                    }
+                ],
+                "flag": "divineFont",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Cleric.DivineFont.Prompt",
+                "rollOption": "divine-font"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/divine-font.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/divine-font.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60dc8233d00f482f80a1dd2c8a326dcb
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/doctrine.json
+++ b/Assets/Resources/DataFiles/classfeatures/doctrine.json
@@ -1,0 +1,52 @@
+{
+    "_id": "tyrBwBTzo5t9Zho7",
+    "img": "icons/magic/symbols/question-stone-yellow.webp",
+    "name": "Doctrine",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Even among followers of the same deity, approaches vary. At 1st level, you select cloistered cleric or warpriest and gain the benefits of its first doctrine. At 3rd level and every four levels thereafter, you gain another benefit from your doctrine.</p>\n<ul>\n<li>@UUID[Compendium.pf2e.classfeatures.Item.Cloistered Cleric]</li>\n<li>@UUID[Compendium.pf2e.classfeatures.Item.Warpriest]</li>\n</ul>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:cleric-doctrine"
+                    ]
+                },
+                "flag": "doctrine",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Cleric.Doctrine.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.system.rulesSelections.doctrine}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/doctrine.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/doctrine.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb9fd417c2814f31a3186ff1e38a07a3
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/first-doctrine-cloistered-cleric.json
+++ b/Assets/Resources/DataFiles/classfeatures/first-doctrine-cloistered-cleric.json
@@ -1,0 +1,41 @@
+{
+    "_id": "aiwxBj5MjnafCMyn",
+    "img": "icons/magic/light/orb-hands-humanoid-yellow.webp",
+    "name": "First Doctrine (Cloistered Cleric)",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You gain the @UUID[Compendium.pf2e.feats-srd.Item.Domain Initiate] cleric feat.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.feats-srd.Item.Domain Initiate"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/first-doctrine-cloistered-cleric.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/first-doctrine-cloistered-cleric.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2ec59da05624734a5f6d7b8beede351
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/classfeatures/first-doctrine.json
+++ b/Assets/Resources/DataFiles/classfeatures/first-doctrine.json
@@ -1,0 +1,41 @@
+{
+    "_id": "Qejo7FUWQtPTpgWH",
+    "img": "icons/magic/symbols/question-stone-yellow.webp",
+    "name": "First Doctrine",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You gain the first benefit of your doctrine:</p>\n<ul>\n<li>@UUID[Compendium.pf2e.classfeatures.Item.First Doctrine (Cloistered Cleric)]{Cloistered Cleric}</li>\n<li>@UUID[Compendium.pf2e.classfeatures.Item.First Doctrine (Warpriest)]{Warpriest}</li>\n</ul>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "{actor|flags.system.cleric.firstDoctrine}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/classfeatures/first-doctrine.json.meta
+++ b/Assets/Resources/DataFiles/classfeatures/first-doctrine.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74b73d7067a94e81bbaa2fcce9ad0333
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/cleric.meta
+++ b/Assets/Resources/DataFiles/feats/class/cleric.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 116fc7030cf142ac91ef6ef309f1d247
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/feats/class/cleric/domain-initiate.json
+++ b/Assets/Resources/DataFiles/feats/class/cleric/domain-initiate.json
@@ -1,0 +1,51 @@
+{
+    "_id": "hT4INKGtly4QY8KN",
+    "folder": "J4qk5NbwDuKa9WWz",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "Domain Initiate",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "class",
+        "description": {
+            "value": "<p>Your deity bestows a special spell related to their powers. Select one domain—a subject of particular interest to you within your religion—from your deity's list. You gain an initial domain spell for that domain, a spell unique to the domain and not available to other clerics.</p>\n<p>Domain spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell, and you start with a focus pool of 1 Focus Point. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to pray to your deity or do service toward their causes.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and can't be cast using spell slots. Your focus pool can hold one Focus Point for each focus spell you have, up to 3 points.</p>\n<hr />\n<p><strong>Special</strong> You can select this feat multiple times, selecting a different domain each time and gaining its domain spell.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "maxTakable": null,
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": "system.details.deities.domains",
+                "flag": "domainInitiate",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.DeitysDomain"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.soulWarden.featCount",
+                "value": 1
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "cleric"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/Assets/Resources/DataFiles/feats/class/cleric/domain-initiate.json.meta
+++ b/Assets/Resources/DataFiles/feats/class/cleric/domain-initiate.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 45c89313b600456c952fdda4e91f6692
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/spells/1st-rank/bless.json
+++ b/Assets/Resources/DataFiles/spells/1st-rank/bless.json
@@ -1,56 +1,58 @@
 {
-  "name": "Bless",
-  "system": {
-    "area": {
-      "type": "emanation",
-      "value": 15
+    "_id": "XSujb7EsSwKl19Uu",
+    "folder": "T8AzYUgNIAgTJ9Iz",
+    "img": "systems/pf2e/icons/spells/bless.webp",
+    "name": "Bless",
+    "system": {
+        "area": {
+            "type": "emanation",
+            "value": 15
+        },
+        "cost": {
+            "value": ""
+        },
+        "counteraction": true,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>Blessings from beyond help your companions strike true. You and your allies gain a +1 status bonus to attack rolls while within the emanation. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet.</p>\n<p>Bless can counteract @UUID[Compendium.pf2e.spells-srd.Item.Bane].</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Bless]</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": "1 minute"
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": ""
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": "you and allies in the area"
+        },
+        "time": {
+            "value": "2"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "divine",
+                "occult"
+            ],
+            "value": [
+                "aura",
+                "concentrate",
+                "manipulate",
+                "mental"
+            ]
+        }
     },
-    "cost": {
-      "value": ""
-    },
-    "counteraction": true,
-    "damage": {},
-    "defense": null,
-    "description": {
-      "value": "<p>Blessings from beyond help your companions strike true. You and your allies gain a +1 status bonus to attack rolls while within the emanation. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet.</p>\n<p>Bless can counteract @UUID[Compendium.pf2e.spells-srd.Item.Bane].</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Aura: Bless]</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": "1 minute"
-    },
-    "level": {
-      "value": 1
-    },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": ""
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": "you and allies in the area"
-    },
-    "time": {
-      "value": "2"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "divine",
-        "occult"
-      ],
-      "value": [
-        "aura",
-        "concentrate",
-        "manipulate",
-        "mental"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/1st-rank"
+    "type": "spell"
 }

--- a/Assets/Resources/DataFiles/spells/1st-rank/heal.json
+++ b/Assets/Resources/DataFiles/spells/1st-rank/heal.json
@@ -1,187 +1,189 @@
 {
-  "name": "Heal",
-  "system": {
-    "area": null,
-    "cost": {
-      "value": ""
-    },
-    "counteraction": false,
-    "damage": {
-      "0": {
-        "applyMod": false,
-        "category": null,
-        "formula": "1d8",
-        "kinds": [
-          "damage",
-          "healing"
-        ],
-        "materials": [],
-        "type": "vitality"
-      }
-    },
-    "defense": {
-      "save": {
-        "basic": true,
-        "statistic": "fortitude"
-      }
-    },
-    "description": {
-      "value": "<p>You channel vital energy to heal the living or damage the undead. If the target is a willing living creature, you restore 1d8 Hit Points. If the target is undead, you deal that amount of vitality damage to it, and it gets a basic Fortitude save. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"action-glyph\">1</span> The spell has a range of touch.</p>\n<p><span class=\"action-glyph\">2</span> <strong>(concentrate)</strong> The spell has a range of 30 feet. If you're healing a living creature, increase the Hit Points restored by 8.</p>\n<p><span class=\"action-glyph\">3</span> <strong>(concentrate)</strong> You disperse vital energy in a @Template[emanation|distance:30]. This targets all living and undead creatures in the burst.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": ""
-    },
-    "heightening": {
-      "damage": {
-        "0": "1d8"
-      },
-      "interval": 1,
-      "type": "interval"
-    },
-    "level": {
-      "value": 1
-    },
-    "overlays": {
-      "37gy7l19tik74o4s": {
-        "_id": "37gy7l19tik74o4s",
-        "name": "Heal (vs. Living)",
-        "overlayType": "override",
-        "sort": 2,
-        "system": {
-          "damage": {
-            "0": {
-              "formula": "1d8+8",
-              "kinds": [
-                "healing"
-              ]
-            }
-          },
-          "defense": null,
-          "heightening": {
-            "damage": {
-              "0": "1d8+8"
-            }
-          },
-          "range": {
-            "value": "30 feet"
-          },
-          "time": {
-            "value": "2"
-          },
-          "traits": {
-            "value": [
-              "concentrate",
-              "healing",
-              "manipulate",
-              "vitality"
-            ]
-          }
-        }
-      },
-      "7qdtetowq348s9oc": {
-        "_id": "7qdtetowq348s9oc",
-        "overlayType": "override",
-        "sort": 1,
-        "system": {
-          "range": {
-            "value": "touch"
-          },
-          "time": {
-            "value": "1"
-          }
-        }
-      },
-      "7vbvdrv2cl87sqta": {
-        "_id": "7vbvdrv2cl87sqta",
-        "overlayType": "override",
-        "sort": 4,
-        "system": {
-          "area": {
-            "type": "emanation",
-            "value": 30
-          },
-          "range": {
+    "_id": "rfZpqmj0AIIdkVIs",
+    "folder": "T8AzYUgNIAgTJ9Iz",
+    "img": "icons/magic/life/cross-worn-green.webp",
+    "name": "Heal",
+    "system": {
+        "area": null,
+        "cost": {
             "value": ""
-          },
-          "target": {
-            "value": "all living and undead creatures"
-          },
-          "time": {
-            "value": "3"
-          },
-          "traits": {
-            "value": [
-              "concentrate",
-              "healing",
-              "manipulate",
-              "vitality"
-            ]
-          }
-        }
-      },
-      "lfxcoz2d3f8j2zq1": {
-        "_id": "lfxcoz2d3f8j2zq1",
-        "name": "Heal (vs. Undead)",
-        "overlayType": "override",
-        "sort": 3,
-        "system": {
-          "damage": {
+        },
+        "counteraction": false,
+        "damage": {
             "0": {
-              "kinds": [
-                "damage"
-              ]
+                "applyMod": false,
+                "category": null,
+                "formula": "1d8",
+                "kinds": [
+                    "damage",
+                    "healing"
+                ],
+                "materials": [],
+                "type": "vitality"
             }
-          },
-          "range": {
-            "value": "30 feet"
-          },
-          "target": {
-            "value": "1 undead"
-          },
-          "time": {
-            "value": "2"
-          },
-          "traits": {
+        },
+        "defense": {
+            "save": {
+                "basic": true,
+                "statistic": "fortitude"
+            }
+        },
+        "description": {
+            "value": "<p>You channel vital energy to heal the living or damage the undead. If the target is a willing living creature, you restore 1d8 Hit Points. If the target is undead, you deal that amount of vitality damage to it, and it gets a basic Fortitude save. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"action-glyph\">1</span> The spell has a range of touch.</p>\n<p><span class=\"action-glyph\">2</span> (concentrate) The spell has a range of 30 feet. If you're healing a living creature, increase the Hit Points restored by 8.</p>\n<p><span class=\"action-glyph\">3</span> (concentrate) You disperse vital energy in a @Template[emanation|distance:30]. This targets all living and undead creatures in the burst.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": ""
+        },
+        "heightening": {
+            "damage": {
+                "0": "1d8"
+            },
+            "interval": 1,
+            "type": "interval"
+        },
+        "level": {
+            "value": 1
+        },
+        "overlays": {
+            "37gy7l19tik74o4s": {
+                "_id": "37gy7l19tik74o4s",
+                "name": "Heal (vs. Living)",
+                "overlayType": "override",
+                "sort": 2,
+                "system": {
+                    "damage": {
+                        "0": {
+                            "formula": "1d8+8",
+                            "kinds": [
+                                "healing"
+                            ]
+                        }
+                    },
+                    "defense": null,
+                    "heightening": {
+                        "damage": {
+                            "0": "1d8+8"
+                        }
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "time": {
+                        "value": "2"
+                    },
+                    "traits": {
+                        "value": [
+                            "concentrate",
+                            "healing",
+                            "manipulate",
+                            "vitality"
+                        ]
+                    }
+                }
+            },
+            "7qdtetowq348s9oc": {
+                "_id": "7qdtetowq348s9oc",
+                "overlayType": "override",
+                "sort": 1,
+                "system": {
+                    "range": {
+                        "value": "touch"
+                    },
+                    "time": {
+                        "value": "1"
+                    }
+                }
+            },
+            "7vbvdrv2cl87sqta": {
+                "_id": "7vbvdrv2cl87sqta",
+                "overlayType": "override",
+                "sort": 4,
+                "system": {
+                    "area": {
+                        "type": "emanation",
+                        "value": 30
+                    },
+                    "range": {
+                        "value": ""
+                    },
+                    "target": {
+                        "value": "all living and undead creatures"
+                    },
+                    "time": {
+                        "value": "3"
+                    },
+                    "traits": {
+                        "value": [
+                            "concentrate",
+                            "healing",
+                            "manipulate",
+                            "vitality"
+                        ]
+                    }
+                }
+            },
+            "lfxcoz2d3f8j2zq1": {
+                "_id": "lfxcoz2d3f8j2zq1",
+                "name": "Heal (vs. Undead)",
+                "overlayType": "override",
+                "sort": 3,
+                "system": {
+                    "damage": {
+                        "0": {
+                            "kinds": [
+                                "damage"
+                            ]
+                        }
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "target": {
+                        "value": "1 undead"
+                    },
+                    "time": {
+                        "value": "2"
+                    },
+                    "traits": {
+                        "value": [
+                            "concentrate",
+                            "healing",
+                            "manipulate",
+                            "vitality"
+                        ]
+                    }
+                }
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": "varies"
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": "1 willing living creature or 1 undead"
+        },
+        "time": {
+            "value": "1 to 3"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "divine",
+                "primal"
+            ],
             "value": [
-              "concentrate",
-              "healing",
-              "manipulate",
-              "vitality"
+                "healing",
+                "manipulate",
+                "vitality"
             ]
-          }
         }
-      }
     },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": "varies"
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": "1 willing living creature or 1 undead"
-    },
-    "time": {
-      "value": "1 to 3"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "divine",
-        "primal"
-      ],
-      "value": [
-        "healing",
-        "manipulate",
-        "vitality"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/1st-rank"
+    "type": "spell"
 }

--- a/Assets/Resources/DataFiles/spells/1st-rank/infuse-vitality.json
+++ b/Assets/Resources/DataFiles/spells/1st-rank/infuse-vitality.json
@@ -1,55 +1,57 @@
 {
-  "name": "Infuse Vitality",
-  "system": {
-    "area": null,
-    "cost": {
-      "value": ""
+    "_id": "2iQKhCQBijhj5Rf3",
+    "folder": "T8AzYUgNIAgTJ9Iz",
+    "img": "icons/weapons/swords/sword-gold-holy.webp",
+    "name": "Infuse Vitality",
+    "system": {
+        "area": null,
+        "cost": {
+            "value": ""
+        },
+        "counteraction": false,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>You empower attacks with vital energy. The number of targets is equal to the number of actions you spent casting this spell. Each target's unarmed and weapon Strikes deal an extra 1d4 vitality damage. (This damage typically damages only undead). If you have the holy trait, you can add that trait to this spell and to the Strikes affected by the spell.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> The damage increases to 2d4 damage.</p>\n<p><strong>Heightened (5th)</strong> The damage increases to 3d4 damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Infuse Vitality]</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": "1 minute"
+        },
+        "heightening": {
+            "levels": {},
+            "type": "fixed"
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": "30 feet"
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": "1 to 3 willing creatures"
+        },
+        "time": {
+            "value": "1 to 3"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "divine"
+            ],
+            "value": [
+                "concentrate",
+                "manipulate",
+                "vitality"
+            ]
+        }
     },
-    "counteraction": false,
-    "damage": {},
-    "defense": null,
-    "description": {
-      "value": "<p>You empower attacks with vital energy. The number of targets is equal to the number of actions you spent casting this spell. Each target's unarmed and weapon Strikes deal an extra 1d4 vitality damage. (This damage typically damages only undead). If you have the holy trait, you can add that trait to this spell and to the Strikes affected by the spell.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> The damage increases to 2d4 damage.</p>\n<p><strong>Heightened (5th)</strong> The damage increases to 3d4 damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Infuse Vitality]</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": "1 minute"
-    },
-    "heightening": {
-      "levels": {},
-      "type": "fixed"
-    },
-    "level": {
-      "value": 1
-    },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": "30 feet"
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": "1 to 3 willing creatures"
-    },
-    "time": {
-      "value": "1 to 3"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "divine"
-      ],
-      "value": [
-        "concentrate",
-        "manipulate",
-        "vitality"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/1st-rank"
+    "type": "spell"
 }

--- a/Assets/Resources/DataFiles/spells/cantrip/guidance.json
+++ b/Assets/Resources/DataFiles/spells/cantrip/guidance.json
@@ -1,52 +1,54 @@
 {
-  "name": "Guidance",
-  "system": {
-    "area": null,
-    "cost": {
-      "value": ""
+    "_id": "izcxFQFwf3woCnFs",
+    "folder": "D7UVaOiB40wTR6kv",
+    "img": "systems/pf2e/icons/spells/guidance.webp",
+    "name": "Guidance",
+    "system": {
+        "area": null,
+        "cost": {
+            "value": ""
+        },
+        "counteraction": false,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>You ask for the guidance of supernatural entities, granting the target a +1 status bonus to one attack roll, Perception check, saving throw, or skill check the target attempts before the duration ends. The target chooses which roll to use the bonus on before rolling. If the target uses the bonus, the spell ends. Either way, the target is then temporarily immune for 1 hour.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Guidance]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Guidance Immunity]</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": "until the start of your next turn"
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": "30 feet"
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": "1 creature"
+        },
+        "time": {
+            "value": "1"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "divine",
+                "occult",
+                "primal"
+            ],
+            "value": [
+                "cantrip",
+                "concentrate"
+            ]
+        }
     },
-    "counteraction": false,
-    "damage": {},
-    "defense": null,
-    "description": {
-      "value": "<p>You ask for the guidance of supernatural entities, granting the target a +1 status bonus to one attack roll, Perception check, saving throw, or skill check the target attempts before the duration ends. The target chooses which roll to use the bonus on before rolling. If the target uses the bonus, the spell ends. Either way, the target is then temporarily immune for 1 hour.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Guidance]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Guidance Immunity]</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": "until the start of your next turn"
-    },
-    "level": {
-      "value": 1
-    },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": "30 feet"
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": "1 creature"
-    },
-    "time": {
-      "value": "1"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "divine",
-        "occult",
-        "primal"
-      ],
-      "value": [
-        "cantrip",
-        "concentrate"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/cantrip"
+    "type": "spell"
 }

--- a/Assets/Resources/DataFiles/spells/cantrip/haunting-hymn.json
+++ b/Assets/Resources/DataFiles/spells/cantrip/haunting-hymn.json
@@ -1,10 +1,13 @@
 {
-    "_id": "qwZBXN6zBoB9BHXE",
+    "_id": "b5BQbwmuBhgPXTyi",
     "folder": "D7UVaOiB40wTR6kv",
-    "img": "systems/pf2e/icons/spells/divine-lance.webp",
-    "name": "Divine Lance",
+    "img": "icons/commodities/tech/antenna-powered-purple.webp",
+    "name": "Haunting Hymn",
     "system": {
-        "area": null,
+        "area": {
+            "type": "cone",
+            "value": 15
+        },
         "cost": {
             "value": ""
         },
@@ -13,17 +16,22 @@
             "0": {
                 "applyMod": false,
                 "category": null,
-                "formula": "2d4",
+                "formula": "1d8",
                 "kinds": [
                     "damage"
                 ],
                 "materials": [],
-                "type": "spirit"
+                "type": "sonic"
             }
         },
-        "defense": null,
+        "defense": {
+            "save": {
+                "basic": true,
+                "statistic": "fortitude"
+            }
+        },
         "description": {
-            "value": "<p>You unleash a beam of divine energy. Make a ranged spell attack against the target's AC. On a hit, the target takes 2d4 spirit damage (double damage on a critical hit).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d4.</p>"
+            "value": "<p>You echo a jarring hymn that only creatures in the area can hear. The hymn deals 1d8 sonic damage, with a basic Fortitude save. If a target critically fails the save, it's also @UUID[Compendium.pf2e.conditionitems.Item.Deafened] for 1 minute.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d8.</p>"
         },
         "duration": {
             "sustained": false,
@@ -31,27 +39,26 @@
         },
         "heightening": {
             "damage": {
-                "0": "1d4"
+                "0": "1d8"
             },
-            "interval": 1,
+            "interval": 2,
             "type": "interval"
         },
         "level": {
             "value": 1
         },
-        "overlays": {},
         "publication": {
             "license": "ORC",
             "remaster": true,
-            "title": "Pathfinder Player Core"
+            "title": "Pathfinder Player Core 2"
         },
         "range": {
-            "value": "60 feet"
+            "value": ""
         },
         "requirements": "",
         "rules": [],
         "target": {
-            "value": "1 creature"
+            "value": ""
         },
         "time": {
             "value": "2"
@@ -59,15 +66,15 @@
         "traits": {
             "rarity": "common",
             "traditions": [
-                "divine"
+                "divine",
+                "occult"
             ],
             "value": [
-                "attack",
+                "auditory",
                 "cantrip",
                 "concentrate",
                 "manipulate",
-                "sanctified",
-                "spirit"
+                "sonic"
             ]
         }
     },

--- a/Assets/Resources/DataFiles/spells/cantrip/haunting-hymn.json.meta
+++ b/Assets/Resources/DataFiles/spells/cantrip/haunting-hymn.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88d5a957931c4f7fa02377700d683c5f
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/DataFiles/spells/cantrip/light.json
+++ b/Assets/Resources/DataFiles/spells/cantrip/light.json
@@ -1,55 +1,57 @@
 {
-  "name": "Light",
-  "system": {
-    "area": null,
-    "cost": {
-      "value": ""
+    "_id": "WBmvzNDfpwka3qT4",
+    "folder": "D7UVaOiB40wTR6kv",
+    "img": "systems/pf2e/icons/spells/light.webp",
+    "name": "Light",
+    "system": {
+        "area": null,
+        "cost": {
+            "value": ""
+        },
+        "counteraction": false,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>You create an orb of light that sheds bright light in a 20-foot radius (and dim light for the next 20 feet) in a color you choose. If you create the light in the same space as a willing creature, you can attach the light to the creature, causing it to float near that creature as it moves. You can Sustain the spell to move the light up to 60 feet; you can attach or detach it from a creature as part of this movement.</p>\n<p>You can Dismiss the spell. If you Cast the Spell while you already have four <em>light</em> spells active, you must choose one of the existing spells to end.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Light]</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The orb sheds light in a 60-foot radius (and dim light for the next 60 feet).</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": "until your next daily preparations"
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": "120 feet"
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": ""
+        },
+        "time": {
+            "value": "2"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "arcane",
+                "divine",
+                "occult",
+                "primal"
+            ],
+            "value": [
+                "cantrip",
+                "concentrate",
+                "light",
+                "manipulate"
+            ]
+        }
     },
-    "counteraction": false,
-    "damage": {},
-    "defense": null,
-    "description": {
-      "value": "<p>You create an orb of light that sheds bright light in a 20-foot radius (and dim light for the next 20 feet) in a color you choose. If you create the light in the same space as a willing creature, you can attach the light to the creature, causing it to float near that creature as it moves. You can Sustain the spell to move the light up to 60 feet; you can attach or detach it from a creature as part of this movement.</p>\n<p>You can Dismiss the spell. If you Cast the Spell while you already have four <em>light</em> spells active, you must choose one of the existing spells to end.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Light]</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The orb sheds light in a 60-foot radius (and dim light for the next 60 feet).</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": "until your next daily preparations"
-    },
-    "level": {
-      "value": 1
-    },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": "120 feet"
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": ""
-    },
-    "time": {
-      "value": "2"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "arcane",
-        "divine",
-        "occult",
-        "primal"
-      ],
-      "value": [
-        "cantrip",
-        "concentrate",
-        "light",
-        "manipulate"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/cantrip"
+    "type": "spell"
 }

--- a/Assets/Resources/DataFiles/spells/cantrip/shield.json
+++ b/Assets/Resources/DataFiles/spells/cantrip/shield.json
@@ -1,53 +1,55 @@
 {
-  "name": "Shield",
-  "system": {
-    "area": null,
-    "cost": {
-      "value": ""
+    "_id": "TVKNbcgTee19PXZR",
+    "folder": "D7UVaOiB40wTR6kv",
+    "img": "systems/pf2e/icons/spells/shield.webp",
+    "name": "Shield",
+    "system": {
+        "area": null,
+        "cost": {
+            "value": ""
+        },
+        "counteraction": false,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>You raise a magical shield of force. This counts as using the Raise a Shield action, giving you a +1 circumstance bonus to AC until the start of your next turn, but it doesn't require a hand to use.</p>\n<p>While the spell is in effect, you can use the @UUID[Compendium.pf2e.feats-srd.Item.Shield Block] reaction with your magic shield. The shield has Hardness 5. You can use the spell's reaction to reduce damage from any spell or magical effect, even if it doesn't deal physical damage. After you use Shield Block, the spell ends and you can't cast it again for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Shield]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Shield Immunity]</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The shield's Hardness increases by 5.</p>"
+        },
+        "duration": {
+            "sustained": false,
+            "value": "until the start of your next turn"
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "range": {
+            "value": ""
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": ""
+        },
+        "time": {
+            "value": "1"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "arcane",
+                "divine",
+                "occult"
+            ],
+            "value": [
+                "cantrip",
+                "concentrate",
+                "force"
+            ]
+        }
     },
-    "counteraction": false,
-    "damage": {},
-    "defense": null,
-    "description": {
-      "value": "<p>You raise a magical shield of force. This counts as using the Raise a Shield action, giving you a +1 circumstance bonus to AC until the start of your next turn, but it doesn't require a hand to use.</p>\n<p>While the spell is in effect, you can use the @UUID[Compendium.pf2e.feats-srd.Item.Shield Block] reaction with your magic shield. The shield has Hardness 5. You can use the spell's reaction to reduce damage from any spell or magical effect, even if it doesn't deal physical damage. After you use Shield Block, the spell ends and you can't cast it again for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Shield]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Shield Immunity]</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The shield's Hardness increases by 5.</p>"
-    },
-    "duration": {
-      "sustained": false,
-      "value": "until the start of your next turn"
-    },
-    "level": {
-      "value": 1
-    },
-    "publication": {
-      "license": "ORC",
-      "remaster": true,
-      "title": "Pathfinder Player Core"
-    },
-    "range": {
-      "value": ""
-    },
-    "requirements": "",
-    "rules": [],
-    "target": {
-      "value": ""
-    },
-    "time": {
-      "value": "1"
-    },
-    "traits": {
-      "rarity": "common",
-      "traditions": [
-        "arcane",
-        "divine",
-        "occult"
-      ],
-      "value": [
-        "cantrip",
-        "concentrate",
-        "force"
-      ]
-    }
-  },
-  "type": "spell",
-  "Source": "packs/spells/cantrip"
+    "type": "spell"
 }

--- a/Assets/Scripts/Combat/ActionController.cs
+++ b/Assets/Scripts/Combat/ActionController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Game.Creature;
 using NUnit.Framework;
 using Game.Strikes;
+using Game.Combat.Spells;
 
 public abstract class ActionController : MonoBehaviour
 {
@@ -26,7 +27,7 @@ public abstract class ActionController : MonoBehaviour
     [SerializeField]
     List<string> _actionNames = new List<string>(); // Temporary list of action names to add for testing purposes.  TODO remove
 
-    
+
 
     /// <summary>
     /// Starts this creature's turn
@@ -38,6 +39,7 @@ public abstract class ActionController : MonoBehaviour
         ResetActionPointsEvent.Invoke(newActionPoints);
         ActionPoints = newActionPoints.Value;
         StrikePenalty = 0;
+        SpellEffectController.ExpireAtStartOfTurn(gameObject);
     }
 
     public abstract void EndTurn();

--- a/Assets/Scripts/Combat/Spells.meta
+++ b/Assets/Scripts/Combat/Spells.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88c3d6a2b30547ab8640c489e17af3f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Spells/CastSpellAction.cs
+++ b/Assets/Scripts/Combat/Spells/CastSpellAction.cs
@@ -1,0 +1,84 @@
+using Game.Creature;
+using Game.Creature.Rules;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Combat.Spells
+{
+    [Serializable]
+    public class CastSpellAction : MultiFrameEntityAction
+    {
+        private readonly PreparedSpell spell;
+        private readonly uint variantActionCost;
+        private readonly ISpellDefinition definition;
+
+        public PreparedSpell Spell => spell;
+        public override string ActionName => BuildActionName(spell, variantActionCost);
+
+        public CastSpellAction(PreparedSpell spell, uint actionCost, ISpellDefinition definition) : base(actionCost)
+        {
+            this.spell = spell;
+            variantActionCost = actionCost;
+            this.definition = definition;
+        }
+
+        public static void AddSpellActions(GameObject caster)
+        {
+            CreatureComponent creature = caster != null ? caster.GetComponent<CreatureComponent>() : null;
+            ActionController controller = caster != null ? caster.GetComponent<ActionController>() : null;
+            SpellcastingState state = creature?.Prepared?.Spellcasting;
+            if (controller == null || state == null)
+                return;
+
+            HashSet<string> existing = controller.GetActions().Select(action => action.ActionName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (PreparedSpell preparedSpell in state.PreparedSpells)
+            {
+                if (!SpellRegistry.TryGet(preparedSpell.Slug, out ISpellDefinition spellDefinition))
+                    continue;
+
+                foreach (uint cost in spellDefinition.GetActionCosts(preparedSpell))
+                {
+                    CastSpellAction action = new(preparedSpell, cost, spellDefinition);
+                    if (!existing.Contains(action.ActionName))
+                    {
+                        controller.AddAction(action);
+                        existing.Add(action.ActionName);
+                        if (!creature.actions.Contains(action.ActionName))
+                            creature.actions.Add(action.ActionName);
+                    }
+                }
+            }
+        }
+
+        public CastSpellResult Cast(GameObject caster, IReadOnlyList<GameObject> targets = null, GridPublic.AreaTargetResult area = null)
+        {
+            return SpellcastingRuntime.Cast(caster, spell, variantActionCost, targets, area, spendActions: true);
+        }
+
+        protected override IEnumerator MFInvoke(GameObject caster)
+        {
+            ActionController actionController = caster.GetComponent<ActionController>();
+            if (definition == null)
+            {
+                if (actionController != null)
+                    actionController.IsTakingAction = false;
+                yield break;
+            }
+
+            SpellCastContext context = new(caster, spell, variantActionCost, spendActions: true, definition);
+            yield return definition.SelectAndCast(context);
+        }
+
+        private static string BuildActionName(PreparedSpell spell, uint actionCost)
+        {
+            if (spell == null)
+                return "Cast Spell";
+            if (spell.ActionCosts.Count > 1)
+                return spell.Name + " " + actionCost + "A";
+            return spell.Name;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Spells/CastSpellAction.cs.meta
+++ b/Assets/Scripts/Combat/Spells/CastSpellAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1635d2c9d39d414190d383d96b3200f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Spells/SpellDefinitions.cs
+++ b/Assets/Scripts/Combat/Spells/SpellDefinitions.cs
@@ -1,0 +1,289 @@
+using Game.Creature;
+using Game.Creature.Rules;
+using GridPublic;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Combat.Spells
+{
+    public interface ISpellDefinition
+    {
+        string Slug { get; }
+        IReadOnlyList<uint> GetActionCosts(PreparedSpell spell);
+        IEnumerator SelectAndCast(SpellCastContext context);
+        bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result);
+        bool AppliesMultipleAttackPenalty(SpellCastContext context);
+    }
+
+    public abstract class SpellDefinition : ISpellDefinition
+    {
+        public abstract string Slug { get; }
+
+        public virtual IReadOnlyList<uint> GetActionCosts(PreparedSpell spell) => spell?.ActionCosts ?? Array.Empty<uint>();
+        public virtual bool AppliesMultipleAttackPenalty(SpellCastContext context) => false;
+        public abstract IEnumerator SelectAndCast(SpellCastContext context);
+        public abstract bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result);
+
+        protected static IEnumerator CastNow(SpellCastContext context, SpellTargetSelection selection)
+        {
+            context.Cast(selection);
+            yield break;
+        }
+
+        protected static IEnumerator SelectFixedRangeTargetAndCast(SpellCastContext context, int rangeFeet)
+        {
+            CoroutineResult<StrikeTargetResult> target = new();
+            yield return GridAPI.GetInstance().GetStrikeTarget(context.Caster, SpellcastingRuntime.FixedRangeTarget(rangeFeet), target);
+            if (target.Value != null && target.Value.Target != null)
+                context.Cast(SpellTargetSelection.ForTarget(target.Value.Target));
+            else
+                SpellcastingRuntime.Fail(new CastSpellResult(), "Spell target is invalid.", context.ActionController);
+        }
+
+        protected static IEnumerator SelectAreaAndCast(SpellCastContext context, AreaTargetRequest request)
+        {
+            CoroutineResult<AreaTargetResult> area = new();
+            yield return GridAPI.GetInstance().GetAreaTarget(context.Caster, request, area);
+            if (area.Value != null)
+                context.Cast(SpellTargetSelection.ForArea(area.Value));
+            else
+                SpellcastingRuntime.Fail(new CastSpellResult(), "Spell target is invalid.", context.ActionController);
+        }
+
+        protected static GameObject FirstTarget(SpellTargetSelection selection)
+        {
+            return selection?.Targets != null && selection.Targets.Count > 0 ? selection.Targets[0] : null;
+        }
+    }
+
+    public static class SpellRegistry
+    {
+        private static readonly Dictionary<string, ISpellDefinition> Definitions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["shield"] = new ShieldSpell(),
+            ["guidance"] = new GuidanceSpell(),
+            ["divine-lance"] = new DivineLanceSpell(),
+            ["haunting-hymn"] = new HauntingHymnSpell(),
+            ["light"] = new LightSpell(),
+            ["bless"] = new BlessSpell(),
+            ["infuse-vitality"] = new InfuseVitalitySpell(),
+            ["heal"] = new HealSpell()
+        };
+
+        public static bool TryGet(string slug, out ISpellDefinition definition)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                definition = null;
+                return false;
+            }
+            return Definitions.TryGetValue(slug, out definition);
+        }
+    }
+
+    public sealed class ShieldSpell : SpellDefinition
+    {
+        public override string Slug => "shield";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context) => CastNow(context, SpellTargetSelection.None);
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            SpellEffectController.GetOrAdd(context.Caster).AddOrRefresh(new ShieldSpellEffect(context.Caster));
+            result.Targets.Add(context.Caster);
+            return true;
+        }
+    }
+
+    public sealed class LightSpell : SpellDefinition
+    {
+        public override string Slug => "light";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context) => CastNow(context, SpellTargetSelection.None);
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            result.Targets.Add(context.Caster);
+            return true;
+        }
+    }
+
+    public sealed class GuidanceSpell : SpellDefinition
+    {
+        public override string Slug => "guidance";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context) => SelectFixedRangeTargetAndCast(context, 30);
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            GameObject target = FirstTarget(selection) ?? context.Caster;
+            if (!SpellcastingRuntime.IsFriendly(context.Caster, target) || SpellcastingRuntime.DistanceFeet(context.Caster, target) > 30)
+                return false;
+            SpellEffectController controller = SpellEffectController.GetOrAdd(target);
+            if (controller.HasEffect<GuidanceImmunitySpellEffect>())
+                return false;
+            controller.AddOrRefresh(new GuidanceSpellEffect(context.Caster));
+            result.Targets.Add(target);
+            return true;
+        }
+    }
+
+    public sealed class DivineLanceSpell : SpellDefinition
+    {
+        public override string Slug => "divine-lance";
+        public override bool AppliesMultipleAttackPenalty(SpellCastContext context) => true;
+
+        public override IEnumerator SelectAndCast(SpellCastContext context) => SelectFixedRangeTargetAndCast(context, 60);
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            GameObject target = FirstTarget(selection);
+            if (target == null || SpellcastingRuntime.DistanceFeet(context.Caster, target) > 60)
+                return false;
+            CreatureComponent casterCreature = context.CasterCreature;
+            StrikeProfile profile = new(new List<Dice> { new Dice(2, 4, "spirit") }, new List<DamageValue>())
+            {
+                AttackModifierOverride = casterCreature.Prepared.Spellcasting.SpellAttackModifier,
+                SourceInfo = new AttackSourceInfo("Divine Lance", "spell", "spell", new[] { "attack", "spell", "spirit" }),
+                Traits = new List<string> { "attack", "spell", "spirit" },
+                ItemSlug = "divine-lance",
+                WeaponCategory = string.Empty,
+                IsRangedAttack = true,
+                ReachFeet = 60
+            };
+            StrikeTargetResult targeting = new()
+            {
+                Target = target,
+                DistanceFeet = SpellcastingRuntime.DistanceFeet(context.Caster, target),
+                LineOfEffect = StrikeLineOfEffect.Clear,
+                Cover = StrikeCover.None,
+                RangePenalty = 0
+            };
+            StrikeResolutionPipeline.Resolve(new StrikeResolutionRequest
+            {
+                Attacker = context.Caster,
+                Target = target,
+                Profile = profile,
+                TargetingResult = targeting
+            });
+            result.Targets.Add(target);
+            return true;
+        }
+    }
+
+    public sealed class HauntingHymnSpell : SpellDefinition
+    {
+        public override string Slug => "haunting-hymn";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context)
+        {
+            return SelectAreaAndCast(context, new AreaTargetRequest { Shape = AreaShape.Cone, SizeFeet = 15 });
+        }
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            if (selection?.Area == null)
+                return false;
+            foreach (AreaAffectedCreature affected in selection.Area.Creatures.Where(creature => creature.IsAffected))
+                SpellcastingRuntime.ApplyBasicFortitudeDamage(context.Caster, affected.Creature, new Dice(1, 8, "sonic"), result, applyDeafenedOnCriticalFailure: true);
+            return true;
+        }
+    }
+
+    public sealed class BlessSpell : SpellDefinition
+    {
+        public override string Slug => "bless";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context)
+        {
+            return CastNow(context, SpellTargetSelection.ForTargets(SpellcastingRuntime.FriendlyCreaturesInEmanation(context.Caster, 15)));
+        }
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            IReadOnlyList<GameObject> selected = selection?.Targets == null || selection.Targets.Count == 0
+                ? new[] { context.Caster }
+                : selection.Targets;
+            foreach (GameObject target in selected)
+            {
+                if (target != null && SpellcastingRuntime.IsFriendly(context.Caster, target) && SpellcastingRuntime.DistanceFeet(context.Caster, target) <= 15)
+                {
+                    SpellEffectController.GetOrAdd(target).AddOrRefresh(new BlessSpellEffect(context.Caster));
+                    result.Targets.Add(target);
+                }
+            }
+            return result.Targets.Count > 0;
+        }
+    }
+
+    public sealed class InfuseVitalitySpell : SpellDefinition
+    {
+        public override string Slug => "infuse-vitality";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context) => SelectFixedRangeTargetAndCast(context, 30);
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            if (selection?.Targets == null || selection.Targets.Count == 0 || selection.Targets.Count > context.ActionCost)
+                return false;
+            HashSet<GameObject> unique = new();
+            foreach (GameObject target in selection.Targets)
+            {
+                if (target == null || !unique.Add(target) || !SpellcastingRuntime.IsFriendly(context.Caster, target) || SpellcastingRuntime.DistanceFeet(context.Caster, target) > 30)
+                    return false;
+            }
+            foreach (GameObject target in unique)
+            {
+                SpellEffectController.GetOrAdd(target).AddOrRefresh(new InfuseVitalitySpellEffect(context.Caster));
+                result.Targets.Add(target);
+            }
+            return true;
+        }
+    }
+
+    public sealed class HealSpell : SpellDefinition
+    {
+        public override string Slug => "heal";
+
+        public override IEnumerator SelectAndCast(SpellCastContext context)
+        {
+            if (context.ActionCost == 3)
+                return SelectAreaAndCast(context, new AreaTargetRequest { Shape = AreaShape.Emanation, SizeFeet = 30, IncludeCenter = true });
+            return SelectFixedRangeTargetAndCast(context, context.ActionCost == 1 ? 5 : 30);
+        }
+
+        public override bool Cast(SpellCastContext context, SpellTargetSelection selection, CastSpellResult result)
+        {
+            List<GameObject> selected = new();
+            if (context.ActionCost == 3 && selection?.Area != null)
+                selected.AddRange(selection.Area.Creatures.Where(creature => creature.IsAffected).Select(creature => creature.Creature));
+            else if (selection?.Targets != null)
+                selected.AddRange(selection.Targets.Where(target => target != null));
+            if (selected.Count == 0)
+                return false;
+            foreach (GameObject target in selected.Distinct())
+            {
+                if (context.ActionCost == 1 && SpellcastingRuntime.DistanceFeet(context.Caster, target) > 5)
+                    return false;
+                if (context.ActionCost == 2 && SpellcastingRuntime.DistanceFeet(context.Caster, target) > 30)
+                    return false;
+                CreatureComponent creature = target.GetComponent<CreatureComponent>();
+                if (creature == null)
+                    continue;
+                int amount = new Dice(1, 8, "vitality").Roll() + (context.ActionCost == 2 && !SpellcastingRuntime.IsUndead(creature) ? 8 : 0);
+                result.Targets.Add(target);
+                if (SpellcastingRuntime.IsUndead(creature))
+                    SpellcastingRuntime.ApplyBasicFortitudeDamage(context.Caster, target, new DamageValue("vitality", amount), result, applyDeafenedOnCriticalFailure: false);
+                else if (SpellcastingRuntime.IsFriendly(context.Caster, target))
+                {
+                    creature.Heal(amount);
+                    result.Amount += amount;
+                }
+            }
+            return result.Targets.Count > 0;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Spells/SpellDefinitions.cs.meta
+++ b/Assets/Scripts/Combat/Spells/SpellDefinitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 079ae035df274f1aa3fe4725a8290f99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Spells/SpellEffectController.cs
+++ b/Assets/Scripts/Combat/Spells/SpellEffectController.cs
@@ -1,0 +1,244 @@
+using Game.Creature;
+using Game.Rules;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Combat.Spells
+{
+    public abstract class ActiveSpellEffect
+    {
+        protected ActiveSpellEffect(GameObject source, string sourceLabel, int remainingTargetTurnStarts = 0, bool expiresAtSourceTurnStart = false)
+        {
+            Source = source;
+            SourceLabel = sourceLabel ?? string.Empty;
+            RemainingTargetTurnStarts = remainingTargetTurnStarts;
+            ExpiresAtSourceTurnStart = expiresAtSourceTurnStart;
+        }
+
+        public GameObject Source { get; private set; }
+        public string SourceLabel { get; private set; }
+        public int RemainingTargetTurnStarts { get; set; }
+        public bool ExpiresAtSourceTurnStart { get; private set; }
+        public bool Consumed { get; protected set; }
+        public virtual bool ExpiresWhenTargetTurnCounterReachesZero => false;
+
+        public bool Matches(ActiveSpellEffect other)
+        {
+            return other != null
+                && GetType() == other.GetType()
+                && Source == other.Source
+                && string.Equals(SourceLabel, other.SourceLabel, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void RefreshFrom(ActiveSpellEffect other)
+        {
+            Source = other.Source;
+            SourceLabel = other.SourceLabel;
+            RemainingTargetTurnStarts = other.RemainingTargetTurnStarts;
+            ExpiresAtSourceTurnStart = other.ExpiresAtSourceTurnStart;
+            Consumed = false;
+        }
+
+        public virtual IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic, SpellEffectController owner)
+        {
+            yield break;
+        }
+
+        public virtual IEnumerable<IStrikeAdjustment> GetStrikeAdjustments(StrikeResolutionContext context, SpellEffectController owner)
+        {
+            yield break;
+        }
+    }
+
+    public sealed class ShieldSpellEffect : ActiveSpellEffect
+    {
+        public ShieldSpellEffect(GameObject source)
+            : base(source, "Shield", expiresAtSourceTurnStart: true)
+        {
+        }
+
+        public override IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic, SpellEffectController owner)
+        {
+            if (statistic == Pf2eStatistic.ArmorClass)
+                yield return new Pf2eModifier(1, Pf2eModifierType.Circumstance, "Shield", statistic);
+        }
+    }
+
+    public sealed class GuidanceSpellEffect : ActiveSpellEffect
+    {
+        public GuidanceSpellEffect(GameObject source)
+            : base(source, "Guidance", expiresAtSourceTurnStart: true)
+        {
+        }
+
+        public override IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic, SpellEffectController owner)
+        {
+            if (Consumed || !IsGuidanceStatistic(statistic))
+                yield break;
+
+            Consumed = true;
+            owner.AddOrRefresh(new GuidanceImmunitySpellEffect(owner.gameObject));
+            yield return new Pf2eModifier(1, Pf2eModifierType.Status, "Guidance", statistic);
+        }
+
+        private static bool IsGuidanceStatistic(Pf2eStatistic statistic)
+        {
+            return statistic == Pf2eStatistic.AttackRoll
+                || statistic == Pf2eStatistic.FortitudeSave
+                || statistic == Pf2eStatistic.ReflexSave
+                || statistic == Pf2eStatistic.WillSave
+                || statistic == Pf2eStatistic.SkillCheck
+                || statistic == Pf2eStatistic.Initiative;
+        }
+    }
+
+    public sealed class GuidanceImmunitySpellEffect : ActiveSpellEffect
+    {
+        public GuidanceImmunitySpellEffect(GameObject source)
+            : base(source, "Guidance Immunity")
+        {
+        }
+    }
+
+    public sealed class BlessSpellEffect : ActiveSpellEffect
+    {
+        public BlessSpellEffect(GameObject source)
+            : base(source, "Bless", remainingTargetTurnStarts: 10)
+        {
+        }
+
+        public override bool ExpiresWhenTargetTurnCounterReachesZero => true;
+
+        public override IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic, SpellEffectController owner)
+        {
+            if (statistic == Pf2eStatistic.AttackRoll)
+                yield return new Pf2eModifier(1, Pf2eModifierType.Status, "Bless", statistic);
+        }
+    }
+
+    public sealed class InfuseVitalitySpellEffect : ActiveSpellEffect
+    {
+        public InfuseVitalitySpellEffect(GameObject source)
+            : base(source, "Infuse Vitality", remainingTargetTurnStarts: 10)
+        {
+        }
+
+        public override bool ExpiresWhenTargetTurnCounterReachesZero => true;
+
+        public override IEnumerable<IStrikeAdjustment> GetStrikeAdjustments(StrikeResolutionContext context, SpellEffectController owner)
+        {
+            if (context?.AttackerObject == owner.gameObject && context.Profile != null && IsWeaponOrUnarmedStrike(context.Profile))
+                yield return new InfuseVitalityStrikeAdjustment();
+        }
+
+        private static bool IsWeaponOrUnarmedStrike(StrikeProfile strike)
+        {
+            return string.Equals(strike.WeaponCategory, "unarmed", StringComparison.OrdinalIgnoreCase)
+                || !string.IsNullOrWhiteSpace(strike.WeaponCategory);
+        }
+    }
+
+    public class SpellEffectController : MonoBehaviour, IPf2eModifierProvider, IStrikeAdjustmentProvider
+    {
+        private readonly List<ActiveSpellEffect> effects = new();
+        private static readonly List<SpellEffectController> instances = new();
+
+        public IReadOnlyList<ActiveSpellEffect> Effects => effects;
+
+        private void OnEnable()
+        {
+            if (!instances.Contains(this))
+                instances.Add(this);
+        }
+
+        private void OnDisable()
+        {
+            instances.Remove(this);
+        }
+
+        public static SpellEffectController GetOrAdd(GameObject target)
+        {
+            if (target == null)
+                return null;
+            SpellEffectController controller = target.GetComponent<SpellEffectController>();
+            return controller != null ? controller : target.AddComponent<SpellEffectController>();
+        }
+
+        public static void ExpireAtStartOfTurn(GameObject creature)
+        {
+            SpellEffectController ownController = null;
+            if (creature != null && creature.TryGetComponent(out ownController))
+                ownController.ExpireForTurnStart(creature);
+
+            foreach (SpellEffectController controller in instances.ToArray())
+            {
+                if (controller != null && controller != ownController)
+                    controller.ExpireForTurnStart(creature);
+            }
+        }
+
+        public void AddOrRefresh(ActiveSpellEffect effect)
+        {
+            if (effect == null)
+                return;
+            ActiveSpellEffect existing = effects.Find(effect.Matches);
+            if (existing == null)
+                effects.Add(effect);
+            else
+                existing.RefreshFrom(effect);
+        }
+
+        public bool HasEffect<T>() where T : ActiveSpellEffect
+        {
+            return effects.Exists(effect => effect is T && !effect.Consumed);
+        }
+
+        public IEnumerable<Pf2eModifier> GetModifiers(Pf2eStatistic statistic)
+        {
+            foreach (ActiveSpellEffect effect in effects.ToArray())
+            {
+                foreach (Pf2eModifier modifier in effect.GetModifiers(statistic, this))
+                    yield return modifier;
+            }
+            effects.RemoveAll(effect => effect.Consumed);
+        }
+
+        public IEnumerable<IStrikeAdjustment> GetStrikeAdjustments(StrikeResolutionContext context)
+        {
+            foreach (ActiveSpellEffect effect in effects.ToArray())
+            {
+                foreach (IStrikeAdjustment adjustment in effect.GetStrikeAdjustments(context, this))
+                    yield return adjustment;
+            }
+        }
+
+        private void ExpireForTurnStart(GameObject creature)
+        {
+            effects.RemoveAll(effect => effect.ExpiresAtSourceTurnStart && effect.Source == creature);
+            if (creature == gameObject)
+            {
+                foreach (ActiveSpellEffect effect in effects)
+                {
+                    if (effect.RemainingTargetTurnStarts > 0)
+                        effect.RemainingTargetTurnStarts--;
+                }
+                effects.RemoveAll(effect => effect.RemainingTargetTurnStarts == 0 && effect.ExpiresWhenTargetTurnCounterReachesZero);
+            }
+        }
+    }
+
+    public sealed class InfuseVitalityStrikeAdjustment : StrikeAdjustmentBase
+    {
+        public InfuseVitalityStrikeAdjustment()
+            : base(StrikeAdjustmentPhase.BeforeDamageRoll, 0, "Infuse Vitality")
+        {
+        }
+
+        public override void Apply(StrikeResolutionContext context)
+        {
+            context.DamageDice.Add(new Dice(1, 4, "vitality"));
+            context.LogDetails.Add(new CombatLogDetail("Infuse Vitality", "+1d4 vitality"));
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Spells/SpellEffectController.cs.meta
+++ b/Assets/Scripts/Combat/Spells/SpellEffectController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8eaeb1c09d34268aab0ec4bddc1f1b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs
+++ b/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs
@@ -1,0 +1,202 @@
+using Game.Creature;
+using Game.Creature.Rules;
+using GridPrivate;
+using GridPublic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Combat.Spells
+{
+    public sealed class CastSpellResult
+    {
+        public bool Success;
+        public string Message;
+        public List<GameObject> Targets { get; } = new();
+        public List<D20Result> Rolls { get; } = new();
+        public int Amount;
+    }
+
+    public sealed class SpellTargetSelection
+    {
+        public IReadOnlyList<GameObject> Targets { get; }
+        public AreaTargetResult Area { get; }
+
+        public SpellTargetSelection(IReadOnlyList<GameObject> targets = null, AreaTargetResult area = null)
+        {
+            Targets = targets ?? Array.Empty<GameObject>();
+            Area = area;
+        }
+
+        public static SpellTargetSelection None { get; } = new();
+        public static SpellTargetSelection ForTarget(GameObject target) => new(target == null ? Array.Empty<GameObject>() : new[] { target });
+        public static SpellTargetSelection ForTargets(IReadOnlyList<GameObject> targets) => new(targets);
+        public static SpellTargetSelection ForArea(AreaTargetResult area) => new(null, area);
+    }
+
+    public sealed class SpellCastContext
+    {
+        public GameObject Caster { get; }
+        public PreparedSpell Spell { get; }
+        public uint ActionCost { get; }
+        public bool SpendActions { get; }
+        public ISpellDefinition Definition { get; }
+
+        public SpellCastContext(GameObject caster, PreparedSpell spell, uint actionCost, bool spendActions, ISpellDefinition definition)
+        {
+            Caster = caster;
+            Spell = spell;
+            ActionCost = actionCost;
+            SpendActions = spendActions;
+            Definition = definition;
+        }
+
+        public ActionController ActionController => Caster != null ? Caster.GetComponent<ActionController>() : null;
+        public CreatureComponent CasterCreature => Caster != null ? Caster.GetComponent<CreatureComponent>() : null;
+        public SpellcastingState Spellcasting => CasterCreature?.Prepared?.Spellcasting;
+        public CastSpellResult Cast(SpellTargetSelection selection) => SpellcastingRuntime.Cast(this, selection);
+    }
+
+    public static class SpellcastingRuntime
+    {
+        public static StrikeTargetRequest FixedRangeTarget(int rangeFeet)
+        {
+            return new StrikeTargetRequest { IsRanged = true, FixedRangeFeet = rangeFeet, RequiresLineOfEffect = true };
+        }
+
+        public static CastSpellResult Cast(GameObject caster, PreparedSpell spell, uint actionCost, IReadOnlyList<GameObject> targets = null, AreaTargetResult area = null, bool spendActions = true)
+        {
+            if (!SpellRegistry.TryGet(spell?.Slug, out ISpellDefinition definition))
+                return Fail(new CastSpellResult(), spell == null ? "Spell is not prepared." : spell.Name + " is not implemented.", caster != null ? caster.GetComponent<ActionController>() : null);
+
+            SpellCastContext context = new(caster, spell, actionCost, spendActions, definition);
+            return Cast(context, new SpellTargetSelection(targets, area));
+        }
+
+        public static CastSpellResult Cast(SpellCastContext context, SpellTargetSelection selection)
+        {
+            CastSpellResult result = new();
+            CreatureComponent creature = context.CasterCreature;
+            ActionController controller = context.ActionController;
+            SpellcastingState state = context.Spellcasting;
+            if (context.Caster == null || creature == null || state == null || context.Spell == null)
+                return Fail(result, "Caster is not ready to cast spells.", controller);
+            if (context.ActionCost > 0 && controller != null && context.SpendActions && controller.ActionPoints < context.ActionCost)
+                return Fail(result, "Not enough actions.", controller);
+            if (!state.CanCast(context.Spell))
+                return Fail(result, context.Spell.Name + " has no remaining slot.", controller);
+
+            if (!context.Definition.Cast(context, selection ?? SpellTargetSelection.None, result))
+                return Fail(result, "Spell target is invalid.", controller);
+            if (!state.Spend(context.Spell))
+                return Fail(result, context.Spell.Name + " has no remaining slot.", controller);
+            if (controller != null && context.SpendActions)
+            {
+                controller.ActionPoints -= context.ActionCost;
+                if (context.Definition.AppliesMultipleAttackPenalty(context))
+                    controller.StrikePenalty += 1;
+                controller.IsTakingAction = false;
+            }
+            result.Success = true;
+            CombatLogInterface log = UnityEngine.Object.FindFirstObjectByType<CombatLogInterface>();
+            log?.Log("- " + context.Caster.name + " casts " + context.Spell.Name + ".");
+            return result;
+        }
+
+        public static int SpellAttackModifier(CreatureComponent caster)
+        {
+            if (caster == null)
+                return 0;
+            const int trainedProficiency = 2;
+            return caster.level + trainedProficiency + caster.wisMod;
+        }
+
+        public static bool IsFriendly(GameObject caster, GameObject target)
+        {
+            if (caster == null || target == null)
+                return false;
+            if (caster == target)
+                return true;
+            Team casterTeam = caster.GetComponent<Team>();
+            Team targetTeam = target.GetComponent<Team>();
+            if (casterTeam == null || targetTeam == null || string.IsNullOrWhiteSpace(casterTeam.Name) || string.IsNullOrWhiteSpace(targetTeam.Name))
+                return true;
+            TeamRules rules = TeamRules.GetInstance();
+            return rules.Contains(casterTeam.Name) && rules.Contains(targetTeam.Name) && rules.IsFriendly(casterTeam.Name, targetTeam.Name);
+        }
+
+        public static int DistanceFeet(GameObject left, GameObject right)
+        {
+            if (left == null || right == null)
+                return int.MaxValue;
+            return StrikeTargeting.MeasureGridDistanceFeet(Vector3Int.RoundToInt(left.transform.position), Vector3Int.RoundToInt(right.transform.position));
+        }
+
+        public static IReadOnlyList<GameObject> FriendlyCreaturesInEmanation(GameObject caster, int rangeFeet)
+        {
+            if (caster == null)
+                return Array.Empty<GameObject>();
+            List<GameObject> targets = new() { caster };
+            Vector3Int start = Vector3Int.RoundToInt(caster.transform.position);
+            foreach (CreatureComponent creature in UnityEngine.Object.FindObjectsByType<CreatureComponent>(FindObjectsSortMode.None))
+            {
+                if (creature == null || creature.gameObject == caster)
+                    continue;
+                int distance = StrikeTargeting.MeasureGridDistanceFeet(start, Vector3Int.RoundToInt(creature.transform.position));
+                if (distance <= rangeFeet && IsFriendly(caster, creature.gameObject))
+                    targets.Add(creature.gameObject);
+            }
+            return targets;
+        }
+
+        public static void ApplyBasicFortitudeDamage(GameObject caster, GameObject target, Dice dice, CastSpellResult result, bool applyDeafenedOnCriticalFailure)
+        {
+            DamageRollResolution damage = DamageRoller.StartDamageResolution(new List<Dice> { dice }, new List<DamageValue>());
+            DamageRoller.FinalizeDamageResolution(damage);
+            ApplyBasicFortitudeDamage(caster, target, new DamageValue(dice.damageType, damage.TotalDamage), result, applyDeafenedOnCriticalFailure);
+        }
+
+        public static void ApplyBasicFortitudeDamage(GameObject caster, GameObject target, DamageValue damage, CastSpellResult result, bool applyDeafenedOnCriticalFailure)
+        {
+            CreatureComponent casterCreature = caster.GetComponent<CreatureComponent>();
+            CreatureComponent targetCreature = target.GetComponent<CreatureComponent>();
+            int dc = casterCreature.Prepared.Spellcasting.SpellDc;
+            int saveModifier = targetCreature.ResolveFortitudeSave().Total;
+            D20Result save = D20.Roll(saveModifier, dc);
+            result.Rolls.Add(save);
+            int amount = BasicSaveDamage(damage.DamageAmount, save.degree);
+            if (amount > 0)
+                targetCreature.TakeDamage((uint)amount);
+            if (applyDeafenedOnCriticalFailure && save.degree == DegreeOfSuccess.CriticalFail)
+                (target.GetComponent<Conditions>() ?? target.AddComponent<Conditions>()).Add("Deafened", new ConditionSource());
+            result.Targets.Add(target);
+            result.Amount += amount;
+        }
+
+        public static bool IsUndead(CreatureComponent creature)
+        {
+            return creature.traits != null && creature.traits.Any(trait => string.Equals(trait, "undead", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static int BasicSaveDamage(int amount, DegreeOfSuccess degree)
+        {
+            return degree switch
+            {
+                DegreeOfSuccess.CriticalSuccess => 0,
+                DegreeOfSuccess.Success => Mathf.FloorToInt(amount / 2.0f),
+                DegreeOfSuccess.CriticalFail => amount * 2,
+                _ => amount
+            };
+        }
+
+        public static CastSpellResult Fail(CastSpellResult result, string message, ActionController controller)
+        {
+            result.Success = false;
+            result.Message = message;
+            if (controller != null)
+                controller.IsTakingAction = false;
+            return result;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs.meta
+++ b/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8ae731f93b3435fb5c8beae0e01f71a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Spells/SpellcastingState.cs
+++ b/Assets/Scripts/Combat/Spells/SpellcastingState.cs
@@ -1,0 +1,117 @@
+using Game.Creature.Rules;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Combat.Spells
+{
+    public enum SpellSlotKind
+    {
+        Cantrip,
+        Prepared,
+        Font
+    }
+
+    public sealed class SpellSlotPool
+    {
+        public string Id { get; }
+        public SpellSlotKind Kind { get; }
+        public int Rank { get; }
+        public int MaxUses { get; }
+        public int UsesRemaining { get; private set; }
+
+        public SpellSlotPool(string id, SpellSlotKind kind, int rank, int maxUses)
+        {
+            Id = id ?? string.Empty;
+            Kind = kind;
+            Rank = Math.Max(0, rank);
+            MaxUses = Math.Max(0, maxUses);
+            UsesRemaining = MaxUses;
+        }
+
+        public bool Spend()
+        {
+            if (Kind == SpellSlotKind.Cantrip)
+                return true;
+            if (UsesRemaining <= 0)
+                return false;
+            UsesRemaining--;
+            return true;
+        }
+
+        public void Restore() => UsesRemaining = MaxUses;
+    }
+
+    public sealed class PreparedSpell
+    {
+        public string Name { get; }
+        public string Slug { get; }
+        public int Rank { get; }
+        public bool IsCantrip { get; }
+        public bool IsFontSpell { get; }
+        public string SlotPoolId { get; }
+        public IReadOnlyList<uint> ActionCosts { get; }
+
+        public PreparedSpell(string name, int rank, bool isCantrip, bool isFontSpell, string slotPoolId, IEnumerable<uint> actionCosts)
+        {
+            Name = name ?? string.Empty;
+            Slug = Pf2eSlug.FromName(Name);
+            Rank = Math.Max(0, rank);
+            IsCantrip = isCantrip;
+            IsFontSpell = isFontSpell;
+            SlotPoolId = slotPoolId ?? string.Empty;
+            ActionCosts = (actionCosts ?? new[] { 1u }).Distinct().OrderBy(cost => cost).ToArray();
+        }
+    }
+
+    public sealed class SpellcastingState
+    {
+        private readonly Dictionary<string, SpellSlotPool> pools = new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<PreparedSpell> spells = new();
+
+        public string Tradition { get; set; } = "divine";
+        public string Ability { get; set; } = "wis";
+        public int SpellAttackModifier { get; set; }
+        public int SpellDc => 10 + SpellAttackModifier;
+        public IReadOnlyDictionary<string, SpellSlotPool> Pools => pools;
+        public IReadOnlyList<PreparedSpell> PreparedSpells => spells;
+
+        public void AddPool(SpellSlotPool pool)
+        {
+            if (pool == null || string.IsNullOrWhiteSpace(pool.Id))
+                return;
+            pools[pool.Id] = pool;
+        }
+
+        public void AddSpell(PreparedSpell spell)
+        {
+            if (spell == null || spells.Any(existing => string.Equals(existing.Name, spell.Name, StringComparison.OrdinalIgnoreCase) && existing.ActionCosts.SequenceEqual(spell.ActionCosts)))
+                return;
+            spells.Add(spell);
+        }
+
+        public PreparedSpell GetSpell(string slugOrName)
+        {
+            string slug = Pf2eSlug.FromName(slugOrName);
+            return spells.FirstOrDefault(spell => string.Equals(spell.Slug, slug, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool CanCast(PreparedSpell spell)
+        {
+            if (spell == null)
+                return false;
+            if (spell.IsCantrip)
+                return true;
+            return pools.TryGetValue(spell.SlotPoolId, out SpellSlotPool pool) && pool.UsesRemaining > 0;
+        }
+
+        public bool Spend(PreparedSpell spell)
+        {
+            if (spell == null)
+                return false;
+            if (spell.IsCantrip)
+                return true;
+            return pools.TryGetValue(spell.SlotPoolId, out SpellSlotPool pool) && pool.Spend();
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Spells/SpellcastingState.cs.meta
+++ b/Assets/Scripts/Combat/Spells/SpellcastingState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc19fce3512d44b5b40640ce402807df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Creature/CreatureComponent.cs
+++ b/Assets/Scripts/Creature/CreatureComponent.cs
@@ -6,6 +6,7 @@ using Game.Strikes;
 using Game.Rules;
 using GridPublic;
 using Game.Creature.Rules;
+using Game.Combat.Spells;
 
 namespace Game.Creature
 {
@@ -26,7 +27,7 @@ namespace Game.Creature
     /// <summary>
     /// Unity creature component that owns mutable gameplay state and exposes narrow state snapshots for PF2e rules.
     /// </summary>
-    public class CreatureComponent : MonoBehaviour 
+    public class CreatureComponent : MonoBehaviour
     {
 
         // Basic stats
@@ -482,6 +483,7 @@ namespace Game.Creature
             if(this.gameObject.GetComponent<ActionController>() != null){
                 Unarmed.AddUnarmedStrike(this.gameObject);
                 StrikeWeapon.WeaponStrikeAdderAutomatic(this.gameObject);
+                CastSpellAction.AddSpellActions(this.gameObject);
             }else{
                 Debug.LogWarning($"No ActionController found on {name}, cannot add default strikes");
             }
@@ -624,7 +626,7 @@ namespace Game.Creature
             GridAPI.GetInstance().DestroyToken(this.gameObject);
             OnDeath.Invoke(gameObject); // Trigger the death event
             CombatLog.GetInstance().Log("- " + this.gameObject.name + " was defeated!");
-            
+
             gameObject.SetActive(false);
         }
 
@@ -636,7 +638,7 @@ namespace Game.Creature
 
         public void GainTempHp(int tempHpAmount, bool overrideExisting)
         {
-            // TODO replace with UI prompt for player decision about which 
+            // TODO replace with UI prompt for player decision about which
             if(_tempHp > 0)
             {
                 // UI prompt here
@@ -764,16 +766,16 @@ namespace Game.Creature
         // Helper: check if left hand has a valid equipped weapon
         public bool HasEquippedLeftWeapon()
         {
-            return _equippedLeftHand != null && 
-                   !string.IsNullOrWhiteSpace(_equippedLeftHand.name) && 
+            return _equippedLeftHand != null &&
+                   !string.IsNullOrWhiteSpace(_equippedLeftHand.name) &&
                    _equippedLeftHand.damage != null;
         }
 
         // Helper: check if right hand has a valid equipped weapon
         public bool HasEquippedRightWeapon()
         {
-            return _equippedRightHand != null && 
-                   !string.IsNullOrWhiteSpace(_equippedRightHand.name) && 
+            return _equippedRightHand != null &&
+                   !string.IsNullOrWhiteSpace(_equippedRightHand.name) &&
                    _equippedRightHand.damage != null;
         }
 

--- a/Assets/Scripts/Creature/CreatureJsonConverter.cs
+++ b/Assets/Scripts/Creature/CreatureJsonConverter.cs
@@ -40,6 +40,7 @@ namespace Game.Creature
         public DetailsDto details;
         public PerceptionDto perception;
         public SaveSetDto saves;
+        public TraitsDto traits;
         public List<SkillValue> skills;
         public WeaknessDto[] weaknesses;
         public ResistanceDto[] resistances;
@@ -53,7 +54,7 @@ namespace Game.Creature
         public string[] publicNotesParagraphs;
     }
 
-    [Serializable] public class AttributesDto { 
+    [Serializable] public class AttributesDto {
         public int ac;
         public HpDto hp;
         public SpeedEntryDto[] speed;
@@ -93,11 +94,11 @@ namespace Game.Creature
 
     [Serializable] public class RangeDto { public int increment; public int max; }
 
-    [Serializable] public class TraitsDto { public string rarity; public string[] value; }
+    [Serializable] public class TraitsDto { public string rarity; public string size; public string[] value; }
 
     [Serializable] public class EquipmentDto { public string name; public string type; public int quantity; }
-    [Serializable] 
-    public class WeaponDto { 
+    [Serializable]
+    public class WeaponDto {
         public string name;
         public string type;
         public string group;
@@ -168,7 +169,7 @@ namespace Game.Creature
                 ? dto.actions[0]?.system?.bonus?.value ?? target.attackBonus
                 : target.attackBonus;
 
-            // TODO: temporary, damage bonus directly from str mod 
+            // TODO: temporary, damage bonus directly from str mod
             target.damageBonus = dto.system.abilities != null ? dto.system.abilities.str : target.strMod;
 
             // Action-specific weapon attack bonuses from imported creature actions
@@ -219,6 +220,15 @@ namespace Game.Creature
             target.fortitudeSave = dto.system.saves != null ? dto.system.saves.fortitude : target.fortitudeSave;
             target.reflexSave = dto.system.saves != null ? dto.system.saves.reflex : target.reflexSave;
             target.willSave = dto.system.saves != null ? dto.system.saves.will : target.willSave;
+
+            target.traits.Clear();
+            if (dto.system.traits?.value != null)
+            {
+                foreach (string trait in dto.system.traits.value)
+                    if (!string.IsNullOrWhiteSpace(trait))
+                        target.traits.Add(trait);
+            }
+            target.size = dto.system.traits?.size ?? target.size;
 
             // Replace weaknesses/resistances lists
             // Debug.Log(target.name +" weaknesses and resistances from DTO:");
@@ -271,7 +281,7 @@ namespace Game.Creature
                 foreach (var p in dto.passives){
                     if (!string.IsNullOrEmpty(p?.name)){
                         target.passives.Add(p.name);
-                        //DefinedAbilities.TryGet(p.name)?.Apply(target.gameObject); 
+                        //DefinedAbilities.TryGet(p.name)?.Apply(target.gameObject);
                     }
                 }
             }
@@ -338,7 +348,7 @@ namespace Game.Creature
                         // Debug.Log($"CreatureDtoMapper: AC after equipping armor: {target.ac}");
                     }
                 }
-            
+
             // Conditions
             // if (target.conditions == null) target.conditions = new List<string>();
             // target.conditions.Clear();
@@ -574,7 +584,7 @@ namespace Game.Creature
                     EquipmentWeapon weapon = new EquipmentWeapon();
                     weapon.name = dto.name;
                     weapon.type = dto.type;
-                    weapon.group = dto.group;   
+                    weapon.group = dto.group;
                     weapon.category = dto.category;
                     weapon.hands = dto.hands;
                     weapon.damage = new Dice(dto.damageDice, dto.damageDie, dto.damageType);
@@ -592,7 +602,7 @@ namespace Game.Creature
                 }
             }
             return weapons;
-        }   
+        }
 
         public static List<EquipmentArmor> GetAllArmors()
         {
@@ -620,10 +630,10 @@ namespace Game.Creature
                 {
                     EquipmentArmor armor = new EquipmentArmor();
                     armor.name = dto.name;
-                    armor.type = dto.type; 
+                    armor.type = dto.type;
                     armor.category = dto.category;
                     armor.price = dto.price;
-                    armor.acBonus = dto.acBonus;    
+                    armor.acBonus = dto.acBonus;
                     armor.dexCap = dto.dexCap;
                     armor.checkPenalty = dto.checkPenalty;
                     armor.speedPenalty = dto.speedPenalty;

--- a/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
+++ b/Assets/Scripts/Creature/Rules/Pf2eCharacterPreparer.cs
@@ -1,3 +1,4 @@
+using Game.Combat.Spells;
 using Game.Creature;
 using Newtonsoft.Json.Linq;
 using System;
@@ -24,6 +25,7 @@ namespace Game.Creature.Rules
             if (creature == null)
                 return prepared;
 
+            ApplyImplementedBuildDefaults(build);
             prepared.RollOptions.Add($"self:level:{creature.level}");
             AddArmorRollOptions(creature, prepared);
             AddSavedSkillRanks(prepared);
@@ -45,6 +47,7 @@ namespace Game.Creature.Rules
                 ProcessGrantRules(prepared, catalog);
 
             CollectRuleSynthetics(prepared, catalog);
+            PrepareImplementedSpellcasting(creature, prepared);
             return prepared;
         }
 
@@ -58,6 +61,49 @@ namespace Game.Creature.Rules
             if (creature.Prepared == null)
                 creature.Prepared = Prepare(creature, creature.Build ?? new CharacterBuild());
             return creature.Prepared;
+        }
+
+        private static void ApplyImplementedBuildDefaults(CharacterBuild build)
+        {
+            if (build == null || !string.Equals(build.ClassName, "Cleric", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            if (string.IsNullOrWhiteSpace(build.SubclassName) || string.Equals(build.SubclassName, "Cloistered", StringComparison.OrdinalIgnoreCase))
+                build.SubclassName = "Cloistered Cleric";
+            if (string.IsNullOrWhiteSpace(build.ClassFeatName))
+                build.ClassFeatName = "Domain Initiate";
+
+            build.RuleSelections["doctrine"] = "Compendium.pf2e.classfeatures.Item.Cloistered Cleric";
+            build.RuleSelections["divineFont"] = "heal";
+            build.RuleSelections["sanctification"] = "none";
+        }
+
+
+        private static void PrepareImplementedSpellcasting(CreatureComponent creature, PreparedCharacter prepared)
+        {
+            if (!prepared.HasOwnedItem("cleric"))
+                return;
+
+            SpellcastingState spellcasting = new()
+            {
+                Tradition = "divine",
+                Ability = "wis",
+                SpellAttackModifier = SpellcastingRuntime.SpellAttackModifier(creature)
+            };
+            spellcasting.AddPool(new SpellSlotPool("rank-1-bless", SpellSlotKind.Prepared, 1, 1));
+            spellcasting.AddPool(new SpellSlotPool("rank-1-infuse-vitality", SpellSlotKind.Prepared, 1, 1));
+            spellcasting.AddPool(new SpellSlotPool("font-heal", SpellSlotKind.Font, 1, 4));
+
+            spellcasting.AddSpell(new PreparedSpell("Shield", 1, true, false, string.Empty, new[] { 1u }));
+            spellcasting.AddSpell(new PreparedSpell("Guidance", 1, true, false, string.Empty, new[] { 1u }));
+            spellcasting.AddSpell(new PreparedSpell("Divine Lance", 1, true, false, string.Empty, new[] { 2u }));
+            spellcasting.AddSpell(new PreparedSpell("Haunting Hymn", 1, true, false, string.Empty, new[] { 2u }));
+            spellcasting.AddSpell(new PreparedSpell("Light", 1, true, false, string.Empty, new[] { 1u }));
+            spellcasting.AddSpell(new PreparedSpell("Bless", 1, false, false, "rank-1-bless", new[] { 2u }));
+            spellcasting.AddSpell(new PreparedSpell("Infuse Vitality", 1, false, false, "rank-1-infuse-vitality", new[] { 1u, 2u, 3u }));
+            spellcasting.AddSpell(new PreparedSpell("Heal", 1, false, true, "font-heal", new[] { 1u, 2u, 3u }));
+
+            prepared.Spellcasting = spellcasting;
         }
 
         private static void ApplyClassBaseMath(CreatureComponent creature, Pf2eItem classItem, PreparedCharacter prepared)
@@ -124,7 +170,7 @@ namespace Game.Creature.Rules
                 foreach (JObject rule in owned.Item.Rules)
                 {
                     string key = rule.Value<string>("key");
-                    if (key == "ChoiceSet" || key == "GrantItem")
+                    if (key == "ChoiceSet" || key == "GrantItem" || key == "ActiveEffectLike")
                         ProcessRule(rule, owned.Item, prepared, catalog);
                 }
             }
@@ -236,9 +282,7 @@ namespace Game.Creature.Rules
             if (string.IsNullOrWhiteSpace(flag) || prepared.Build.RuleSelections.ContainsKey(flag))
                 return;
 
-            string selectedName = string.Equals(flag, "roguesRacket", StringComparison.OrdinalIgnoreCase)
-                ? prepared.Build.SubclassName
-                : prepared.Build.ClassFeatName;
+            string selectedName = GetChoiceSetSelection(flag, prepared.Build);
             Pf2eItem selected = catalog.Resolve(selectedName);
             if (selected == null)
                 return;
@@ -249,9 +293,17 @@ namespace Game.Creature.Rules
             prepared.Build.RuleSelections[flag] = $"Compendium.pf2e.{pack}.Item.{selected.Name}";
         }
 
+        private static string GetChoiceSetSelection(string flag, CharacterBuild build)
+        {
+            if (string.Equals(flag, "roguesRacket", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(flag, "doctrine", StringComparison.OrdinalIgnoreCase))
+                return build.SubclassName;
+            return build.ClassFeatName;
+        }
+
         private static void ApplyGrantItem(JObject rule, Pf2eItem source, PreparedCharacter prepared, Pf2eItemCatalog catalog)
         {
-            string uuid = ResolveRulesSelectionReference(rule.Value<string>("uuid"), prepared);
+            string uuid = ResolveRuleReference(rule.Value<string>("uuid"), prepared);
             if (string.IsNullOrWhiteSpace(uuid))
                 return;
 
@@ -259,9 +311,13 @@ namespace Game.Creature.Rules
             prepared.AddOwnedItem(granted, source.Slug);
         }
 
-        private static string ResolveRulesSelectionReference(string uuid, PreparedCharacter prepared)
+        private static string ResolveRuleReference(string uuid, PreparedCharacter prepared)
         {
-            if (string.IsNullOrWhiteSpace(uuid) || !uuid.StartsWith("{item|flags.", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(uuid))
+                return null;
+            if (uuid.StartsWith("{actor|", StringComparison.OrdinalIgnoreCase))
+                return ResolveActorReference(uuid, prepared);
+            if (!uuid.StartsWith("{item|flags.", StringComparison.OrdinalIgnoreCase))
                 return uuid;
 
             const string rulesSelections = ".rulesSelections.";
@@ -273,13 +329,31 @@ namespace Game.Creature.Rules
             return prepared.Build.RuleSelections.TryGetValue(flag, out string selection) ? selection : null;
         }
 
+        private static string ResolveActorReference(string uuid, PreparedCharacter prepared)
+        {
+            const string actorPrefix = "{actor|";
+            if (!uuid.StartsWith(actorPrefix, StringComparison.OrdinalIgnoreCase) || !uuid.EndsWith("}"))
+                return uuid;
+
+            string path = uuid.Substring(actorPrefix.Length, uuid.Length - actorPrefix.Length - 1);
+            return prepared.RuleReferences.TryGetValue(path, out string reference) ? reference : null;
+        }
+
         private static void ApplyActiveEffectLike(JObject rule, PreparedCharacter prepared)
         {
             string path = rule.Value<string>("path");
             if (string.IsNullOrWhiteSpace(path))
                 return;
 
-            int value = ResolveRuleInt(rule["value"], prepared);
+            string normalizedPath = path.StartsWith("@actor.", StringComparison.OrdinalIgnoreCase) ? path.Substring("@actor.".Length) : path;
+            JToken valueToken = rule["value"];
+            if (valueToken is JObject objectValue)
+            {
+                StoreRuleReferences(normalizedPath, objectValue, prepared);
+                return;
+            }
+
+            int value = ResolveRuleInt(valueToken, prepared);
             if (path.StartsWith("system.skills.", StringComparison.OrdinalIgnoreCase) && path.EndsWith(".rank", StringComparison.OrdinalIgnoreCase))
             {
                 string skill = path.Substring("system.skills.".Length, path.Length - "system.skills.".Length - ".rank".Length);
@@ -287,11 +361,22 @@ namespace Game.Creature.Rules
                 return;
             }
 
-            string normalizedPath = path.StartsWith("@actor.", StringComparison.OrdinalIgnoreCase) ? path.Substring("@actor.".Length) : path;
             if (string.Equals(rule.Value<string>("mode"), "override", StringComparison.OrdinalIgnoreCase))
                 prepared.RuleValues[normalizedPath] = value;
             else if (!prepared.RuleValues.TryGetValue(normalizedPath, out int current) || value > current)
                 prepared.RuleValues[normalizedPath] = value;
+        }
+
+        private static void StoreRuleReferences(string path, JObject value, PreparedCharacter prepared)
+        {
+            foreach (JProperty property in value.Properties())
+            {
+                string childPath = string.IsNullOrWhiteSpace(path) ? property.Name : path + "." + property.Name;
+                if (property.Value.Type == JTokenType.String)
+                    prepared.RuleReferences[childPath] = property.Value.Value<string>();
+                else if (property.Value is JObject childObject)
+                    StoreRuleReferences(childPath, childObject, prepared);
+            }
         }
 
         private static void AddSavedSkillRanks(PreparedCharacter prepared)
@@ -315,6 +400,8 @@ namespace Game.Creature.Rules
                 return 0;
             if (token.Type == JTokenType.Integer)
                 return token.Value<int>();
+            if (token.Type != JTokenType.String)
+                return 0;
 
             string value = token.Value<string>();
             if (int.TryParse(value, out int parsed))
@@ -349,6 +436,8 @@ namespace Game.Creature.Rules
                 return 0;
             if (token.Type == JTokenType.Integer)
                 return token.Value<int>();
+            if (token.Type != JTokenType.String)
+                return 0;
 
             string value = token.Value<string>();
             if (string.IsNullOrWhiteSpace(value))

--- a/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
+++ b/Assets/Scripts/Creature/Rules/PreparedCharacter.cs
@@ -1,3 +1,4 @@
+using Game.Combat.Spells;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -20,7 +21,9 @@ namespace Game.Creature.Rules
         public List<ActivePf2eEffect> ActiveEffects { get; } = new();
         public Dictionary<string, int> SkillRanks { get; } = new(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, int> RuleValues { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, string> RuleReferences { get; } = new(StringComparer.OrdinalIgnoreCase);
         public List<string> UnsupportedRuleKeys { get; } = new();
+        public SpellcastingState Spellcasting { get; set; }
 
         /// <summary>
         /// Creates prepared state around saved build choices while leaving all derivation to the preparer.

--- a/Assets/Scripts/Grid/StrikeTargeting.cs
+++ b/Assets/Scripts/Grid/StrikeTargeting.cs
@@ -24,11 +24,16 @@ namespace GridPublic
         public int RangeIncrementFeet { get; set; } = 0;
         public bool IsRanged { get; set; } = false;
         public bool RequiresLineOfEffect { get; set; } = true;
+        public int FixedRangeFeet { get; set; } = 0;
 
         public int MaximumRangeFeet
         {
             get
             {
+                if (IsRanged && FixedRangeFeet > 0)
+                    return FixedRangeFeet;
+                if (IsRanged && FixedRangeFeet > 0)
+                    return FixedRangeFeet;
                 if (IsRanged && RangeIncrementFeet > 0)
                     return RangeIncrementFeet * 6;
                 return ReachFeet;
@@ -94,7 +99,11 @@ namespace GridPrivate
 
             int distance = MeasureGridDistanceFeet(start, target);
             if (request.IsRanged)
+            {
+                if (request.FixedRangeFeet > 0)
+                    return distance <= request.FixedRangeFeet;
                 return request.RangeIncrementFeet > 0 && distance <= request.RangeIncrementFeet * 6;
+            }
             return distance <= request.ReachFeet;
         }
 
@@ -155,7 +164,7 @@ namespace GridPrivate
             if (request.IsRanged && clearRays > 0 && clearRays < 16)
                 cover = GridPublic.StrikeCover.Standard;
 
-            int rangePenalty = request.IsRanged
+            int rangePenalty = request.IsRanged && request.FixedRangeFeet <= 0
                 ? CalculateRangePenalty(distance, request.RangeIncrementFeet)
                 : 0;
 

--- a/Assets/Tests/EditMode/Pf2eClericSpellcastingTests.cs
+++ b/Assets/Tests/EditMode/Pf2eClericSpellcastingTests.cs
@@ -1,0 +1,252 @@
+using Game.Combat.Spells;
+using Game.Creature;
+using Game.Creature.Rules;
+using GridPublic;
+using NUnit.Framework;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class Pf2eClericSpellcastingTests
+{
+    private readonly List<GameObject> created = new();
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (GameObject go in created)
+            if (go != null)
+                Object.DestroyImmediate(go);
+        created.Clear();
+        Pf2eItemCatalog.ResetForTests();
+    }
+
+    [Test]
+    public void CatalogResolvesClericItemsAndRequestedSpells()
+    {
+        Pf2eItemCatalog catalog = Pf2eItemCatalog.Instance;
+
+        Assert.That(catalog.Resolve("Compendium.pf2e.classes.Item.Cleric")?.Slug, Is.EqualTo("cleric"));
+        Assert.That(catalog.Resolve("Domain Initiate")?.Slug, Is.EqualTo("domain-initiate"));
+        Assert.That(catalog.Resolve("Haunting Hymn")?.Slug, Is.EqualTo("haunting-hymn"));
+        Assert.That(catalog.Resolve("Infuse Vitality")?.Slug, Is.EqualTo("infuse-vitality"));
+        Assert.That(catalog.Resolve("Cleric Spellcasting")?.Slug, Is.EqualTo("cleric-spellcasting"));
+    }
+
+    [Test]
+    public void LevelOneClericPreparesCloisteredDivineFontAndNoSanctification()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        PreparedCharacter prepared = cleric.Prepared;
+
+        Assert.That(cleric.Build.SubclassName, Is.EqualTo("Cloistered Cleric"));
+        Assert.That(cleric.Build.ClassFeatName, Is.EqualTo("Domain Initiate"));
+        Assert.That(prepared.HasOwnedItem("cleric"), Is.True);
+        Assert.That(prepared.HasOwnedItem("cleric-spellcasting"), Is.True);
+        Assert.That(prepared.HasOwnedItem("cloistered-cleric"), Is.True);
+        Assert.That(prepared.HasOwnedItem("first-doctrine-cloistered-cleric"), Is.True);
+        Assert.That(prepared.HasOwnedItem("divine-font"), Is.True);
+        Assert.That(prepared.HasOwnedItem("healing-domain"), Is.False);
+        Assert.That(prepared.HasOwnedItem("healers-blessing"), Is.False);
+        Assert.That(prepared.Build.RuleSelections["divineFont"], Is.EqualTo("heal"));
+        Assert.That(prepared.Build.RuleSelections["sanctification"], Is.EqualTo("none"));
+        Assert.That(prepared.RollOptions, Does.Not.Contain("holy"));
+        Assert.That(prepared.RollOptions, Does.Not.Contain("unholy"));
+    }
+
+    [Test]
+    public void ClericSpellStateHasRequestedSpellsSlotsAndWisdomMath()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        SpellcastingState state = cleric.Prepared.Spellcasting;
+
+        CollectionAssert.AreEquivalent(new[]
+        {
+            "shield", "guidance", "divine-lance", "haunting-hymn", "light", "bless", "infuse-vitality", "heal"
+        }, state.PreparedSpells.Select(spell => spell.Slug));
+        Assert.That(state.PreparedSpells.Count(spell => spell.IsCantrip), Is.EqualTo(5));
+        Assert.That(state.Pools["rank-1-bless"].UsesRemaining, Is.EqualTo(1));
+        Assert.That(state.Pools["rank-1-infuse-vitality"].UsesRemaining, Is.EqualTo(1));
+        Assert.That(state.Pools["font-heal"].UsesRemaining, Is.EqualTo(4));
+        Assert.That(state.SpellAttackModifier, Is.EqualTo(7));
+        Assert.That(state.SpellDc, Is.EqualTo(17));
+        foreach (PreparedSpell spell in state.PreparedSpells)
+            Assert.That(SpellRegistry.TryGet(spell.Slug, out _), Is.True, spell.Name + " should have a runtime definition");
+    }
+
+    [Test]
+    public void ShieldAddsCircumstanceAcAndExpiresOnCasterNextTurn()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        TestActionController controller = cleric.gameObject.AddComponent<TestActionController>();
+        controller.ActionPoints = 3;
+        controller.IsTakingAction = true;
+
+        Cast("shield", cleric, 1);
+
+        Assert.That(cleric.ResolveArmorClass().Total, Is.EqualTo(12));
+        Assert.That(controller.ActionPoints, Is.EqualTo(2));
+
+        controller.StartTurn();
+
+        Assert.That(cleric.ResolveArmorClass().Total, Is.EqualTo(11));
+    }
+
+    [Test]
+    public void GuidanceAppliesOnceThenRecordsEncounterImmunity()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        CreatureComponent ally = CreateCreature("Ally");
+
+        CastSpellResult result = Cast("guidance", cleric, 1, ally.gameObject);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(ally.ResolveAttackRoll().Total, Is.EqualTo(1));
+        Assert.That(ally.ResolveAttackRoll().Total, Is.EqualTo(0));
+        Assert.That(ally.GetComponent<SpellEffectController>().HasEffect<GuidanceImmunitySpellEffect>(), Is.True);
+
+        CastSpellResult second = SpellcastingRuntime.Cast(cleric.gameObject, cleric.Prepared.Spellcasting.GetSpell("guidance"), 1, new[] { ally.gameObject }, spendActions: false);
+        Assert.That(second.Success, Is.False);
+    }
+
+    [Test]
+    public void BlessGrantsStatusAttackBonusAndConsumesPreparedSlot()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        CreatureComponent ally = CreateCreature("Ally");
+        ally.transform.position = new Vector3(2, 0, 0);
+
+        CastSpellResult result = Cast("bless", cleric, 2, ally.gameObject);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(ally.ResolveAttackRoll().Total, Is.EqualTo(1));
+        Assert.That(cleric.Prepared.Spellcasting.Pools["rank-1-bless"].UsesRemaining, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void InfuseVitalityAddsVitalityDamageToWeaponAndUnarmedStrikes()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        CreatureComponent ally = CreateCreature("Ally");
+
+        CastSpellResult result = Cast("infuse-vitality", cleric, 1, ally.gameObject);
+
+        Assert.That(result.Success, Is.True);
+        CreatureComponent target = CreateCreature("Target");
+        StrikeResolutionContext context = StrikeResolutionContext.FromRequest(new StrikeResolutionRequest
+        {
+            Attacker = ally.gameObject,
+            Target = target.gameObject,
+            Profile = new StrikeProfile(new List<Dice> { new Dice(1, 6, "slashing") }, new List<DamageValue>()) { WeaponCategory = "martial" },
+            TargetingResult = new StrikeTargetResult
+            {
+                Target = target.gameObject,
+                LineOfEffect = StrikeLineOfEffect.Clear,
+                Cover = StrikeCover.None
+            }
+        });
+        foreach (IStrikeAdjustment adjustment in ally.GetComponent<SpellEffectController>().GetStrikeAdjustments(context))
+            adjustment.Apply(context);
+
+        Assert.That(context.DamageDice.Any(die => die.damageType == "vitality" && die.numberOfDice == 1 && die.sidesPerDie == 4), Is.True);
+        Assert.That(cleric.Prepared.Spellcasting.Pools["rank-1-infuse-vitality"].UsesRemaining, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void HealUsesFontPoolAndCanHealLivingTargets()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        CreatureComponent ally = CreateCreature("Ally");
+        ally.hp = 3;
+        ally.maxHp = 20;
+        UnityEngine.Random.InitState(12);
+
+        CastSpellResult result = Cast("heal", cleric, 2, ally.gameObject);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(ally.hp, Is.GreaterThan(3));
+        Assert.That(cleric.Prepared.Spellcasting.Pools["font-heal"].UsesRemaining, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void DivineLanceUsesSpellAttackAndMultipleAttackPenalty()
+    {
+        CreatureComponent cleric = CreatePreparedCleric();
+        TestActionController controller = cleric.gameObject.AddComponent<TestActionController>();
+        controller.ActionPoints = 3;
+        controller.IsTakingAction = true;
+        CreatureComponent target = CreateCreature("Target");
+        target.transform.position = new Vector3(6, 0, 0);
+        target.ac = 12;
+        target.hp = 100;
+        target.maxHp = 100;
+        UnityEngine.Random.InitState(3);
+        InstallTestCombatLog();
+
+        CastSpellResult result = Cast("divine-lance", cleric, 2, target.gameObject);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(controller.ActionPoints, Is.EqualTo(1));
+        Assert.That(controller.StrikePenalty, Is.EqualTo(1));
+    }
+
+    private void InstallTestCombatLog()
+    {
+        GameObject logObject = new("Test Combat Log");
+        created.Add(logObject);
+        TestCombatLog log = logObject.AddComponent<TestCombatLog>();
+        FieldInfo field = typeof(SingletonMonoBehaviour<CombatLogInterface>).GetField("Instance", BindingFlags.Static | BindingFlags.NonPublic);
+        field.SetValue(null, log);
+    }
+    private CastSpellResult Cast(string slug, CreatureComponent caster, uint actionCost, params GameObject[] targets)
+    {
+        PreparedSpell spell = caster.Prepared.Spellcasting.GetSpell(slug);
+        return SpellcastingRuntime.Cast(caster.gameObject, spell, actionCost, targets, spendActions: true);
+    }
+
+    private CreatureComponent CreatePreparedCleric()
+    {
+        CreatureComponent creature = CreateCreature("Prepared Cleric");
+        creature.level = 1;
+        creature.wisMod = 4;
+        creature.ac = 11;
+        creature.Build = new CharacterBuild { ClassName = "Cleric" };
+        creature.Prepared = Pf2eCharacterPreparer.Prepare(creature, creature.Build);
+        return creature;
+    }
+
+    private CreatureComponent CreateCreature(string name)
+    {
+        GameObject go = new(name);
+        created.Add(go);
+        CreatureComponent creature = go.AddComponent<CreatureComponent>();
+        go.AddComponent<Conditions>();
+        creature.hp = 10;
+        creature.maxHp = 10;
+        return creature;
+    }
+
+    private sealed class TestCombatLog : CombatLogInterface
+    {
+        public readonly List<string> Messages = new();
+
+        public override void DevMode() { }
+        public override void ReleaseMode() { }
+        public override void AddWhiteList(string tag) { }
+        public override void AddBlackList(string tag) { }
+        public override void DevLog(string msg) => Messages.Add(msg);
+        public override void DevLog(string msg, string tag) => Messages.Add(msg);
+        public override void DevLog(string msg, List<string> tags) => Messages.Add(msg);
+        public override void Log(string msg) => Messages.Add(msg);
+        public override void Log(string msg, string tag) => Messages.Add(msg);
+        public override void Log(string msg, List<string> tags) => Messages.Add(msg);
+        public override List<string> GetMessages() => new(Messages);
+    }
+
+    private sealed class TestActionController : ActionController    {
+        public override void EndTurn()
+        {
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Pf2eClericSpellcastingTests.cs.meta
+++ b/Assets/Tests/EditMode/Pf2eClericSpellcastingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d23eeb58a42f45a8946de8a89ab0c503
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayMode/TestsState/ClericSpellcastingPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/TestsState/ClericSpellcastingPlayModeTests.cs
@@ -1,0 +1,57 @@
+using Game.Combat.Spells;
+using Game.Creature;
+using Game.Creature.Rules;
+using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class ClericSpellcastingPlayModeTests : PlayModeBase
+{
+    private GameObject clericObject;
+    private ActionController clericController;
+
+    [TearDown]
+    public void CleanupCleric()
+    {
+        if (clericController != null)
+        {
+            CombatManagerInterface manager = Object.FindFirstObjectByType<CombatManagerInterface>();
+            manager?.Remove(clericController);
+            clericController = null;
+        }
+
+        if (clericObject != null)
+            Object.Destroy(clericObject);
+
+        Pf2eItemCatalog.ResetForTests();
+    }
+
+    [UnityTest]
+    public IEnumerator ClericWithPlayerControllerGetsSpellActionsAndLightSpendsActions()
+    {
+        clericObject = new GameObject("PlayMode Cleric");
+        CreatureComponent cleric = clericObject.AddComponent<CreatureComponent>();
+        cleric.level = 1;
+        cleric.wisMod = 4;
+        cleric.Build = new CharacterBuild { ClassName = "Cleric" };
+        cleric.Prepared = Pf2eCharacterPreparer.Prepare(cleric, cleric.Build);
+        clericObject.AddComponent<Team>().Name = "players";
+        PlayerActionController controller = clericObject.AddComponent<PlayerActionController>();
+        clericController = controller;
+
+        yield return null;
+
+        Assert.That(controller.GetActions().Any(action => action.ActionName == "Light"), Is.True);
+        Assert.That(controller.GetActions().Any(action => action.ActionName == "Shield"), Is.True);
+
+        controller.StartTurn();
+        EntityAction light = controller.GetActions().First(action => action.ActionName == "Light");
+        controller.TakeAction(light);
+        yield return null;
+
+        Assert.That(controller.ActionPoints, Is.EqualTo(2));
+        Assert.That(controller.IsTakingAction, Is.False);
+    }
+}

--- a/Assets/Tests/PlayMode/TestsState/ClericSpellcastingPlayModeTests.cs.meta
+++ b/Assets/Tests/PlayMode/TestsState/ClericSpellcastingPlayModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93271c1f4a1c4dcdb5a5e56ef67da02f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UIStuff/HUD/CombatLog.cs
+++ b/Assets/UIStuff/HUD/CombatLog.cs
@@ -55,19 +55,24 @@ public class CombatLog : CombatLogInterface
 
     protected void RefreshLogList()
     {
+        if (LogList == null)
+            return;
+
         CurrentEntries = GetVisibleEntries();
         LogList.itemsSource = CurrentEntries;
         LogList.Rebuild();
-        if (LogList != null && CurrentEntries.Count > 0)
+        if (CurrentEntries.Count > 0)
             LogList.ScrollToItem(CurrentEntries.Count - 1);
     }
 
     protected void UpdateLogList(CombatLogEntry entry)
     {
+        if (CurrentEntries == null || LogList == null)
+            return;
+
         CurrentEntries.Add(entry);
         LogList.RefreshItems();
-        if (LogList != null)
-            LogList.ScrollToItem(CurrentEntries.Count - 1);
+        LogList.ScrollToItem(CurrentEntries.Count - 1);
     }
 
     [ContextMenu("Enable Dev Mode")]


### PR DESCRIPTION
## Summary
- Adds level-1 Cloistered Cleric data and limits the selectable Cleric path to Cloistered Cleric for this pass.
- Adds reusable spellcasting runtime state, slot/font pools, spell actions, and ongoing spell effects for the requested initial Cleric spells.
- Refactors spell behavior into per-spell runtime definition classes registered by slug, so new spells do not extend a central cast switch.
- Adds EditMode and PlayMode coverage for Cleric preparation, spell math, spell effects, action registration, and action spending.

Closes #100
Part of #99
Follow-up: #104

## Data Provenance
- Cleric class, cleric class features including Divine Font, Domain Initiate, Haunting Hymn, and the cleric-used spell JSON are byte-for-byte copies from `foundryvtt/pf2e` `v14-dev` raw JSON.
- Verified 17 JSON files against fresh upstream downloads: Cleric class, eight cleric class features, Domain Initiate, Haunting Hymn, Shield, Guidance, Divine Lance, Light, Bless, Heal, and Infuse Vitality.
- `Resources/Data/class.json` remains local runtime selection metadata and is not a Foundry pack document.

## Design Notes
- `CastSpellAction` is now a thin Unity action wrapper. It resolves an `ISpellDefinition` from `SpellRegistry`, then delegates target selection and cast resolution to that spell class.
- Implemented spells live as separate runtime definitions: Shield, Guidance, Divine Lance, Haunting Hymn, Light, Bless, Infuse Vitality, and Heal.
- Ongoing spell effects are represented by effect objects such as `ShieldSpellEffect`, `GuidanceSpellEffect`, `BlessSpellEffect`, and `InfuseVitalitySpellEffect` instead of a central effect enum switch.

## Scope Notes
- Healing Domain and Healer's Blessing are not granted in this PR because focus spell runtime support is not implemented yet. That work is tracked in #104.
- Light spends actions and logs the cast; no visual light effect is included.
- Shield Block, focus-point casting, Bless sustain expansion, daily rest UI, broader spell preparation, Warpriest, and non-implemented Cleric feats are out of scope.
- No scene/prefab/UI layout visual changes are included in this foundation PR, so no screenshot artifact is attached.

## Tests
- `& "C:\Program Files\Unity\Hub\Editor\6000.2.1f1\Editor\Unity.exe" -batchmode -runTests -projectPath . -testPlatform editmode -testResults TestResults/EditModeResults.xml -logFile TestResults/EditMode.log`
  - Passed: 70/70
- `& "C:\Program Files\Unity\Hub\Editor\6000.2.1f1\Editor\Unity.exe" -batchmode -runTests -projectPath . -testPlatform playmode -testResults TestResults/PlayModeResults.xml -logFile TestResults/PlayMode.log`
  - Passed: 43/43
- `git diff HEAD^ HEAD --check`
  - Passed
- SHA-256 comparison against fresh `foundryvtt/pf2e` `v14-dev` downloads for 17 upstream-backed JSON files
  - Passed
