### PR TITLE
[Docs] Codify feature-owned rules boundaries

### DIFF
--- a/.agents/review/code_review.md
+++ b/.agents/review/code_review.md
@@ -32,6 +32,17 @@ When PF2e behavior or runtime data changes, inspect:
 - JSON shape, DTO conversion, defaults, missing or malformed fields, `Resources.Load` paths, data-driven versus hardcoded content, and compatibility with existing data files.
 - ORC provenance and the boundary between open rules mechanics and protected lore, prose, art, or trade dress.
 
+Also inspect feature ownership boundaries:
+
+- Shared bridges, managers, dispatchers, facades, and catalogs should not acquire feature-named
+  methods, fields, caches, trigger flags, or condition switches. Prefer feature-owned Ops, handlers,
+  listeners, selectors, and adapters over general-purpose helpers that know one feature's rules.
+- Distinguish allowed composition from leaked behavior. A composition root may register a feature
+  module or seed its bindings, but it should not reproduce that feature's validation or workflow.
+- Require each new horizontal API to be necessary for the current vertical slice and expressed
+  without feature terminology. Check whether a feature can construct a generic Op, listen to a
+  generic Fact, or query its own selector before accepting shared infrastructure.
+
 ## UI, scenes, and assets
 
 When UI or serialized Unity content changes, inspect:

--- a/.agents/skills/pf2e-rules/SKILL.md
+++ b/.agents/skills/pf2e-rules/SKILL.md
@@ -18,9 +18,16 @@ Use this skill when changing Pathfinder 2e rules behavior or data in this reposi
 
 1. Locate the affected JSON under `Assets/Resources/DataFiles` and the loading/mapping code in `Assets/Scripts/Creature`.
 2. Locate the runtime calculation path in combat, creature, equipment, action, or condition code.
-3. Add deterministic tests for rules math before refactoring broad behavior.
-4. Cover PF2e-sensitive areas: degree of success, multiple attack penalty, action economy, damage dice, resistances/weaknesses, conditions, proficiency, and item bonuses.
-5. Keep UI labels and player-facing text short and source-safe.
+3. Identify the cohesive feature module that should own the rule-specific operations, validation,
+   handlers, listeners, selectors, state, and Unity adapter code. Follow the boundary in `AGENTS.md`
+   and `Docs/Ops_Based_Rules_Proposal.md`.
+4. Keep shared engines, bridges, managers, and facades feature-agnostic. Prefer publishing generic
+   timing Facts or dispatching generic Ops so the feature module can decide how its rule responds.
+5. Add horizontal infrastructure only when the current vertical slice requires it, and keep the
+   shared API free of feature terminology.
+6. Add deterministic tests for rules math before refactoring broad behavior.
+7. Cover PF2e-sensitive areas: degree of success, multiple attack penalty, action economy, damage dice, resistances/weaknesses, conditions, proficiency, and item bonuses.
+8. Keep UI labels and player-facing text short and source-safe.
 
 ## Data Rules
 

--- a/.agents/skills/unity-coding/SKILL.md
+++ b/.agents/skills/unity-coding/SKILL.md
@@ -22,6 +22,12 @@ Use this skill for C# gameplay, tests, architecture refactors, compile fixes, an
 - Do not raw-edit scenes, prefabs, materials, or serialized assets for gameplay refactors.
 - Follow the C# XML documentation requirements in `AGENTS.md` for new or modified public APIs and complex internal behavior; keep existing documentation synchronized with every behavior change.
 - Avoid new global state. If existing singleton/static-event behavior is involved, isolate it behind a seam before expanding it.
+- Follow the feature-ownership boundary in `AGENTS.md` and
+  `Docs/Ops_Based_Rules_Proposal.md`: feature modules own feature-specific operations, validation,
+  handlers, listeners, selectors, state, and Unity adapters.
+- Keep Unity bridges, managers, and facades feature-agnostic. Composition may install a named
+  feature, but shared code must not implement its conditions or workflow. Prefer feature-created Ops
+  and feature listeners for generic Facts over feature-specific bridge helpers.
 - Save and restore random state in tests that touch randomness.
 - Keep generated Unity files and results out of version control.
 - Remove the task worktree after the work is merged, closed, or abandoned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,18 @@ Use `.agent-temp/` at the checkout root for temporary body files, generated comm
 - Update nearby XML documentation whenever existing code changes make it incomplete, inaccurate, or misleading.
 - Keep gameplay code in the existing assembly boundaries: `MainGameAssembly`, `EditModeAssembly`, and `PlayModeAssembly`.
 - Prefer small vertical changes with targeted EditMode tests first, then PlayMode smoke coverage for scene, UI, or MonoBehaviour behavior.
+- Default each rule, feat, spell, and action to a cohesive feature-owned module. That module should
+  own its feature-specific operations, validation, handlers, listeners, selectors, persistent state,
+  and Unity data extraction or presentation adapters. Feature ownership does not require putting all
+  of those responsibilities in one class.
+- Keep shared rules runtime, bridge, manager, and facade APIs feature-agnostic. A composition root may
+  name a feature to register its definitions or seed its bindings, but general-purpose classes must
+  not implement the feature's conditions or workflow. Avoid feature-named methods, fields, caches,
+  trigger flags, and switches when the feature can construct a generic operation, listen to a generic
+  Fact, or query its own selector.
+- Add horizontal/shared infrastructure only when the current vertical slice proves it necessary, and
+  keep that API free of feature terminology. See `Docs/Ops_Based_Rules_Proposal.md`, especially
+  "Feature modules own feature semantics."
 - Avoid introducing new singleton/static-event coupling. When refactoring combat or rules logic, add testable seams for dice/randomness, data loading, and combat math.
 - Keep PF2e calculations deterministic in tests. Save and restore Unity random state if a test touches random behavior.
 - During active development, do not add compatibility layers, schema/data version dispatch, or migrations for unshipped formats. Make coordinated breaking changes to code, data, fixtures, and tests unless a human explicitly requests compatibility.

--- a/Docs/Ops_Based_Rules_Proposal.md
+++ b/Docs/Ops_Based_Rules_Proposal.md
@@ -949,6 +949,36 @@ The main Unity assembly provides a configurable generic `MonoBehaviour` helper i
 
 Each concrete observer handles one typed transition. For example, a `TokenMovedFact` supplies its old and new squares for animation while `currentSnapshot` supplies the token's authoritative current position and any derived current aura or UI state. This keeps transition history in Facts, current-state lookup in the snapshot, and Unity concerns outside the rules authority.
 
+### 7.3 Feature modules own feature semantics
+
+A rule, feat, spell, or action owns the code that explains what that feature means. Its cohesive
+feature module contains its feature-specific Ops, validation, handlers, binding listeners, selectors,
+persistent state, and any Unity adapter that extracts or presents feature data. These responsibilities
+may be split across several focused classes; feature ownership is a dependency-boundary rule, not a
+requirement to create one oversized class.
+
+Shared runtime and Unity integration code provide mechanisms expressed in domain-neutral vocabulary:
+dispatching an `IRuleOp<TResult>`, publishing a timing Fact, registering a binding, reading a snapshot,
+or projecting committed state. They do not provide shortcuts such as `DispatchSpecificFeat`, remember
+whether one feat's trigger was consumed, or decide whether one spell's conditions match.
+
+A composition root is the narrow exception. It may name a feature module to register its definitions,
+handlers, listeners, or initial bindings. That reference selects installed behavior; it must not
+reimplement the feature's validation or workflow.
+
+For example, general encounter code can publish an `InitiativeRolledFact`. A Quick-Tempered binding
+can listen for that Fact and own the decision to start Rage. Likewise, a Rage action-bar adapter can
+construct `RageActionOp` and pass it through a generic dispatch boundary; the bridge does not need a
+Rage-specific dispatch method.
+
+Before adding a feature-named member to a shared bridge, manager, dispatcher, facade, or catalog, ask
+whether the feature can instead:
+
+- construct and dispatch its own typed Op;
+- react to an existing generic lifecycle Op or committed Fact;
+- expose a feature-owned selector over `RulesSnapshot`; or
+- register feature-owned behavior or bindings at the composition root.
+
 ---
 
 ## 8. Worked example: normal Strike
@@ -2101,6 +2131,7 @@ These rules should be enforced in code review and tests:
 15. **Rules assemblies contain no Unity scene-object references.**
 16. **Each operation result is one sealed structural case; only Resolved exposes a value and only Invalid exposes a reason.**
 17. **Attaching descendant Facts preserves the operation result's concrete case.**
+18. **Feature-specific semantics stay in the feature module; shared runtime and Unity integration expose only generic mechanisms and composition.**
 
 ---
 
@@ -2300,7 +2331,15 @@ When implementing a new rule, answer these questions in order:
 
     Test the committed Facts and state, not only the returned outcome.
 
-If a feature needs a central `switch` on its definition ID, stop and check whether it belongs in a binding, typed state record, handler registration, or data definition instead.
+11. **Where does the feature-specific knowledge live?**
+
+    Keep the feature's operations, validation, handlers, listeners, selectors, state, and Unity
+    extraction or presentation in its feature module. Let shared code publish generic timing Facts,
+    dispatch generic Ops, and register modules without learning the feature's rules.
+
+If a feature needs a central `switch` on its definition ID, or a feature-named method, cache, or
+trigger flag in a shared bridge or facade, stop and check whether it belongs in a binding, typed state
+record, handler registration, selector, or feature adapter instead.
 
 ---
 

--- a/Docs/Ops_Based_Rules_Proposal.md
+++ b/Docs/Ops_Based_Rules_Proposal.md
@@ -2337,9 +2337,9 @@ When implementing a new rule, answer these questions in order:
     extraction or presentation in its feature module. Let shared code publish generic timing Facts,
     dispatch generic Ops, and register modules without learning the feature's rules.
 
-If a feature needs a central `switch` on its definition ID, or a feature-named method, cache, or
-trigger flag in a shared bridge or facade, stop and check whether it belongs in a binding, typed state
-record, handler registration, selector, or feature adapter instead.
+    If a feature needs a central `switch` on its definition ID, or a feature-named method, cache, or
+    trigger flag in a shared bridge or facade, stop and check whether it belongs in a binding, typed
+    state record, handler registration, selector, or feature adapter instead.
 
 ---
 


### PR DESCRIPTION
## Summary

- make cohesive feature ownership the default in `AGENTS.md`
- document the boundary between feature semantics, generic runtime mechanisms, and composition roots
- add explicit feature-leakage checks to the code-review rubric
- reinforce the same default in the Unity coding and PF2e rules skills

## Design rule

Rules, feats, spells, and actions own their feature-specific operations, validation, handlers, listeners, selectors, state, and Unity adapters. Shared bridges, managers, dispatchers, and facades expose feature-agnostic mechanisms. Composition roots may name feature modules to install them, but do not reimplement their behavior.

The guidance explicitly distinguishes a cohesive feature module from a single oversized class.

## Scope

This is a documentation and agent-guidance change only. It modifies:

- `AGENTS.md`
- `Docs/Ops_Based_Rules_Proposal.md`
- `.agents/review/code_review.md`
- `.agents/skills/unity-coding/SKILL.md`
- `.agents/skills/pf2e-rules/SKILL.md`

`Docs/PF2E_RULE_PIPELINE.md` remains unchanged because the Rage implementation it would describe is still under review and has not merged to `main`.

## Verification

- both modified skills pass `quick_validate.py`
- exact five-file changed-scope assertions pass
- required policy anchors occur exactly once
- `git diff --check` passes
- GitHub CSharpier, change-detection, EditMode, and PlayMode checks pass on `19d9a43`
- local Unity tests were not run because no runtime, test, data, or serialized Unity files changed

## Review gates

- a fresh `gpt-5.6-sol` review at `xhigh` found no actionable defects for `006723d` against base `a20220a`
- Copilot identified one Markdown indentation issue; `19d9a43` fixed it and the thread is resolved
- Copilot re-reviewed exact head `19d9a43` and generated no new comments
