### PR TITLE
feat: complete authoritative turn resources (#133)

### DIFF
--- a/Assets/KayKit/Runtime/DungeonDoorController.cs
+++ b/Assets/KayKit/Runtime/DungeonDoorController.cs
@@ -80,6 +80,15 @@ namespace Game.KayKit
         }
 
         /// <summary>
+        /// Determines whether this door can open against its current map state without mutating it.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> when the door is already open or its map cell remains a valid
+        /// door mutation target; otherwise <see langword="false"/>.
+        /// </returns>
+        public bool CanOpen() => IsOpen || map.CanSetDoorState(Cell, true);
+
+        /// <summary>
         /// Opens this door idempotently while atomically updating visuals, movement, pathfinding,
         /// and line of sight. V1 doors expose no runtime close operation.
         /// </summary>

--- a/Assets/Scripts/Combat/ActionController.cs
+++ b/Assets/Scripts/Combat/ActionController.cs
@@ -30,13 +30,18 @@ public abstract class ActionController : MonoBehaviour
         }
     }
 
-    /// <summary>Gets authoritative remaining actions while attached to encounter rules.</summary>
+    /// <summary>Gets authoritative ordinary actions while attached to encounter rules.</summary>
     public uint ActionPoints =>
         TryGetAttachedCombatRules(out UnityCombatRulesBridge bridge, out CreatureId actor)
-            ? checked((uint)bridge.GetActionsRemaining(actor))
+            ? checked((uint)bridge.GetStandardActionsRemaining(actor))
             : 0;
 
-    /// <summary>Gets whether the current encounter reaction has been spent.</summary>
+    /// <summary>Gets whether the authoritative optional action resource is available.</summary>
+    public bool OptionalActionAvailable =>
+        TryGetAttachedCombatRules(out UnityCombatRulesBridge bridge, out CreatureId actor)
+        && bridge.GetOptionalActionAvailable(actor);
+
+    /// <summary>Gets whether the current encounter reaction is unavailable.</summary>
     public bool Reacted =>
         TryGetAttachedCombatRules(out UnityCombatRulesBridge bridge, out CreatureId actor)
         && !bridge.GetActionEconomy(actor).ReactionAvailable;
@@ -75,21 +80,6 @@ public abstract class ActionController : MonoBehaviour
     public virtual void ResetEncounterTurnState()
     {
         IsTakingAction = false;
-    }
-
-    /// <summary>Spends actions through the encounter store when combat rules are attached.</summary>
-    /// <param name="amount">The action count paid by a Unity-hosted action, including a free action.</param>
-    /// <exception cref="System.InvalidOperationException">
-    /// The controller cannot afford the requested positive cost.
-    /// </exception>
-    public void SpendActions(uint amount)
-    {
-        if (amount == 0)
-            return;
-        (UnityCombatRulesBridge bridge, CreatureId actor) = RequireCombatRules();
-        if (amount > checked((uint)bridge.GetActionsRemaining(actor)))
-            throw new System.InvalidOperationException("The controller cannot afford this action.");
-        bridge.SpendEncounterActions(actor, checked((int)amount));
     }
 
     internal void AttachCombatRules(UnityCombatRulesBridge bridge, CreatureId creatureId)

--- a/Assets/Scripts/Combat/DungeonEncounterRuntimeController.cs
+++ b/Assets/Scripts/Combat/DungeonEncounterRuntimeController.cs
@@ -6,6 +6,8 @@ using Game.Combat.Exploration;
 using Game.Creature;
 using Game.DungeonGeneration;
 using Game.KayKit;
+using Game.Rules.Runtime;
+using Game.Rules.Unity;
 using GridPrivate;
 using GridPublic;
 using UnityEngine;
@@ -287,6 +289,8 @@ namespace Game.Combat.Encounters
             bool actorIsAlive = actorIsPartyMember && CanObserve(actor);
             if (
                 actor == null
+                || !actorIsPartyMember
+                || !actorIsAlive
                 || actor.IsTakingAction
                 || mode == DungeonDoorInteractionMode.Combat && !actor.HasTurnAuthority
             )
@@ -298,18 +302,27 @@ namespace Game.Combat.Encounters
             DungeonDoorInteractionDecision decision = DungeonDoorInteractionPolicy.Evaluate(
                 new DungeonDoorInteractionRequest(
                     mode,
-                    actorIsPartyMember,
-                    actorIsAlive,
                     new DungeonCell(actorPosition.x, actorPosition.z),
                     door.Cell,
-                    door.IsOpen,
-                    actor.ActionPoints
+                    door.IsOpen
                 )
             );
-            if (!decision.IsAllowed || !door.TryOpen())
+            if (!decision.IsAllowed)
                 return false;
-
-            actor.SpendActions(decision.ActionCost);
+            if (mode == DungeonDoorInteractionMode.Combat)
+            {
+                if (
+                    !actor.TryGetCombatRules(
+                        out UnityCombatRulesBridge bridge,
+                        out CreatureId creature
+                    )
+                    || bridge.Dispatch(new InteractActionOp(creature))
+                        is not ResolvedOpResult<InteractOutcome>
+                )
+                    return false;
+            }
+            if (!door.TryOpen())
+                return false;
             combatManager.RefreshRulesTopology();
             openDoorIds.Add(door.StableId);
             EnterReachableEncounterRooms();

--- a/Assets/Scripts/Combat/DungeonEncounterRuntimeController.cs
+++ b/Assets/Scripts/Combat/DungeonEncounterRuntimeController.cs
@@ -309,6 +309,8 @@ namespace Game.Combat.Encounters
             );
             if (!decision.IsAllowed)
                 return false;
+            if (!door.CanOpen())
+                return false;
             if (mode == DungeonDoorInteractionMode.Combat)
             {
                 if (
@@ -322,7 +324,12 @@ namespace Game.Combat.Encounters
                     return false;
             }
             if (!door.TryOpen())
-                return false;
+            {
+                throw new InvalidOperationException(
+                    $"Door '{door.StableId}' passed its mutation precondition but could not open. "
+                        + "Door mutation must remain synchronous on Unity's main thread."
+                );
+            }
             combatManager.RefreshRulesTopology();
             openDoorIds.Add(door.StableId);
             EnterReachableEncounterRooms();

--- a/Assets/Scripts/Combat/EntityAction.cs
+++ b/Assets/Scripts/Combat/EntityAction.cs
@@ -37,12 +37,6 @@ public abstract class EntityAction
         return controller.IsInDungeonExploration || ActionCost <= controller.ActionPoints;
     }
 
-    protected void PayCost(ActionController ac)
-    {
-        if (ac != null && !ac.IsInDungeonExploration)
-            ac.SpendActions(ActionCost);
-    }
-
     /// <summary>
     /// Base caller for entity actions. Should be
     /// called once action is completed.

--- a/Assets/Scripts/Combat/Exploration/DungeonDoorInteractionPolicy.cs
+++ b/Assets/Scripts/Combat/Exploration/DungeonDoorInteractionPolicy.cs
@@ -21,20 +21,11 @@ namespace Game.Combat.Exploration
         /// <summary>The supplied gameplay mode is not defined.</summary>
         InvalidMode,
 
-        /// <summary>The actor is not a player character.</summary>
-        ActorIsNotPlayerCharacter,
-
-        /// <summary>The actor is not alive.</summary>
-        ActorIsDead,
-
         /// <summary>The target door is already open.</summary>
         DoorAlreadyOpen,
 
         /// <summary>The actor does not occupy a cardinally adjacent cell.</summary>
         ActorIsNotAdjacent,
-
-        /// <summary>The actor lacks the actions required to open the door in combat.</summary>
-        InsufficientActionPoints,
     }
 
     /// <summary>
@@ -44,39 +35,24 @@ namespace Game.Combat.Exploration
     {
         /// <summary>Creates a door-opening authorization request without referencing mutable Unity objects.</summary>
         /// <param name="mode">The gameplay mode in which the interaction occurs.</param>
-        /// <param name="actorIsPlayerCharacter">Whether the actor belongs to the player-character party.</param>
-        /// <param name="actorIsAlive">Whether the actor is currently alive.</param>
         /// <param name="actorCell">The actor's current grid cell.</param>
         /// <param name="doorCell">The target door's grid cell.</param>
         /// <param name="doorIsOpen">Whether the target door is already open.</param>
-        /// <param name="availableActionPoints">The actor's current unspent combat actions.</param>
         public DungeonDoorInteractionRequest(
             DungeonDoorInteractionMode mode,
-            bool actorIsPlayerCharacter,
-            bool actorIsAlive,
             DungeonCell actorCell,
             DungeonCell doorCell,
-            bool doorIsOpen,
-            uint availableActionPoints
+            bool doorIsOpen
         )
         {
             Mode = mode;
-            ActorIsPlayerCharacter = actorIsPlayerCharacter;
-            ActorIsAlive = actorIsAlive;
             ActorCell = actorCell;
             DoorCell = doorCell;
             DoorIsOpen = doorIsOpen;
-            AvailableActionPoints = availableActionPoints;
         }
 
         /// <summary>Gets the gameplay mode in which the interaction occurs.</summary>
         public DungeonDoorInteractionMode Mode { get; }
-
-        /// <summary>Gets whether the actor belongs to the player-character party.</summary>
-        public bool ActorIsPlayerCharacter { get; }
-
-        /// <summary>Gets whether the actor is currently alive.</summary>
-        public bool ActorIsAlive { get; }
 
         /// <summary>Gets the actor's current grid cell.</summary>
         public DungeonCell ActorCell { get; }
@@ -86,93 +62,49 @@ namespace Game.Combat.Exploration
 
         /// <summary>Gets whether the target door is already open.</summary>
         public bool DoorIsOpen { get; }
-
-        /// <summary>Gets the actor's current unspent combat actions.</summary>
-        public uint AvailableActionPoints { get; }
     }
 
-    /// <summary>Reports whether a door interaction is authorized and its required action cost.</summary>
+    /// <summary>Reports whether a door interaction is geometrically authorized.</summary>
     public readonly struct DungeonDoorInteractionDecision
     {
         internal DungeonDoorInteractionDecision(
             bool isAllowed,
-            uint actionCost,
             DungeonDoorInteractionRejection rejection
         )
         {
             IsAllowed = isAllowed;
-            ActionCost = actionCost;
             Rejection = rejection;
         }
 
         /// <summary>Gets whether the caller may open the door.</summary>
         public bool IsAllowed { get; }
 
-        /// <summary>
-        /// Gets the number of actions the caller must spend if the interaction is performed.
-        /// A rejected valid-mode request still reports its mode's required cost.
-        /// </summary>
-        public uint ActionCost { get; }
-
         /// <summary>Gets the rejection category, or <see cref="DungeonDoorInteractionRejection.None"/> when authorized.</summary>
         public DungeonDoorInteractionRejection Rejection { get; }
     }
 
     /// <summary>
-    /// Applies the pure authorization and action-cost rules for opening generated dungeon doors.
+    /// Applies the pure geometry and mode rules for opening generated dungeon doors.
     /// </summary>
     public static class DungeonDoorInteractionPolicy
     {
-        /// <summary>The number of combat actions required to open a closed adjacent door.</summary>
-        public const uint CombatActionCost = 1;
-
         /// <summary>
-        /// Evaluates a door-opening request without opening the door or consuming action points.
+        /// Evaluates a door-opening request without opening the door or granting rules authority.
         /// </summary>
         /// <param name="request">The immutable actor, door, and mode facts to evaluate.</param>
-        /// <returns>An explicit authorization decision and the applicable action cost.</returns>
+        /// <returns>An explicit geometry and mode authorization decision.</returns>
         public static DungeonDoorInteractionDecision Evaluate(DungeonDoorInteractionRequest request)
         {
-            if (!TryGetActionCost(request.Mode, out uint actionCost))
-                return Reject(0, DungeonDoorInteractionRejection.InvalidMode);
-            if (!request.ActorIsPlayerCharacter)
-                return Reject(
-                    actionCost,
-                    DungeonDoorInteractionRejection.ActorIsNotPlayerCharacter
-                );
-            if (!request.ActorIsAlive)
-                return Reject(actionCost, DungeonDoorInteractionRejection.ActorIsDead);
-            if (request.DoorIsOpen)
-                return Reject(actionCost, DungeonDoorInteractionRejection.DoorAlreadyOpen);
-            if (!IsCardinallyAdjacent(request.ActorCell, request.DoorCell))
-                return Reject(actionCost, DungeonDoorInteractionRejection.ActorIsNotAdjacent);
             if (
-                request.Mode == DungeonDoorInteractionMode.Combat
-                && request.AvailableActionPoints < actionCost
+                request.Mode != DungeonDoorInteractionMode.Exploration
+                && request.Mode != DungeonDoorInteractionMode.Combat
             )
-                return Reject(actionCost, DungeonDoorInteractionRejection.InsufficientActionPoints);
-
-            return new DungeonDoorInteractionDecision(
-                true,
-                actionCost,
-                DungeonDoorInteractionRejection.None
-            );
-        }
-
-        private static bool TryGetActionCost(DungeonDoorInteractionMode mode, out uint actionCost)
-        {
-            switch (mode)
-            {
-                case DungeonDoorInteractionMode.Exploration:
-                    actionCost = 0;
-                    return true;
-                case DungeonDoorInteractionMode.Combat:
-                    actionCost = CombatActionCost;
-                    return true;
-                default:
-                    actionCost = 0;
-                    return false;
-            }
+                return Reject(DungeonDoorInteractionRejection.InvalidMode);
+            if (request.DoorIsOpen)
+                return Reject(DungeonDoorInteractionRejection.DoorAlreadyOpen);
+            if (!IsCardinallyAdjacent(request.ActorCell, request.DoorCell))
+                return Reject(DungeonDoorInteractionRejection.ActorIsNotAdjacent);
+            return new DungeonDoorInteractionDecision(true, DungeonDoorInteractionRejection.None);
         }
 
         private static bool IsCardinallyAdjacent(DungeonCell actorCell, DungeonCell doorCell)
@@ -183,8 +115,7 @@ namespace Game.Combat.Exploration
         }
 
         private static DungeonDoorInteractionDecision Reject(
-            uint actionCost,
             DungeonDoorInteractionRejection rejection
-        ) => new(false, actionCost, rejection);
+        ) => new(false, rejection);
     }
 }

--- a/Assets/Scripts/Combat/MindlessController.cs
+++ b/Assets/Scripts/Combat/MindlessController.cs
@@ -93,13 +93,19 @@ public class MindlessController : AIActionController
         // Let StartTurn retain the coroutine handle before this sequence can complete or end a turn.
         yield return null;
 
-        while (ActionPoints > 0)
+        while (
+            TryGetTurnEconomy(
+                out UnityCombatRulesBridge bridge,
+                out CreatureId actor,
+                out ActionEconomyState economy
+            ) && (economy.StandardActionsRemaining > 0 || !economy.OptionalAction.IsNone)
+        )
         {
             //Debug.Log(ActionPoints + " action points remaining");
             EntityAction action = SelectNextAction();
             if (action != null)
             {
-                uint actionsBeforeInvocation = ActionPoints;
+                ActionEconomyState economyBeforeInvocation = economy;
                 //wait for half a second as to not spam attacks
                 yield return new WaitForSeconds(1f);
                 // yield return waits for the TakeAction coroutine to completely finish
@@ -117,7 +123,10 @@ public class MindlessController : AIActionController
                     TakeAction(action);
                 }
                 yield return new WaitUntil(() => !IsTakingAction); // Wait until the action is fully resolved before continuing
-                if (ActionPoints >= actionsBeforeInvocation)
+                if (
+                    !TryGetTurnEconomy(out bridge, out actor, out ActionEconomyState currentEconomy)
+                    || currentEconomy == economyBeforeInvocation
+                )
                 {
                     // A rejected selection or dispatch makes no rules progress. Retrying the same
                     // deterministic decision would otherwise keep this turn alive forever.
@@ -134,6 +143,24 @@ public class MindlessController : AIActionController
         turnSequence = null;
         EndTurn();
         yield return null;
+    }
+
+    private bool TryGetTurnEconomy(
+        out UnityCombatRulesBridge bridge,
+        out CreatureId actor,
+        out ActionEconomyState economy
+    )
+    {
+        if (TryGetCombatRules(out bridge, out actor) && bridge.HasTurnAuthority(actor))
+        {
+            economy = bridge.GetActionEconomy(actor);
+            return true;
+        }
+
+        bridge = null;
+        actor = default;
+        economy = default;
+        return false;
     }
 
     /// <summary>Selects the next action for the turn loop.</summary>

--- a/Assets/Scripts/Combat/Spells/CastSpellAction.cs
+++ b/Assets/Scripts/Combat/Spells/CastSpellAction.cs
@@ -71,14 +71,7 @@ namespace Game.Combat.Spells
             GridPublic.AreaTargetResult area = null
         )
         {
-            return SpellcastingRuntime.Cast(
-                caster,
-                spell,
-                variantActionCost,
-                targets,
-                area,
-                spendActions: true
-            );
+            return SpellcastingRuntime.Cast(caster, spell, variantActionCost, targets, area);
         }
 
         protected override IEnumerator MFInvoke(GameObject caster)
@@ -91,13 +84,7 @@ namespace Game.Combat.Spells
                 yield break;
             }
 
-            SpellCastContext context = new(
-                caster,
-                spell,
-                variantActionCost,
-                spendActions: true,
-                definition
-            );
+            SpellCastContext context = new(caster, spell, variantActionCost, definition);
             yield return definition.SelectAndCast(context);
         }
 

--- a/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs
+++ b/Assets/Scripts/Combat/Spells/SpellcastingRuntime.cs
@@ -10,13 +10,9 @@ using Game.Rules.Unity.Spells;
 using GridPrivate;
 using GridPublic;
 using UnityEngine;
-using AdvanceMultipleAttackPenaltyOp = Game.Rules.Runtime.AdvanceMultipleAttackPenaltyOp;
 using CreatureId = Game.Rules.Runtime.CreatureId;
 using DegreeOfSuccess = Game.Creature.DegreeOfSuccess;
-using InvalidMapOpResult = Game.Rules.Runtime.InvalidOpResult<Game.Rules.Runtime.MultipleAttackPenaltyState>;
-using MapOpResult = Game.Rules.Runtime.OpResult<Game.Rules.Runtime.MultipleAttackPenaltyState>;
 using MultipleAttackPenaltyState = Game.Rules.Runtime.MultipleAttackPenaltyState;
-using ResolvedMapOpResult = Game.Rules.Runtime.ResolvedOpResult<Game.Rules.Runtime.MultipleAttackPenaltyState>;
 using RuleSource = Game.Rules.Runtime.RuleSource;
 
 namespace Game.Combat.Spells
@@ -60,21 +56,18 @@ namespace Game.Combat.Spells
         public GameObject Caster { get; }
         public PreparedSpell Spell { get; }
         public uint ActionCost { get; }
-        public bool SpendActions { get; }
         public ISpellDefinition Definition { get; }
 
         public SpellCastContext(
             GameObject caster,
             PreparedSpell spell,
             uint actionCost,
-            bool spendActions,
             ISpellDefinition definition
         )
         {
             Caster = caster;
             Spell = spell;
             ActionCost = actionCost;
-            SpendActions = spendActions;
             Definition = definition;
         }
 
@@ -105,8 +98,7 @@ namespace Game.Combat.Spells
             PreparedSpell spell,
             uint actionCost,
             IReadOnlyList<GameObject> targets = null,
-            AreaTargetResult area = null,
-            bool spendActions = true
+            AreaTargetResult area = null
         )
         {
             ActionController controller = caster?.GetComponent<ActionController>();
@@ -124,7 +116,6 @@ namespace Game.Combat.Spells
                     spell,
                     actionCost,
                     new SpellTargetSelection(targets, area),
-                    spendActions,
                     CreateInvocationId("programmatic-cast")
                 );
             if (!SpellRegistry.TryGet(spell?.Slug, out ISpellDefinition definition))
@@ -134,7 +125,7 @@ namespace Game.Combat.Spells
                     controller
                 );
 
-            SpellCastContext context = new(caster, spell, actionCost, spendActions, definition);
+            SpellCastContext context = new(caster, spell, actionCost, definition);
             return Cast(context, new SpellTargetSelection(targets, area));
         }
 
@@ -183,7 +174,6 @@ namespace Game.Combat.Spells
                 spell,
                 actionCost,
                 new SpellTargetSelection(targets, area),
-                spendActions: true,
                 invocationId: invocationId
             );
         }
@@ -208,7 +198,6 @@ namespace Game.Combat.Spells
                     context.Spell,
                     context.ActionCost,
                     selection,
-                    context.SpendActions,
                     CreateInvocationId("programmatic-cast")
                 );
             if (
@@ -218,13 +207,6 @@ namespace Game.Combat.Spells
                 || context.Spell == null
             )
                 return Fail(result, "Caster is not ready to cast spells.", controller);
-            if (
-                context.ActionCost > 0
-                && controller != null
-                && context.SpendActions
-                && controller.ActionPoints < context.ActionCost
-            )
-                return Fail(result, "Not enough actions.", controller);
             if (!state.CanCast(context.Spell))
                 return Fail(result, context.Spell.Name + " has no remaining slot.", controller);
 
@@ -232,37 +214,8 @@ namespace Game.Combat.Spells
                 return Fail(result, "Spell target is invalid.", controller);
             if (!state.Spend(context.Spell))
                 return Fail(result, context.Spell.Name + " has no remaining slot.", controller);
-            if (controller != null && context.SpendActions)
-            {
-                try
-                {
-                    controller.SpendActions(context.ActionCost);
-                    if (context.Definition.AppliesMultipleAttackPenalty(context))
-                    {
-                        if (
-                            controller.TryGetCombatRules(
-                                out UnityCombatRulesBridge mapBridge,
-                                out CreatureId mapActor
-                            )
-                        )
-                        {
-                            MapOpResult map = mapBridge.Dispatch(
-                                new AdvanceMultipleAttackPenaltyOp(mapActor)
-                            );
-                            if (map is InvalidMapOpResult invalid)
-                                throw new InvalidOperationException(invalid.Reason);
-                            if (map is not ResolvedMapOpResult)
-                                throw new InvalidOperationException(
-                                    "MAP advancement did not resolve."
-                                );
-                        }
-                    }
-                }
-                finally
-                {
-                    controller.IsTakingAction = false;
-                }
-            }
+            if (controller != null)
+                controller.IsTakingAction = false;
             result.Success = true;
             if (!creature.IsDefeated)
                 context
@@ -351,15 +304,10 @@ namespace Game.Combat.Spells
             PreparedSpell spell,
             uint actionCost,
             SpellTargetSelection selection,
-            bool spendActions,
             ActionInvocationId invocationId
         )
         {
             CastSpellResult result = new();
-            if (!spendActions)
-                throw new InvalidOperationException(
-                    "Encounter spellcasting cannot bypass authoritative action costs."
-                );
             if (spell == null || actionCost == 0 || actionCost > 3)
                 return Fail(result, "The encounter spell request is incomplete.", controller);
             SpellTargetSelection requested = selection ?? SpellTargetSelection.None;

--- a/Assets/Scripts/Creature/Conditions/ConditionEncounterModule.cs
+++ b/Assets/Scripts/Creature/Conditions/ConditionEncounterModule.cs
@@ -9,7 +9,8 @@ namespace Game.Creature.Rules
     /// <summary>Composes condition workflows and immutable persistence enrollment.</summary>
     internal sealed class ConditionEncounterModule
         : IUnityEncounterDispatcherModule,
-            IUnityCombatantEnrollmentModule
+            IUnityCombatantEnrollmentModule,
+            IUnityEncounterTurnResourceModule
     {
         private readonly UnityCombatRulesBridge owner;
         private readonly RuleRegistry registry;
@@ -28,11 +29,22 @@ namespace Game.Creature.Rules
 
         /// <inheritdoc/>
         public void ConfigureDispatcher(RuleDispatcherBuilder builder) =>
-            builder.UseConditionRules(registry);
+            builder
+                .UseConditionRules(registry)
+                .RegisterActionPermission(
+                    ConditionTurnResourceComposition.CreateActionPermission()
+                );
+
+        /// <inheritdoc/>
+        public ITurnResourceContributionProvider CreateTurnResourceProvider() =>
+            ConditionTurnResourceComposition.CreateProvider();
 
         /// <inheritdoc/>
         public void PrepareCombatant(UnityCombatantEnrollmentBuilder builder)
         {
+            builder.AddRuleBindings(
+                new[] { ConditionTurnResourceComposition.CreateListenerBinding(builder.CreatureId) }
+            );
             // A detached exploration action is not an encounter authority. It must neither adopt
             // nor consume the detached snapshot reserved for the next owning encounter.
             if (!installUnityAuthority)

--- a/Assets/Scripts/Creature/Conditions/Implemented/SlowedEncounterModule.cs
+++ b/Assets/Scripts/Creature/Conditions/Implemented/SlowedEncounterModule.cs
@@ -1,29 +1,19 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Game.Rules.Runtime;
 using Game.Rules.Unity;
 using Game.Rules.Unity.Composition;
 
 namespace Game.Creature.Rules
 {
-    /// <summary>Projects authoritative Slowed state into the transitional turn-start contribution.</summary>
-    internal sealed class SlowedEncounterModule
-        : IUnityEncounterTurnStartModule,
-            IUnityCombatantEnrollmentModule
+    /// <summary>Seeds the authored passive Slowed identity for later resource integration.</summary>
+    internal sealed class SlowedEncounterModule : IUnityCombatantEnrollmentModule
     {
         private const string AuthoredPassiveName = "Slow";
         private readonly UnityCombatRulesBridge owner;
-        private readonly Dictionary<CreatureId, AuthoredPassiveSlowedIdentity> authoredPassives =
-            new();
 
         internal SlowedEncounterModule(UnityCombatRulesBridge owner) =>
             this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
-
-        /// <inheritdoc/>
-        public IEncounterTurnStartAdapter CreateTurnStartAdapter() =>
-            new TurnStartAdapter(authoredPassives);
 
         /// <inheritdoc/>
         public void PrepareCombatant(UnityCombatantEnrollmentBuilder builder)
@@ -42,52 +32,7 @@ namespace Game.Creature.Rules
                 builder.CreatureId,
                 owner.GetDurableActorId(builder.CreatureId)
             );
-            if (!authoredPassives.TryAdd(builder.CreatureId, identity))
-                throw new InvalidOperationException(
-                    "The authored Slow passive was prepared more than once for one combatant."
-                );
-            builder.Own(new RegistrationToken(() => authoredPassives.Remove(builder.CreatureId)));
             builder.AddActiveEffects(new[] { identity.Registration });
-        }
-
-        private sealed class TurnStartAdapter : IEncounterTurnStartAdapter
-        {
-            private readonly IReadOnlyDictionary<
-                CreatureId,
-                AuthoredPassiveSlowedIdentity
-            > authoredPassives;
-
-            internal TurnStartAdapter(
-                IReadOnlyDictionary<CreatureId, AuthoredPassiveSlowedIdentity> authoredPassives
-            ) =>
-                this.authoredPassives =
-                    authoredPassives ?? throw new ArgumentNullException(nameof(authoredPassives));
-
-            /// <inheritdoc/>
-            public ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
-            {
-                int slowed = ConditionSelectors.TryGetSlowed(
-                    context.Snapshot,
-                    context.Actor,
-                    out ConditionSelection<SlowedConditionState> selected
-                )
-                    ? selected.State.Value
-                    : 0;
-                bool suppressesReaction =
-                    authoredPassives.TryGetValue(
-                        context.Actor,
-                        out AuthoredPassiveSlowedIdentity authored
-                    ) && authored.IsExactActiveRegistration(context.Snapshot);
-                return new ValueTask<TurnStartContribution>(
-                    new TurnStartContribution(
-                        Math.Max(0, current.Actions - slowed),
-                        current.ReactionAvailable && !suppressesReaction
-                    )
-                );
-            }
         }
     }
 
@@ -98,16 +43,9 @@ namespace Game.Creature.Rules
     {
         private static readonly RuleSource Source = RuleSource.FromSlug("authored-passive-slow");
 
-        private AuthoredPassiveSlowedIdentity(
-            CreatureId owner,
-            ActiveEffectRegistration registration
-        )
-        {
-            Owner = owner;
+        private AuthoredPassiveSlowedIdentity(ActiveEffectRegistration registration) =>
             Registration = registration;
-        }
 
-        internal CreatureId Owner { get; }
         internal ActiveEffectRegistration Registration { get; }
 
         internal static AuthoredPassiveSlowedIdentity Create(CreatureId owner, string durableOwner)
@@ -134,22 +72,7 @@ namespace Game.Creature.Rules
                 Source,
                 0
             );
-            return new AuthoredPassiveSlowedIdentity(
-                owner,
-                new ActiveEffectRegistration(effect, binding)
-            );
-        }
-
-        internal bool IsExactActiveRegistration(RulesSnapshot snapshot)
-        {
-            ActiveEffectInstance expectedEffect = Registration.Effect;
-            ActiveRuleBinding expectedBinding = Registration.Binding;
-            return snapshot.ActiveEffects.TryGet(expectedEffect.Id, out ActiveEffectInstance effect)
-                && snapshot.RuleBindings.TryGet(expectedBinding.Id, out ActiveRuleBinding binding)
-                && effect.Status == ActiveEffectStatus.Active
-                && binding.IsEnabled
-                && Owner == expectedBinding.Owner
-                && Registration.HasSameStructure(new ActiveEffectRegistration(effect, binding));
+            return new AuthoredPassiveSlowedIdentity(new ActiveEffectRegistration(effect, binding));
         }
     }
 }

--- a/Assets/Scripts/Creature/Conditions/Implemented/SlowedEncounterModule.cs
+++ b/Assets/Scripts/Creature/Conditions/Implemented/SlowedEncounterModule.cs
@@ -6,14 +6,43 @@ using Game.Rules.Unity.Composition;
 
 namespace Game.Creature.Rules
 {
-    /// <summary>Seeds the authored passive Slowed identity for later resource integration.</summary>
-    internal sealed class SlowedEncounterModule : IUnityCombatantEnrollmentModule
+    /// <summary>Seeds the authored zombie Slow condition and its separate no-reactions rule.</summary>
+    internal sealed class SlowedEncounterModule
+        : IUnityCombatantEnrollmentModule,
+            IUnityEncounterTurnResourceModule,
+            IUnityEncounterDispatcherModule
     {
         private const string AuthoredPassiveName = "Slow";
+        internal static readonly RuleDefinitionId NoReactionsDefinitionId = new(
+            "authored-passive-slow-no-reactions"
+        );
+        private static readonly RuleSource NoReactionsSource = RuleSource.FromSlug(
+            "authored-passive-slow-no-reactions"
+        );
         private readonly UnityCombatRulesBridge owner;
 
         internal SlowedEncounterModule(UnityCombatRulesBridge owner) =>
             this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        internal static RuleRegistryBuilder DefineRules(RuleRegistryBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+            builder.Define(NoReactionsDefinitionId);
+            return builder;
+        }
+
+        /// <summary>Creates the feature-owned permission that enforces No Reactions.</summary>
+        internal static IActionPermission CreateNoReactionsActionPermission() =>
+            new NoReactionsActionPermission();
+
+        /// <inheritdoc/>
+        public ITurnResourceContributionProvider CreateTurnResourceProvider() =>
+            new NoReactionsTurnResourceProvider();
+
+        /// <inheritdoc/>
+        public void ConfigureDispatcher(RuleDispatcherBuilder builder) =>
+            builder.RegisterActionPermission(CreateNoReactionsActionPermission());
 
         /// <inheritdoc/>
         public void PrepareCombatant(UnityCombatantEnrollmentBuilder builder)
@@ -33,6 +62,64 @@ namespace Game.Creature.Rules
                 owner.GetDurableActorId(builder.CreatureId)
             );
             builder.AddActiveEffects(new[] { identity.Registration });
+            builder.AddRuleBindings(
+                new[] { CreateNoReactionsBinding(builder.CreatureId, identity.StableOwner) }
+            );
+        }
+
+        private static ActiveRuleBinding CreateNoReactionsBinding(
+            CreatureId actor,
+            string stableOwner
+        ) =>
+            new(
+                new BindingId($"authored-passive-slow-{stableOwner}-no-reactions-binding"),
+                NoReactionsDefinitionId,
+                actor,
+                default,
+                NoReactionsSource,
+                0
+            );
+
+        private sealed class NoReactionsTurnResourceProvider : ITurnResourceContributionProvider
+        {
+            public TurnResourceContributionBatch GetContributions(
+                RulesSnapshot snapshot,
+                CreatureId actor
+            )
+            {
+                bool active = snapshot.RuleBindings.Any(pair =>
+                    pair.Value.Owner == actor
+                    && pair.Value.DefinitionId == NoReactionsDefinitionId
+                    && pair.Value.IsEnabled
+                    && !pair.Value.EffectId.HasValue
+                );
+                return new TurnResourceContributionBatch(
+                    active
+                        ? new[] { TurnResourceContribution.SuppressReaction() }
+                        : Array.Empty<TurnResourceContribution>()
+                );
+            }
+        }
+
+        private sealed class NoReactionsActionPermission : IActionPermission
+        {
+            public ActionValidationResult Validate(
+                ActionOpInfo action,
+                ActionProfile profile,
+                RulesSnapshot snapshot
+            )
+            {
+                if (profile.Cost.Kind != ActionCostKind.Reaction)
+                    return ActionValidationResult.Valid;
+                return snapshot.RuleBindings.Any(pair =>
+                    pair.Value.Owner == action.Actor
+                    && pair.Value.DefinitionId == NoReactionsDefinitionId
+                    && pair.Value.IsEnabled
+                    && !pair.Value.EffectId.HasValue
+                )
+                    ? ActionValidationResult.Invalid("The actor cannot use reactions.")
+                    : ActionValidationResult.Valid;
+            }
         }
     }
 
@@ -43,10 +130,17 @@ namespace Game.Creature.Rules
     {
         private static readonly RuleSource Source = RuleSource.FromSlug("authored-passive-slow");
 
-        private AuthoredPassiveSlowedIdentity(ActiveEffectRegistration registration) =>
+        private AuthoredPassiveSlowedIdentity(
+            ActiveEffectRegistration registration,
+            string stableOwner
+        )
+        {
             Registration = registration;
+            StableOwner = stableOwner;
+        }
 
         internal ActiveEffectRegistration Registration { get; }
+        internal string StableOwner { get; }
 
         internal static AuthoredPassiveSlowedIdentity Create(CreatureId owner, string durableOwner)
         {
@@ -72,7 +166,10 @@ namespace Game.Creature.Rules
                 Source,
                 0
             );
-            return new AuthoredPassiveSlowedIdentity(new ActiveEffectRegistration(effect, binding));
+            return new AuthoredPassiveSlowedIdentity(
+                new ActiveEffectRegistration(effect, binding),
+                stableOwner
+            );
         }
     }
 }

--- a/Assets/Scripts/Creature/CreatureEvents.cs
+++ b/Assets/Scripts/Creature/CreatureEvents.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
-
-/// <summary>Triggered upon reseting action points</summary>
-public class OnResetActionPoints : UnityEvent<Ref<uint>> { }
 
 /// <summary>Triggered upon actions retrieval</summary>
 public class OnGetActions : UnityEvent<List<EntityAction>> { }

--- a/Assets/Scripts/Creature/Rules/Auras/RottingAuraEncounterModule.cs
+++ b/Assets/Scripts/Creature/Rules/Auras/RottingAuraEncounterModule.cs
@@ -26,10 +26,7 @@ namespace Game.Creature.Rules
             internal TurnStartAdapter(UnityCombatRulesBridge owner) => this.owner = owner;
 
             /// <inheritdoc/>
-            public async ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public async ValueTask Apply(EncounterTurnStartContext context)
             {
                 EncounterState encounter = context.Snapshot.Encounters[context.Encounter];
                 ActionController actor = owner.GetController(context.Actor);
@@ -54,10 +51,7 @@ namespace Game.Creature.Rules
                                 source
                             ))
                             .ToList();
-                        return await context.CommitFinalDamageBatchAndCompleteAdapter(
-                            changes,
-                            current
-                        );
+                        return await context.CommitFinalDamageBatchAndCompleteAdapter(changes);
                     },
                     target =>
                     {
@@ -74,7 +68,6 @@ namespace Game.Creature.Rules
                         return default;
                     }
                 );
-                return current;
             }
         }
     }

--- a/Assets/Scripts/Grid/Generation/Map.cs
+++ b/Assets/Scripts/Grid/Generation/Map.cs
@@ -1003,6 +1003,23 @@ public class Map : MonoBehaviour
     }
 
     /// <summary>
+    /// Determines whether one generated door state can be applied without changing map state.
+    /// </summary>
+    /// <param name="cell">The generated door cell to inspect.</param>
+    /// <param name="isOpen">Whether the requested state is open.</param>
+    /// <returns>
+    /// <see langword="true"/> when the current map or live grid data accepts the requested state;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    public bool CanSetDoorState(DungeonCell cell, bool isOpen)
+    {
+        GridBase grid = GetComponent<GridBase>();
+        return grid != null && grid.IsInitialized
+            ? grid.CanSetDoorState(cell, isOpen)
+            : GridBase.CanSetDoorState(GridData, LineOfSightBlocks, null, cell, isOpen);
+    }
+
+    /// <summary>
     /// Updates one generated door's semantic grid state without rebuilding owned geometry.
     /// </summary>
     /// <param name="cell">The generated door cell.</param>
@@ -1014,20 +1031,7 @@ public class Map : MonoBehaviour
         GridBase grid = GetComponent<GridBase>();
         if (grid != null && grid.IsInitialized)
             return grid.TrySetDoorState(cell, isOpen);
-        if (
-            GridData == null
-            || LineOfSightBlocks == null
-            || cell.X < 0
-            || cell.Z < 0
-            || cell.X >= GridData.GetLength(0)
-            || cell.Z >= GridData.GetLength(1)
-        )
-        {
-            return false;
-        }
-
-        TileType current = GridData[cell.X, cell.Z];
-        if (current != TileType.Door && current != TileType.ClosedDoor)
+        if (!GridBase.CanSetDoorState(GridData, LineOfSightBlocks, null, cell, isOpen))
             return false;
         GridData[cell.X, cell.Z] = isOpen ? TileType.Door : TileType.ClosedDoor;
         LineOfSightBlocks[cell.X, cell.Z] = !isOpen;

--- a/Assets/Scripts/Grid/GridBase.cs
+++ b/Assets/Scripts/Grid/GridBase.cs
@@ -386,6 +386,62 @@ namespace GridPrivate
         }
 
         /// <summary>
+        /// Determines whether one generated door state can be applied without changing grid state.
+        /// </summary>
+        /// <param name="cell">The generated door cell to inspect.</param>
+        /// <param name="isOpen">Whether the requested state is open.</param>
+        /// <returns>
+        /// <see langword="true"/> when <see cref="TrySetDoorState"/> can apply the requested state;
+        /// otherwise <see langword="false"/>.
+        /// </returns>
+        public bool CanSetDoorState(DungeonCell cell, bool isOpen) =>
+            CanSetDoorState(GridData, LineOfSightBlocks, Tiles, cell, isOpen);
+
+        /// <summary>
+        /// Evaluates the shared door mutation precondition against supplied topology data.
+        /// </summary>
+        /// <remarks>
+        /// This method must remain free of mutations because combat adapters may authorize and pay
+        /// for an action between this preflight and the synchronous mutation.
+        /// </remarks>
+        internal static bool CanSetDoorState(
+            TileType[,] gridData,
+            bool[,] lineOfSightBlocks,
+            Tile[,] tiles,
+            DungeonCell cell,
+            bool isOpen
+        )
+        {
+            if (
+                gridData == null
+                || lineOfSightBlocks == null
+                || cell.X < 0
+                || cell.Z < 0
+                || cell.X >= gridData.GetLength(0)
+                || cell.Z >= gridData.GetLength(1)
+                || cell.X >= lineOfSightBlocks.GetLength(0)
+                || cell.Z >= lineOfSightBlocks.GetLength(1)
+                || tiles != null && (cell.X >= tiles.GetLength(0) || cell.Z >= tiles.GetLength(1))
+            )
+            {
+                return false;
+            }
+
+            TileType current = gridData[cell.X, cell.Z];
+            if (current != TileType.Door && current != TileType.ClosedDoor)
+                return false;
+
+            if (tiles != null && !isOpen)
+            {
+                Tile tile = tiles[cell.X, cell.Z];
+                if (tile != null && tile.Occupants.Count > 0)
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Applies a generated door state to the shared navigation and line-of-sight arrays.
         /// </summary>
         /// <param name="cell">The validated generated door cell.</param>
@@ -396,28 +452,8 @@ namespace GridPrivate
         /// </returns>
         public bool TrySetDoorState(DungeonCell cell, bool isOpen)
         {
-            if (
-                GridData == null
-                || LineOfSightBlocks == null
-                || cell.X < 0
-                || cell.Z < 0
-                || cell.X >= GridData.GetLength(0)
-                || cell.Z >= GridData.GetLength(1)
-            )
-            {
+            if (!CanSetDoorState(cell, isOpen))
                 return false;
-            }
-
-            TileType current = GridData[cell.X, cell.Z];
-            if (current != TileType.Door && current != TileType.ClosedDoor)
-                return false;
-
-            if (Tiles != null && !isOpen)
-            {
-                Tile tile = Tiles[cell.X, cell.Z];
-                if (tile != null && tile.Occupants.Count > 0)
-                    return false;
-            }
 
             GridData[cell.X, cell.Z] = isOpen ? TileType.Door : TileType.ClosedDoor;
             LineOfSightBlocks[cell.X, cell.Z] = !isOpen;

--- a/Assets/Scripts/Rules/Runtime/ActionCostFacts.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionCostFacts.cs
@@ -2,6 +2,104 @@ using System;
 
 namespace Game.Rules.Runtime
 {
+    /// <summary>Records one standard or optional action-resource grant at turn refresh.</summary>
+    public sealed class ActionResourceGainedFact : RuleFact
+    {
+        /// <summary>Creates an immutable resource-grant fact.</summary>
+        public ActionResourceGainedFact(CreatureId actor, ActionResourceKind resource, int amount)
+        {
+            if (actor.IsEmpty)
+                throw new ArgumentException("An actor is required.", nameof(actor));
+            if (amount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(amount));
+            Actor = actor;
+            Resource = resource;
+            Amount = amount;
+        }
+
+        /// <summary>Gets the creature receiving the resource.</summary>
+        public CreatureId Actor { get; }
+
+        /// <summary>Gets whether ordinary or optional actions were granted.</summary>
+        public ActionResourceKind Resource { get; }
+
+        /// <summary>Gets the number of resources granted.</summary>
+        public int Amount { get; }
+    }
+
+    /// <summary>Records one standard or optional action-resource loss without expenditure.</summary>
+    public sealed class ActionResourceLostFact : RuleFact
+    {
+        /// <summary>Creates an immutable resource-loss fact.</summary>
+        public ActionResourceLostFact(CreatureId actor, ActionResourceKind resource, int amount)
+        {
+            if (actor.IsEmpty)
+                throw new ArgumentException("An actor is required.", nameof(actor));
+            if (amount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(amount));
+            Actor = actor;
+            Resource = resource;
+            Amount = amount;
+        }
+
+        /// <summary>Gets the creature losing the resource.</summary>
+        public CreatureId Actor { get; }
+
+        /// <summary>Gets whether ordinary or optional actions were lost.</summary>
+        public ActionResourceKind Resource { get; }
+
+        /// <summary>Gets the number of resources lost.</summary>
+        public int Amount { get; }
+    }
+
+    /// <summary>Records one standard or optional action-resource expenditure.</summary>
+    public sealed class ActionResourceSpentFact : RuleFact
+    {
+        /// <summary>Creates an immutable resource-spend fact.</summary>
+        public ActionResourceSpentFact(
+            OpId actionOpId,
+            CreatureId actor,
+            ActionResourceKind resource,
+            int amount,
+            int standardActionsRemaining,
+            bool optionalActionAvailable
+        )
+        {
+            if (actionOpId.IsEmpty)
+                throw new ArgumentException("An action Op ID is required.", nameof(actionOpId));
+            if (actor.IsEmpty)
+                throw new ArgumentException("An actor is required.", nameof(actor));
+            if (amount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(amount));
+            if (standardActionsRemaining < 0)
+                throw new ArgumentOutOfRangeException(nameof(standardActionsRemaining));
+            ActionOpId = actionOpId;
+            Actor = actor;
+            Resource = resource;
+            Amount = amount;
+            StandardActionsRemaining = standardActionsRemaining;
+            OptionalActionAvailable = optionalActionAvailable;
+        }
+
+        /// <summary>Gets the action frame paying the resource.</summary>
+        public OpId ActionOpId { get; }
+
+        /// <summary>Gets the creature spending the resource.</summary>
+        public CreatureId Actor { get; }
+
+        /// <summary>Gets whether ordinary or optional actions were spent.</summary>
+        public ActionResourceKind Resource { get; }
+
+        /// <summary>Gets the number of resources spent.</summary>
+        public int Amount { get; }
+
+        /// <summary>Gets the committed ordinary actions remaining.</summary>
+        public int StandardActionsRemaining { get; }
+
+        /// <summary>Gets whether the optional allowance remains available.</summary>
+        public bool OptionalActionAvailable { get; }
+    }
+
     /// <summary>
     /// Proves that an action or reaction resource was spent for one action invocation.
     /// </summary>

--- a/Assets/Scripts/Rules/Runtime/ActionDefinitions.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionDefinitions.cs
@@ -1,7 +1,150 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Game.Rules.Runtime
 {
+    /// <summary>
+    /// Describes which exact action definitions may spend an optional action resource.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="None"/> represents an absent optional resource. A present resource is either
+    /// <see cref="Unrestricted"/> or a nonempty restricted set created by <see cref="Restricted"/>.
+    /// This value answers definition membership only. A restricted PF2e action resource must also
+    /// require an exact single-action cost when it is spent; an allowed subordinate action does not
+    /// authorize the two- or three-action activity that contains it.
+    /// </remarks>
+    public sealed class ActionAllowance : IEquatable<ActionAllowance>
+    {
+        private readonly IReadOnlyList<ActionDefinitionId> allowedActions;
+        private readonly HashSet<ActionDefinitionId> allowedActionLookup;
+
+        private ActionAllowance(bool isUnrestricted, ActionDefinitionId[] allowedActions)
+        {
+            IsUnrestricted = isUnrestricted;
+            this.allowedActions = Array.AsReadOnly(allowedActions);
+            allowedActionLookup = new HashSet<ActionDefinitionId>(allowedActions);
+        }
+
+        /// <summary>Gets the value representing an absent optional action resource.</summary>
+        public static ActionAllowance None { get; } =
+            new ActionAllowance(false, Array.Empty<ActionDefinitionId>());
+
+        /// <summary>Gets an allowance that permits every valid action definition.</summary>
+        public static ActionAllowance Unrestricted { get; } =
+            new ActionAllowance(true, Array.Empty<ActionDefinitionId>());
+
+        /// <summary>Creates an allowance restricted to a nonempty set of action definitions.</summary>
+        /// <param name="allowedActions">The definitions that may spend the resource.</param>
+        /// <returns>An immutable allowance in canonical ordinal order.</returns>
+        public static ActionAllowance Restricted(IEnumerable<ActionDefinitionId> allowedActions)
+        {
+            if (allowedActions == null)
+                throw new ArgumentNullException(nameof(allowedActions));
+
+            ActionDefinitionId[] copied = allowedActions.ToArray();
+            if (copied.Length == 0)
+                throw new ArgumentException(
+                    "A restricted allowance must contain at least one action definition.",
+                    nameof(allowedActions)
+                );
+            if (copied.Any(action => action.IsEmpty))
+                throw new ArgumentException(
+                    "An allowance cannot contain an empty action definition.",
+                    nameof(allowedActions)
+                );
+
+            return new ActionAllowance(
+                false,
+                copied.Distinct().OrderBy(action => action.Value, StringComparer.Ordinal).ToArray()
+            );
+        }
+
+        /// <summary>Gets whether this value represents an absent optional resource.</summary>
+        public bool IsNone => !IsUnrestricted && allowedActions.Count == 0;
+
+        /// <summary>Gets whether a present resource permits only listed definitions.</summary>
+        public bool IsRestricted => !IsUnrestricted && allowedActions.Count > 0;
+
+        /// <summary>Gets whether the present resource permits every action definition.</summary>
+        public bool IsUnrestricted { get; }
+
+        /// <summary>
+        /// Gets the canonical allowed definitions, empty for <see cref="None"/> and
+        /// <see cref="Unrestricted"/>.
+        /// </summary>
+        public IReadOnlyList<ActionDefinitionId> AllowedActions => allowedActions;
+
+        /// <summary>Tests whether this allowance permits the supplied exact action definition.</summary>
+        /// <param name="action">The valid action definition to inspect.</param>
+        /// <returns><see langword="true"/> when the definition is permitted.</returns>
+        public bool Allows(ActionDefinitionId action)
+        {
+            if (action.IsEmpty)
+                throw new ArgumentException("An action definition is required.", nameof(action));
+            return IsUnrestricted || allowedActionLookup.Contains(action);
+        }
+
+        /// <summary>
+        /// Tests whether this allowance may pay the complete action-economy cost of an invocation.
+        /// </summary>
+        /// <param name="action">The exact top-level action definition being invoked.</param>
+        /// <param name="profile">The invocation's resolved action profile.</param>
+        /// <returns>
+        /// <see langword="true"/> only for an allowed definition whose complete cost is exactly one
+        /// action.
+        /// </returns>
+        public bool Allows(ActionDefinitionId action, ActionProfile profile)
+        {
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+            return profile.Cost == ActionCost.One && Allows(action);
+        }
+
+        /// <summary>Combines two optional allowances, with unrestricted permission dominating.</summary>
+        /// <param name="other">The allowance to combine with this value.</param>
+        /// <returns>The canonical union of both allowances.</returns>
+        public ActionAllowance Union(ActionAllowance other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+            if (IsUnrestricted || other.IsUnrestricted)
+                return Unrestricted;
+            if (allowedActions.Count == 0)
+                return other;
+            if (other.allowedActions.Count == 0)
+                return this;
+            return Restricted(allowedActions.Concat(other.allowedActions));
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(ActionAllowance other) =>
+            other != null
+            && IsUnrestricted == other.IsUnrestricted
+            && allowedActions.SequenceEqual(other.allowedActions);
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => obj is ActionAllowance other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            HashCode hash = new HashCode();
+            hash.Add(IsUnrestricted);
+            foreach (ActionDefinitionId action in allowedActions)
+                hash.Add(action);
+            return hash.ToHashCode();
+        }
+
+        /// <summary>Compares two allowances by value.</summary>
+        public static bool operator ==(ActionAllowance left, ActionAllowance right) =>
+            ReferenceEquals(left, right) || (left?.Equals(right) ?? false);
+
+        /// <summary>Compares two allowances by value.</summary>
+        public static bool operator !=(ActionAllowance left, ActionAllowance right) =>
+            !(left == right);
+    }
+
     /// <summary>
     /// Connects an action's preview, typed input workflow, and immutable root operation without
     /// choosing a presentation or registration model.

--- a/Assets/Scripts/Rules/Runtime/ActionLifecycleHandlers.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionLifecycleHandlers.cs
@@ -84,37 +84,37 @@ namespace Game.Rules.Runtime
                 );
             }
 
-            if (cost.Kind == ActionCostKind.Actions)
-            {
-                if (economy.ActionsRemaining < cost.Amount)
-                    return ActionValidationResult.Invalid(
-                        "The actor has insufficient actions remaining."
-                    );
+            if (
+                !ActionResourcePayment.TryPay(
+                    economy,
+                    op.DefinitionId,
+                    op.Profile,
+                    out ActionEconomyState remaining,
+                    out ActionResourceKind? spentResource
+                )
+            )
+                return ActionValidationResult.Invalid(
+                    cost.Kind == ActionCostKind.Reaction
+                        ? "The actor's reaction is not available."
+                        : "The actor has insufficient actions remaining."
+                );
 
-                state.ActionEconomy.Set(
-                    op.Actor,
-                    new ActionEconomyState(
-                        economy.ActionsRemaining - cost.Amount,
-                        economy.ReactionAvailable
+            state.ActionEconomy.Set(op.Actor, remaining);
+
+            facts.Stage(new ActionCostSpentFact(op.ActionOpId, op.Actor, cost));
+            if (spentResource.HasValue)
+            {
+                facts.Stage(
+                    new ActionResourceSpentFact(
+                        op.ActionOpId,
+                        op.Actor,
+                        spentResource.Value,
+                        cost.Amount,
+                        remaining.StandardActionsRemaining,
+                        !remaining.OptionalAction.IsNone
                     )
                 );
             }
-            else if (cost.Kind == ActionCostKind.Reaction)
-            {
-                if (!economy.ReactionAvailable)
-                    return ActionValidationResult.Invalid("The actor's reaction is not available.");
-
-                state.ActionEconomy.Set(
-                    op.Actor,
-                    new ActionEconomyState(economy.ActionsRemaining, false)
-                );
-            }
-            else
-            {
-                throw new InvalidOperationException($"Unsupported action cost kind {cost.Kind}.");
-            }
-
-            facts.Stage(new ActionCostSpentFact(op.ActionOpId, op.Actor, cost));
             return ActionValidationResult.Valid;
         }
 

--- a/Assets/Scripts/Rules/Runtime/ActionLifecycleOperations.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionLifecycleOperations.cs
@@ -125,20 +125,33 @@ namespace Game.Rules.Runtime
     /// </remarks>
     public sealed class CommitActionCostsOp : IRuleOp<ActionCostsOutcome>
     {
-        internal CommitActionCostsOp(OpId actionOpId, CreatureId actor, ActionProfile profile)
-            : this(actionOpId, actor, profile, ActionCostReceiptCheckpoint.None) { }
+        internal CommitActionCostsOp(
+            OpId actionOpId,
+            CreatureId actor,
+            ActionDefinitionId definitionId,
+            ActionProfile profile
+        )
+            : this(actionOpId, actor, definitionId, profile, ActionCostReceiptCheckpoint.None) { }
 
         internal CommitActionCostsOp(
             OpId actionOpId,
             CreatureId actor,
+            ActionDefinitionId definitionId,
             ActionProfile profile,
             IReceiptedActionOp receiptedAction
         )
-            : this(actionOpId, actor, profile, ActionCostReceiptCheckpoint.For(receiptedAction)) { }
+            : this(
+                actionOpId,
+                actor,
+                definitionId,
+                profile,
+                ActionCostReceiptCheckpoint.For(receiptedAction)
+            ) { }
 
         private CommitActionCostsOp(
             OpId actionOpId,
             CreatureId actor,
+            ActionDefinitionId definitionId,
             ActionProfile profile,
             ActionCostReceiptCheckpoint receiptCheckpoint
         )
@@ -147,8 +160,14 @@ namespace Game.Rules.Runtime
                 throw new ArgumentException("An action Op ID is required.", nameof(actionOpId));
             if (actor.IsEmpty)
                 throw new ArgumentException("An action actor is required.", nameof(actor));
+            if (definitionId.IsEmpty)
+                throw new ArgumentException(
+                    "An action definition is required.",
+                    nameof(definitionId)
+                );
             ActionOpId = actionOpId;
             Actor = actor;
+            DefinitionId = definitionId;
             Profile = profile ?? throw new ArgumentNullException(nameof(profile));
             ReceiptCheckpoint =
                 receiptCheckpoint ?? throw new ArgumentNullException(nameof(receiptCheckpoint));
@@ -163,6 +182,9 @@ namespace Game.Rules.Runtime
         /// Gets the creature paying the costs.
         /// </summary>
         public CreatureId Actor { get; }
+
+        /// <summary>Gets the trusted top-level action definition from the parent frame.</summary>
+        public ActionDefinitionId DefinitionId { get; }
 
         /// <summary>
         /// Gets the engine-owned frozen profile from the parent action frame.

--- a/Assets/Scripts/Rules/Runtime/ActionLifecycleRuntime.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionLifecycleRuntime.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Game.Rules.Runtime
 {
@@ -114,8 +115,9 @@ namespace Game.Rules.Runtime
         public static ActionRuntime Create(
             IActionCatalog catalog,
             IActionProfileResolver resolver,
-            IDictionary<Type, List<IActionValidatorRegistration>> validators
-        ) => new ConfiguredActionRuntime(catalog, resolver, validators);
+            IDictionary<Type, List<IActionValidatorRegistration>> validators,
+            IReadOnlyList<IActionPermission> permissions
+        ) => new ConfiguredActionRuntime(catalog, resolver, validators, permissions);
 
         private sealed class DisabledActionRuntime : ActionRuntime
         {
@@ -165,11 +167,13 @@ namespace Game.Rules.Runtime
                 Type,
                 IReadOnlyList<IActionValidatorRegistration>
             > validators;
+            private readonly IReadOnlyList<IActionPermission> permissions;
 
             public ConfiguredActionRuntime(
                 IActionCatalog catalog,
                 IActionProfileResolver resolver,
-                IDictionary<Type, List<IActionValidatorRegistration>> validators
+                IDictionary<Type, List<IActionValidatorRegistration>> validators,
+                IReadOnlyList<IActionPermission> permissions
             )
             {
                 this.catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
@@ -183,6 +187,9 @@ namespace Game.Rules.Runtime
                     Type,
                     IReadOnlyList<IActionValidatorRegistration>
                 >(copied);
+                this.permissions = Array.AsReadOnly(
+                    permissions?.ToArray() ?? throw new ArgumentNullException(nameof(permissions))
+                );
             }
 
             public override FrameActionState CreateFrameState(
@@ -262,6 +269,20 @@ namespace Game.Rules.Runtime
 
             public override ActionValidationResult Validate(IFrameInvocation invocation)
             {
+                foreach (IActionPermission permission in permissions)
+                {
+                    ActionValidationResult result = permission.Validate(
+                        invocation.FrameView.ActionInfo,
+                        invocation.FrameView.ActionProfile,
+                        invocation.FrameView.Snapshot
+                    );
+                    if (result == null)
+                        throw new InvalidOperationException(
+                            $"Action permission {permission.GetType().Name} returned null."
+                        );
+                    if (result is ActionValidationResult.InvalidActionValidationResult)
+                        return result;
+                }
                 if (
                     !validators.TryGetValue(
                         invocation.FrameView.OpType,
@@ -299,7 +320,8 @@ namespace Game.Rules.Runtime
         public abstract bool IsConfigured { get; }
 
         public abstract ActionRuntime CreateRuntime(
-            IDictionary<Type, List<IActionValidatorRegistration>> validators
+            IDictionary<Type, List<IActionValidatorRegistration>> validators,
+            IReadOnlyList<IActionPermission> permissions
         );
 
         public static ActionRuntimeConfiguration Configure(
@@ -312,7 +334,8 @@ namespace Game.Rules.Runtime
             public override bool IsConfigured => false;
 
             public override ActionRuntime CreateRuntime(
-                IDictionary<Type, List<IActionValidatorRegistration>> validators
+                IDictionary<Type, List<IActionValidatorRegistration>> validators,
+                IReadOnlyList<IActionPermission> permissions
             ) => ActionRuntime.Disabled;
         }
 
@@ -333,8 +356,9 @@ namespace Game.Rules.Runtime
             public override bool IsConfigured => true;
 
             public override ActionRuntime CreateRuntime(
-                IDictionary<Type, List<IActionValidatorRegistration>> validators
-            ) => ActionRuntime.Create(catalog, resolver, validators);
+                IDictionary<Type, List<IActionValidatorRegistration>> validators,
+                IReadOnlyList<IActionPermission> permissions
+            ) => ActionRuntime.Create(catalog, resolver, validators, permissions);
         }
     }
 

--- a/Assets/Scripts/Rules/Runtime/ActionValidation.cs
+++ b/Assets/Scripts/Rules/Runtime/ActionValidation.cs
@@ -72,4 +72,18 @@ namespace Game.Rules.Runtime
         /// <returns>A valid result or the first reason the action cannot legally begin.</returns>
         ActionValidationResult Validate(OpFrame<TOp> frame, RulesSnapshot snapshot);
     }
+
+    /// <summary>
+    /// Applies one feature-owned permission rule to every action, reaction, and free action at the
+    /// shared lifecycle boundary.
+    /// </summary>
+    public interface IActionPermission
+    {
+        /// <summary>Validates the trusted action identity and frozen profile without side effects.</summary>
+        ActionValidationResult Validate(
+            ActionOpInfo action,
+            ActionProfile profile,
+            RulesSnapshot snapshot
+        );
+    }
 }

--- a/Assets/Scripts/Rules/Runtime/ConditionContracts.cs
+++ b/Assets/Scripts/Rules/Runtime/ConditionContracts.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace Game.Rules.Runtime
 {
@@ -232,69 +230,43 @@ namespace Game.Rules.Runtime
     /// <summary>Stores an unrestricted or immutable restricted Quickened action allowance.</summary>
     public sealed class QuickenedConditionState : IEffectState, IEquatable<QuickenedConditionState>
     {
-        private readonly IReadOnlyList<ActionDefinitionId> allowedActions;
-        private readonly HashSet<ActionDefinitionId> allowedActionLookup;
-
         /// <summary>Creates a restricted Quickened source.</summary>
+        /// <param name="allowedActions">The nonempty definitions allowed by this source.</param>
         public QuickenedConditionState(IEnumerable<ActionDefinitionId> allowedActions)
+            : this(ActionAllowance.Restricted(allowedActions)) { }
+
+        private QuickenedConditionState(ActionAllowance allowance)
         {
-            if (allowedActions == null)
-                throw new ArgumentNullException(nameof(allowedActions));
-
-            ActionDefinitionId[] copied = allowedActions
-                .Distinct()
-                .OrderBy(action => action.Value, StringComparer.Ordinal)
-                .ToArray();
-            if (copied.Length == 0)
-                throw new ArgumentException(
-                    "Quickened must allow at least one action definition.",
-                    nameof(allowedActions)
-                );
-            if (copied.Any(action => action.IsEmpty))
-                throw new ArgumentException(
-                    "Quickened cannot allow an empty action definition.",
-                    nameof(allowedActions)
-                );
-
-            this.allowedActions = new ReadOnlyCollection<ActionDefinitionId>(copied);
-            allowedActionLookup = new HashSet<ActionDefinitionId>(copied);
-            IsRestricted = true;
-        }
-
-        private QuickenedConditionState()
-        {
-            allowedActions = Array.AsReadOnly(Array.Empty<ActionDefinitionId>());
-            allowedActionLookup = new HashSet<ActionDefinitionId>();
-            IsRestricted = false;
+            Allowance = allowance ?? throw new ArgumentNullException(nameof(allowance));
         }
 
         /// <summary>Gets the unrestricted Quickened state.</summary>
-        public static QuickenedConditionState Unrestricted { get; } = new QuickenedConditionState();
+        public static QuickenedConditionState Unrestricted { get; } =
+            new QuickenedConditionState(ActionAllowance.Unrestricted);
+
+        /// <summary>Gets the generic immutable allowance contributed by this source.</summary>
+        public ActionAllowance Allowance { get; }
 
         /// <summary>Gets whether this source restricts its additional action.</summary>
-        public bool IsRestricted { get; }
+        public bool IsRestricted => !Allowance.IsUnrestricted;
 
         /// <summary>Gets the canonical allowed definitions, empty only when unrestricted.</summary>
-        public IReadOnlyList<ActionDefinitionId> AllowedActions => allowedActions;
+        public IReadOnlyList<ActionDefinitionId> AllowedActions => Allowance.AllowedActions;
 
         /// <summary>Tests whether the source permits the supplied action.</summary>
-        public bool Allows(ActionDefinitionId action) =>
-            !IsRestricted || allowedActionLookup.Contains(action);
+        /// <param name="action">The valid exact action definition to inspect.</param>
+        /// <returns><see langword="true"/> when this source permits the definition.</returns>
+        public bool Allows(ActionDefinitionId action) => Allowance.Allows(action);
 
+        /// <inheritdoc/>
         public bool Equals(QuickenedConditionState other) =>
-            other != null
-            && IsRestricted == other.IsRestricted
-            && allowedActions.SequenceEqual(other.allowedActions);
+            other != null && Allowance.Equals(other.Allowance);
 
+        /// <inheritdoc/>
         public override bool Equals(object obj) =>
             obj is QuickenedConditionState other && Equals(other);
 
-        public override int GetHashCode()
-        {
-            int hash = 17;
-            foreach (ActionDefinitionId action in allowedActions)
-                hash = HashCode.Combine(hash, action);
-            return hash;
-        }
+        /// <inheritdoc/>
+        public override int GetHashCode() => Allowance.GetHashCode();
     }
 }

--- a/Assets/Scripts/Rules/Runtime/ConditionContracts.cs
+++ b/Assets/Scripts/Rules/Runtime/ConditionContracts.cs
@@ -45,6 +45,7 @@ namespace Game.Rules.Runtime
             builder.Define(Slowed);
             builder.Define(Stunned);
             builder.Define(Quickened);
+            ConditionTurnResourceRules.Define(builder);
             return builder;
         }
 

--- a/Assets/Scripts/Rules/Runtime/ConditionRuleRuntime.cs
+++ b/Assets/Scripts/Rules/Runtime/ConditionRuleRuntime.cs
@@ -30,6 +30,11 @@ namespace Game.Rules.Runtime
                     new CleanupConditionsFromSourceReducer(),
                     LifecycleSource,
                     InvocationPolicy.ExternalAllowed
+                )
+                .RegisterReducer<CommitMidTurnStunnedLossOp, MidTurnStunnedLossOutcome>(
+                    new CommitMidTurnStunnedLossReducer(),
+                    ConditionTurnResourceRules.Source,
+                    InvocationPolicy.ExternalAllowed
                 );
         }
     }

--- a/Assets/Scripts/Rules/Runtime/ConditionSelectors.cs
+++ b/Assets/Scripts/Rules/Runtime/ConditionSelectors.cs
@@ -102,7 +102,13 @@ namespace Game.Rules.Runtime
             );
 
         /// <summary>Unions active Quickened allowances, with unrestricted sources dominating.</summary>
-        public static QuickenedAllowance GetQuickenedAllowance(
+        /// <param name="snapshot">The authoritative snapshot to inspect.</param>
+        /// <param name="owner">The creature whose active Quickened sources are selected.</param>
+        /// <returns>
+        /// <see cref="ActionAllowance.None"/> when no source is active; otherwise the canonical
+        /// union of every active source.
+        /// </returns>
+        public static ActionAllowance GetQuickenedAllowance(
             RulesSnapshot snapshot,
             CreatureId owner
         )
@@ -113,10 +119,9 @@ namespace Game.Rules.Runtime
                     owner,
                     ConditionRuleDefinitions.Quickened
                 );
-            if (sources.Any(source => !source.State.IsRestricted))
-                return QuickenedAllowance.Unrestricted;
-            return QuickenedAllowance.Restricted(
-                sources.SelectMany(source => source.State.AllowedActions)
+            return sources.Aggregate(
+                ActionAllowance.None,
+                (allowance, source) => allowance.Union(source.State.Allowance)
             );
         }
 
@@ -237,40 +242,5 @@ namespace Game.Rules.Runtime
 
             return new ConditionSelection<TState>(effect, binding, state);
         }
-    }
-
-    /// <summary>Represents the effective union of all active Quickened sources.</summary>
-    public sealed class QuickenedAllowance
-    {
-        private readonly IReadOnlyList<ActionDefinitionId> allowedActions;
-
-        private QuickenedAllowance(bool isUnrestricted, IEnumerable<ActionDefinitionId> actions)
-        {
-            IsUnrestricted = isUnrestricted;
-            allowedActions = Array.AsReadOnly(
-                actions.Distinct().OrderBy(action => action.Value, StringComparer.Ordinal).ToArray()
-            );
-        }
-
-        /// <summary>Gets the allowance produced by at least one unrestricted source.</summary>
-        public static QuickenedAllowance Unrestricted { get; } =
-            new QuickenedAllowance(true, Array.Empty<ActionDefinitionId>());
-
-        /// <summary>Creates the union of restricted sources, including an empty inactive union.</summary>
-        public static QuickenedAllowance Restricted(IEnumerable<ActionDefinitionId> actions) =>
-            new QuickenedAllowance(
-                false,
-                actions ?? throw new ArgumentNullException(nameof(actions))
-            );
-
-        /// <summary>Gets whether any active source is unrestricted.</summary>
-        public bool IsUnrestricted { get; }
-
-        /// <summary>Gets the canonical union of restricted action definitions.</summary>
-        public IReadOnlyList<ActionDefinitionId> AllowedActions => allowedActions;
-
-        /// <summary>Tests whether the effective allowance permits an action definition.</summary>
-        public bool Allows(ActionDefinitionId action) =>
-            IsUnrestricted || allowedActions.Contains(action);
     }
 }

--- a/Assets/Scripts/Rules/Runtime/ConditionTurnResourceRules.cs
+++ b/Assets/Scripts/Rules/Runtime/ConditionTurnResourceRules.cs
@@ -1,0 +1,426 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Game.Rules.Runtime
+{
+    /// <summary>Exposes the condition feature's explicit generic composition capabilities.</summary>
+    public static class ConditionTurnResourceComposition
+    {
+        /// <summary>Creates the permission that blocks every action while Stunned remains.</summary>
+        public static IActionPermission CreateActionPermission() => new StunnedActionPermission();
+
+        /// <summary>Creates the provider for Quickened, Slowed, and elected Stunned state.</summary>
+        public static ITurnResourceContributionProvider CreateProvider() =>
+            new ConditionTurnResourceProvider();
+
+        /// <summary>Creates the stable listener binding for one enrolled actor.</summary>
+        public static ActiveRuleBinding CreateListenerBinding(CreatureId actor) =>
+            ConditionTurnResourceRules.CreateListenerBinding(actor);
+    }
+
+    /// <summary>Owns condition-derived turn resources, Stunned permission, and mid-turn loss.</summary>
+    internal static class ConditionTurnResourceRules
+    {
+        internal static readonly RuleDefinitionId ListenerDefinitionId = new(
+            "condition-turn-resources"
+        );
+        internal static readonly RuleSource Source = RuleSource.FromSlug(
+            "condition-turn-resources"
+        );
+
+        internal static RuleRegistryBuilder Define(RuleRegistryBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+            MidTurnStunnedListener listener = new();
+            builder
+                .Define(ListenerDefinitionId)
+                .FactListener<ActiveEffectCreatedFact>(RuleLifecyclePhase.Reaction, listener)
+                .FactListener<ActiveEffectStateUpdatedFact>(RuleLifecyclePhase.Reaction, listener);
+            return builder;
+        }
+
+        internal static ActiveRuleBinding CreateListenerBinding(CreatureId actor) =>
+            new(
+                new BindingId($"condition-turn-resources-{actor.Value}"),
+                ListenerDefinitionId,
+                actor,
+                default,
+                Source,
+                0
+            );
+    }
+
+    internal sealed class ConditionTurnResourceProvider : ITurnResourceContributionProvider
+    {
+        public TurnResourceContributionBatch GetContributions(
+            RulesSnapshot snapshot,
+            CreatureId actor
+        )
+        {
+            List<TurnResourceContribution> contributions = new();
+            ActionAllowance quickened = ConditionSelectors.GetQuickenedAllowance(snapshot, actor);
+            if (!quickened.IsNone)
+                contributions.Add(TurnResourceContribution.OptionalAction(quickened));
+            if (ConditionSelectors.TryGetSlowed(snapshot, actor, out var slowed))
+                contributions.Add(TurnResourceContribution.StartTurnLoss(slowed.State.Value));
+
+            ITurnResourceEffectAdjustment adjustment = NoTurnResourceEffectAdjustment.Instance;
+            if (ConditionSelectors.TryGetStunned(snapshot, actor, out var stunned))
+            {
+                if (stunned.State is DurationOnlyStunnedConditionState)
+                {
+                    contributions.Add(
+                        TurnResourceContribution.StunnedBy(StunnedResourcePolicy.DurationOnly)
+                    );
+                }
+                else
+                {
+                    ValuedStunnedConditionState valued = (ValuedStunnedConditionState)stunned.State;
+                    contributions.Add(
+                        TurnResourceContribution.StunnedBy(
+                            StunnedResourcePolicy.Valued(valued.Value)
+                        )
+                    );
+                    adjustment = new ValuedStunnedTurnAdjustment(
+                        ConditionSelectors.GetActiveInstances(
+                            snapshot,
+                            actor,
+                            ConditionRuleDefinitions.Stunned
+                        )
+                    );
+                }
+            }
+            return new TurnResourceContributionBatch(contributions, adjustment);
+        }
+    }
+
+    internal sealed class ValuedStunnedTurnAdjustment : ITurnResourceEffectAdjustment
+    {
+        private readonly IReadOnlyList<ConditionSelection<StunnedConditionState>> selections;
+
+        internal ValuedStunnedTurnAdjustment(
+            IEnumerable<ConditionSelection<IEffectState>> activeStunned
+        )
+        {
+            if (activeStunned == null)
+                throw new ArgumentNullException(nameof(activeStunned));
+            selections = activeStunned
+                .Where(selection => selection.State is ValuedStunnedConditionState)
+                .Select(selection => new ConditionSelection<StunnedConditionState>(
+                    selection.Effect,
+                    selection.Binding,
+                    (StunnedConditionState)selection.State
+                ))
+                .ToArray();
+            if (selections.Count == 0)
+                throw new ArgumentException(
+                    "At least one valued Stunned selection is required.",
+                    nameof(activeStunned)
+                );
+            if (
+                selections.Select(selection => selection.Owner).Distinct().Count() != 1
+                || selections.Select(selection => selection.EffectId).Distinct().Count()
+                    != selections.Count
+                || selections.Select(selection => selection.BindingId).Distinct().Count()
+                    != selections.Count
+            )
+                throw new ArgumentException(
+                    "Valued Stunned adjustments require distinct effects for one owner.",
+                    nameof(activeStunned)
+                );
+        }
+
+        public bool IsPresent => true;
+
+        public IReadOnlyList<TurnResourceEffectChange> CreateChanges(int resourcesConsumed)
+        {
+            if (resourcesConsumed <= 0)
+                throw new ArgumentOutOfRangeException(nameof(resourcesConsumed));
+            return selections
+                .Select(selection =>
+                {
+                    int remaining =
+                        ((ValuedStunnedConditionState)selection.State).Value - resourcesConsumed;
+                    return new TurnResourceEffectChange(
+                        selection.Owner,
+                        selection.EffectId,
+                        selection.BindingId,
+                        selection.Version,
+                        selection.Source,
+                        remaining > 0 ? new ValuedStunnedConditionState(remaining) : null
+                    );
+                })
+                .ToArray();
+        }
+    }
+
+    internal sealed class StunnedActionPermission : IActionPermission
+    {
+        public ActionValidationResult Validate(
+            ActionOpInfo action,
+            ActionProfile profile,
+            RulesSnapshot snapshot
+        ) =>
+            ConditionSelectors.TryGetStunned(snapshot, action.Actor, out _)
+                ? ActionValidationResult.Invalid("A Stunned actor cannot take actions.")
+                : ActionValidationResult.Valid;
+    }
+
+    internal sealed class CommitMidTurnStunnedLossOp : IRuleOp<MidTurnStunnedLossOutcome>
+    {
+        internal CommitMidTurnStunnedLossOp(
+            TurnIdentity turn,
+            ConditionSelection<StunnedConditionState> effective,
+            ITurnResourceEffectAdjustment effectAdjustment
+        )
+        {
+            Turn = turn;
+            if (effective == null)
+                throw new ArgumentNullException(nameof(effective));
+            EffectId = effective.EffectId;
+            BindingId = effective.BindingId;
+            ExpectedVersion = effective.Version;
+            Source = effective.Source;
+            Stunned =
+                effective.State is DurationOnlyStunnedConditionState
+                    ? StunnedResourcePolicy.DurationOnly
+                    : StunnedResourcePolicy.Valued(
+                        ((ValuedStunnedConditionState)effective.State).Value
+                    );
+            EffectAdjustment =
+                effectAdjustment ?? throw new ArgumentNullException(nameof(effectAdjustment));
+            if (Stunned.Kind == StunnedResourcePolicyKind.Valued && !EffectAdjustment.IsPresent)
+                throw new ArgumentException(
+                    "Valued Stunned requires exact source adjustments.",
+                    nameof(effectAdjustment)
+                );
+        }
+
+        internal TurnIdentity Turn { get; }
+        internal ActiveEffectId EffectId { get; }
+        internal BindingId BindingId { get; }
+        internal EffectStateVersion ExpectedVersion { get; }
+        internal RuleSource Source { get; }
+        internal StunnedResourcePolicy Stunned { get; }
+        internal ITurnResourceEffectAdjustment EffectAdjustment { get; }
+    }
+
+    internal readonly struct MidTurnStunnedLossOutcome
+    {
+        internal MidTurnStunnedLossOutcome(int resourcesLost, bool stunnedRemains)
+        {
+            ResourcesLost = resourcesLost;
+            StunnedRemains = stunnedRemains;
+        }
+
+        internal int ResourcesLost { get; }
+        internal bool StunnedRemains { get; }
+    }
+
+    internal sealed class CommitMidTurnStunnedLossReducer
+        : IOpReducer<CommitMidTurnStunnedLossOp, MidTurnStunnedLossOutcome>
+    {
+        public ReductionResult<MidTurnStunnedLossOutcome> Reduce(
+            ReductionContext<CommitMidTurnStunnedLossOp> context,
+            RulesStateDraft state,
+            FactSink facts
+        )
+        {
+            CommitMidTurnStunnedLossOp op = context.Op;
+            if (
+                !state.Encounters.TryGet(op.Turn.Encounter, out EncounterState encounter)
+                || encounter.Phase != EncounterPhase.Active
+                || !encounter.CurrentTurn.HasValue
+                || encounter.CurrentTurn.Value != op.Turn
+            )
+                return ReductionResult<MidTurnStunnedLossOutcome>.Reject(
+                    "The active turn identity is stale."
+                );
+            if (
+                !ActiveEffectReduction.TryGetCurrent(
+                    state,
+                    op.EffectId,
+                    op.ExpectedVersion,
+                    true,
+                    out ActiveEffectInstance effect,
+                    out string rejection
+                )
+                || !ActiveEffectReduction.TryGetAssociatedBinding(
+                    state,
+                    effect,
+                    op.BindingId,
+                    true,
+                    out ActiveRuleBinding binding,
+                    out rejection
+                )
+                || !ActiveEffectReduction.TryValidateSourceOwner(effect, op.Source, out rejection)
+            )
+                return ReductionResult<MidTurnStunnedLossOutcome>.Reject(rejection);
+            if (
+                binding.Owner != op.Turn.Actor
+                || effect.DefinitionId != ConditionRuleDefinitions.Stunned
+                || op.Stunned.Kind == StunnedResourcePolicyKind.DurationOnly
+                    && effect.State is not DurationOnlyStunnedConditionState
+                || op.Stunned.Kind == StunnedResourcePolicyKind.Valued
+                    && (
+                        effect.State is not ValuedStunnedConditionState valued
+                        || valued.Value != op.Stunned.Value
+                    )
+            )
+                return ReductionResult<MidTurnStunnedLossOutcome>.Reject(
+                    "The exact effective Stunned effect does not belong to the turn actor."
+                );
+            if (!state.ActionEconomy.TryGet(op.Turn.Actor, out ActionEconomyState economy))
+                return ReductionResult<MidTurnStunnedLossOutcome>.Reject(
+                    "The turn actor has no authoritative action economy."
+                );
+
+            int availableResources =
+                economy.StandardActionsRemaining + (economy.OptionalAction.IsNone ? 0 : 1);
+            int totalLost =
+                op.Stunned.Kind == StunnedResourcePolicyKind.DurationOnly
+                    ? availableResources
+                    : Math.Min(availableResources, op.Stunned.Value);
+            bool optionalLost = !economy.OptionalAction.IsNone && totalLost > 0;
+            int standardLost = totalLost - (optionalLost ? 1 : 0);
+            bool stunnedRemains =
+                op.Stunned.Kind == StunnedResourcePolicyKind.DurationOnly
+                || op.Stunned.Value > totalLost;
+            if (
+                totalLost > 0
+                && op.EffectAdjustment.IsPresent
+                && !TurnResourceEffectReduction.TryCommit(
+                    state,
+                    facts,
+                    op.Turn.Actor,
+                    op.EffectAdjustment,
+                    totalLost,
+                    out rejection
+                )
+            )
+                return ReductionResult<MidTurnStunnedLossOutcome>.Reject(rejection);
+
+            state.ActionEconomy.Set(
+                op.Turn.Actor,
+                new ActionEconomyState(
+                    economy.StandardActionsRemaining - standardLost,
+                    optionalLost ? ActionAllowance.None : economy.OptionalAction,
+                    stunnedRemains ? false : economy.ReactionAvailable
+                )
+            );
+            if (optionalLost)
+                facts.Stage(
+                    new ActionResourceLostFact(op.Turn.Actor, ActionResourceKind.Optional, 1)
+                );
+            if (standardLost > 0)
+                facts.Stage(
+                    new ActionResourceLostFact(
+                        op.Turn.Actor,
+                        ActionResourceKind.Standard,
+                        standardLost
+                    )
+                );
+
+            return ReductionResult<MidTurnStunnedLossOutcome>.Accept(
+                new MidTurnStunnedLossOutcome(totalLost, stunnedRemains)
+            );
+        }
+    }
+
+    internal sealed class MidTurnStunnedListener
+        : IRuleFactListener<ActiveEffectCreatedFact>,
+            IRuleFactListener<ActiveEffectStateUpdatedFact>
+    {
+        public ValueTask OnFactCommitted(ActiveEffectCreatedFact fact, FactContext context) =>
+            Drain(fact.EffectId, fact.DefinitionId, fact.SourceOpId, false, context);
+
+        public ValueTask OnFactCommitted(ActiveEffectStateUpdatedFact fact, FactContext context) =>
+            Drain(fact.EffectId, fact.DefinitionId, fact.SourceOpId, true, context);
+
+        private static async ValueTask Drain(
+            ActiveEffectId effectId,
+            RuleDefinitionId definitionId,
+            OpId sourceOpId,
+            bool isStateUpdate,
+            FactContext context
+        )
+        {
+            if (definitionId != ConditionRuleDefinitions.Stunned)
+                return;
+            if (
+                isStateUpdate
+                && (
+                    context.Trace.Require(sourceOpId).OpType == typeof(CommitTurnBeginOp)
+                    || context.Trace.Require(sourceOpId).OpType
+                        == typeof(CommitMidTurnStunnedLossOp)
+                )
+            )
+                return;
+            if (
+                !context.Snapshot.ActiveEffects.TryGet(effectId, out ActiveEffectInstance effect)
+                || effect.Status != ActiveEffectStatus.Active
+                || effect.DefinitionId != ConditionRuleDefinitions.Stunned
+            )
+                return;
+            ActiveRuleBinding binding = context
+                .Snapshot.RuleBindings.Select(pair => pair.Value)
+                .SingleOrDefault(candidate =>
+                    candidate.IsEnabled
+                    && candidate.EffectId.HasValue
+                    && candidate.EffectId.Value == effect.Id
+                    && candidate.DefinitionId == effect.DefinitionId
+                    && candidate.Source == effect.Source
+                );
+            if (binding == null)
+                return;
+            if (context.Binding.Owner != binding.Owner)
+                return;
+            if (
+                !ConditionSelectors.TryGetStunned(
+                    context.Snapshot,
+                    binding.Owner,
+                    out ConditionSelection<StunnedConditionState> effective
+                )
+            )
+                return;
+            EncounterState[] encounters = context
+                .Snapshot.Encounters.Select(pair => pair.Value)
+                .Where(encounter =>
+                    encounter.Phase == EncounterPhase.Active
+                    && encounter.CurrentTurn.HasValue
+                    && encounter.CurrentTurn.Value.Actor == binding.Owner
+                )
+                .ToArray();
+            if (encounters.Length == 0)
+                return;
+            if (encounters.Length != 1)
+                throw new InvalidOperationException(
+                    "A creature cannot own more than one active encounter turn."
+                );
+            OpResult<MidTurnStunnedLossOutcome> result = await context.Dispatch(
+                new CommitMidTurnStunnedLossOp(
+                    encounters[0].CurrentTurn.Value,
+                    effective,
+                    effective.State is ValuedStunnedConditionState
+                        ? new ValuedStunnedTurnAdjustment(
+                            ConditionSelectors.GetActiveInstances(
+                                context.Snapshot,
+                                binding.Owner,
+                                ConditionRuleDefinitions.Stunned
+                            )
+                        )
+                        : NoTurnResourceEffectAdjustment.Instance
+                )
+            );
+            if (result is InvalidOpResult<MidTurnStunnedLossOutcome> invalid)
+                throw new InvalidOperationException(invalid.Reason);
+            if (result is not ResolvedOpResult<MidTurnStunnedLossOutcome>)
+                throw new InvalidOperationException(
+                    "Mid-turn Stunned resource loss did not resolve."
+                );
+        }
+    }
+}

--- a/Assets/Scripts/Rules/Runtime/ConditionTurnResourceRules.cs.meta
+++ b/Assets/Scripts/Rules/Runtime/ConditionTurnResourceRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18f2846a1e364cb69b38c45c2fa52b89

--- a/Assets/Scripts/Rules/Runtime/EncounterFacts.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterFacts.cs
@@ -209,28 +209,4 @@ namespace Game.Rules.Runtime
             Outcome = outcome;
         }
     }
-
-    /// <summary>Reports an authoritative encounter action spend.</summary>
-    public sealed class EncounterActionsSpentFact : RuleFact
-    {
-        /// <summary>Gets the spending actor.</summary>
-        public CreatureId Actor { get; }
-
-        /// <summary>Gets the number of actions spent.</summary>
-        public int Amount { get; }
-
-        /// <summary>Gets the actor's committed remaining actions.</summary>
-        public int Remaining { get; }
-
-        /// <summary>Creates a fact for one committed encounter action spend.</summary>
-        /// <param name="actor">The creature that spent actions.</param>
-        /// <param name="amount">The positive action cost.</param>
-        /// <param name="remaining">The committed remaining actions.</param>
-        public EncounterActionsSpentFact(CreatureId actor, int amount, int remaining)
-        {
-            Actor = actor;
-            Amount = amount;
-            Remaining = remaining;
-        }
-    }
 }

--- a/Assets/Scripts/Rules/Runtime/EncounterOperations.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterOperations.cs
@@ -25,20 +25,6 @@ namespace Game.Rules.Runtime
                 );
             return Array.AsReadOnly(copied);
         }
-
-        public static IReadOnlyList<CreatureId> CopyRequiredLivingTargets(
-            IEnumerable<CreatureId> targets
-        )
-        {
-            CreatureId[] copied =
-                targets?.Distinct().ToArray() ?? throw new ArgumentNullException(nameof(targets));
-            if (copied.Any(target => target.IsEmpty))
-                throw new ArgumentException(
-                    "Required living targets cannot contain an empty creature identity.",
-                    nameof(targets)
-                );
-            return Array.AsReadOnly(copied);
-        }
     }
 
     /// <summary>Requests a new encounter, initiative rolls, and its first eligible turn.</summary>
@@ -317,69 +303,6 @@ namespace Game.Rules.Runtime
         internal TurnEndingOp(TurnIdentity turn) => Turn = turn;
     }
 
-    /// <summary>Requests exact-turn authorization with an optional authoritative action spend.</summary>
-    public sealed class SpendEncounterActionsOp : IRuleOp<EncounterActionSpendOutcome>
-    {
-        /// <summary>Gets the creature whose reducer-owned actions are spent.</summary>
-        public CreatureId Actor { get; }
-
-        /// <summary>Gets the non-negative action cost; zero validates authority without mutation.</summary>
-        public int Amount { get; }
-
-        /// <summary>
-        /// Gets the encounter participants that must still be living when the spend commits.
-        /// </summary>
-        public IReadOnlyList<CreatureId> RequiredLivingTargets { get; }
-
-        /// <summary>Creates an authoritative encounter action authorization/spend request.</summary>
-        /// <param name="actor">The creature paying the action cost.</param>
-        /// <param name="amount">The non-negative number of actions to spend.</param>
-        public SpendEncounterActionsOp(CreatureId actor, int amount)
-            : this(actor, amount, Array.Empty<CreatureId>()) { }
-
-        /// <summary>
-        /// Creates an action spend that atomically requires one current living encounter target.
-        /// </summary>
-        /// <param name="actor">The creature paying the action cost.</param>
-        /// <param name="amount">The non-negative number of actions to spend.</param>
-        /// <param name="requiredLivingTarget">
-        /// The selected participant that must remain living in the actor's encounter.
-        /// </param>
-        public SpendEncounterActionsOp(
-            CreatureId actor,
-            int amount,
-            CreatureId requiredLivingTarget
-        )
-            : this(actor, amount, new[] { requiredLivingTarget }) { }
-
-        /// <summary>
-        /// Creates an action spend that atomically requires every selected encounter target to
-        /// remain living.
-        /// </summary>
-        /// <param name="actor">The creature paying the action cost.</param>
-        /// <param name="amount">The non-negative number of actions to spend.</param>
-        /// <param name="requiredLivingTargets">
-        /// The selected participants that must remain living in the actor's encounter. The
-        /// operation copies and de-duplicates this sequence before dispatch.
-        /// </param>
-        public SpendEncounterActionsOp(
-            CreatureId actor,
-            int amount,
-            IEnumerable<CreatureId> requiredLivingTargets
-        )
-        {
-            if (actor.IsEmpty)
-                throw new ArgumentException("An actor is required.", nameof(actor));
-            if (amount < 0)
-                throw new ArgumentOutOfRangeException(nameof(amount));
-            Actor = actor;
-            Amount = amount;
-            RequiredLivingTargets = EncounterOperationValues.CopyRequiredLivingTargets(
-                requiredLivingTargets
-            );
-        }
-    }
-
     /// <summary>Returns the encounter snapshot produced by a successful start.</summary>
     public readonly struct EncounterStartOutcome : ISettledOperationResult<EncounterStartOutcome>
     {
@@ -491,15 +414,6 @@ namespace Game.Rules.Runtime
     {
         /// <summary>Gets the completed hook marker.</summary>
         public static TurnEndContribution Complete => default;
-    }
-
-    /// <summary>Returns remaining actions after exact-turn authorization and any requested spend.</summary>
-    public readonly struct EncounterActionSpendOutcome
-    {
-        /// <summary>Gets the actor's committed action count.</summary>
-        public int Remaining { get; }
-
-        internal EncounterActionSpendOutcome(int remaining) => Remaining = remaining;
     }
 
     internal sealed class CommitEncounterStartOp : IRuleOp<EncounterStartOutcome>
@@ -614,20 +528,17 @@ namespace Game.Rules.Runtime
     {
         public EncounterId Encounter { get; }
         public CreatureId Actor { get; }
-        public int Actions { get; }
-        public bool ReactionAvailable { get; }
+        public TurnResourceCommitPlan Resources { get; }
 
         public CommitTurnBeginOp(
             EncounterId encounter,
             CreatureId actor,
-            int actions,
-            bool reactionAvailable
+            TurnResourceCommitPlan resources
         )
         {
             Encounter = encounter;
             Actor = actor;
-            Actions = actions;
-            ReactionAvailable = reactionAvailable;
+            Resources = resources ?? throw new ArgumentNullException(nameof(resources));
         }
     }
 
@@ -777,24 +688,6 @@ namespace Game.Rules.Runtime
         {
             Encounter = encounter;
             Outcome = outcome;
-        }
-    }
-
-    internal sealed class CommitEncounterActionsOp : IRuleOp<EncounterActionSpendOutcome>
-    {
-        public CreatureId Actor { get; }
-        public int Amount { get; }
-        public IReadOnlyList<CreatureId> RequiredLivingTargets { get; }
-
-        public CommitEncounterActionsOp(
-            CreatureId actor,
-            int amount,
-            IReadOnlyList<CreatureId> requiredLivingTargets
-        )
-        {
-            Actor = actor;
-            Amount = amount;
-            RequiredLivingTargets = requiredLivingTargets;
         }
     }
 

--- a/Assets/Scripts/Rules/Runtime/EncounterOperations.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterOperations.cs
@@ -195,8 +195,8 @@ namespace Game.Rules.Runtime
                 : encounter;
     }
 
-    /// <summary>Opens the narrow turn-start extension point before final resource regain.</summary>
-    public sealed class TurnStartingOp : IRuleOp<TurnStartContribution>
+    /// <summary>Opens the narrow completion-only turn-start extension point.</summary>
+    public sealed class TurnStartingOp : IRuleOp<TurnStartCompletion>
     {
         /// <summary>Gets the encounter whose reached boundary owns the hook.</summary>
         public EncounterId Encounter { get; }
@@ -215,24 +215,19 @@ namespace Game.Rules.Runtime
     /// Adapts one unmigrated turn-start behavior into the authoritative encounter dispatch.
     /// </summary>
     /// <remarks>
-    /// Adapters run sequentially in registration order before resource regain. They may commit
-    /// health changes only through the supplied <see cref="EncounterTurnStartContext"/>, keeping
-    /// the work inside the active dispatcher root. The returned contribution becomes the input to
-    /// the next adapter; the final value is the action count committed with <see cref="TurnBeganFact"/>.
+    /// Adapters run sequentially in registration order before resource regain. They may commit an
+    /// ordered final-damage batch only through the supplied
+    /// <see cref="EncounterTurnStartContext"/>, keeping the work inside the active dispatcher root.
     /// The engine checkpoints only after <see cref="Apply"/> returns successfully. An adapter that
-    /// performs multiple internal commits must make those commits transactional or safe for exact
-    /// replay if one of them fails; this checkpoint does not roll back partial adapter work.
+    /// requires fallible post-damage presentation must use the context's atomic damage-and-
+    /// completion boundary so recovery cannot replay its damage.
     /// </remarks>
     public interface IEncounterTurnStartAdapter
     {
-        /// <summary>Runs one awaited turn-start contribution for the reached living actor.</summary>
+        /// <summary>Runs one awaited turn-start adapter for the reached living actor.</summary>
         /// <param name="context">The narrow same-dispatcher services for this boundary.</param>
-        /// <param name="current">The action contribution produced so far.</param>
-        /// <returns>The contribution to pass to the next adapter or final turn-begin reducer.</returns>
-        ValueTask<TurnStartContribution> Apply(
-            EncounterTurnStartContext context,
-            TurnStartContribution current
-        );
+        /// <returns>A task that completes after the adapter's work finishes.</returns>
+        ValueTask Apply(EncounterTurnStartContext context);
     }
 
     /// <summary>
@@ -244,7 +239,6 @@ namespace Game.Rules.Runtime
         private readonly RoundNumber round;
         private readonly int slot;
         private readonly int adapterIndex;
-        private readonly TurnStartContribution priorContribution;
 
         internal bool HasCommittedCompletion { get; private set; }
 
@@ -254,7 +248,6 @@ namespace Game.Rules.Runtime
             RoundNumber round,
             int slot,
             int adapterIndex,
-            TurnStartContribution priorContribution,
             OpHandlerContext context
         )
         {
@@ -263,7 +256,6 @@ namespace Game.Rules.Runtime
             this.round = round;
             this.slot = slot;
             this.adapterIndex = adapterIndex;
-            this.priorContribution = priorContribution;
             this.context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
@@ -276,32 +268,6 @@ namespace Game.Rules.Runtime
         /// <summary>Gets the latest committed snapshot after all previously awaited adapters.</summary>
         public RulesSnapshot Snapshot => context.Snapshot;
 
-        /// <summary>Commits already-final damage as a nested child of the active encounter root.</summary>
-        /// <param name="target">The creature receiving the final damage.</param>
-        /// <param name="amount">The non-negative damage remaining after upstream calculations.</param>
-        /// <param name="origin">The stable Unity health-request identity.</param>
-        /// <param name="source">The rule source responsible for the damage.</param>
-        /// <returns>The exact health changes committed before this method completes.</returns>
-        /// <exception cref="ArgumentException"><paramref name="target"/> is not <see cref="Actor"/>.</exception>
-        /// <exception cref="InvalidOperationException">The nested health request is rejected.</exception>
-        public async ValueTask<DamageOutcome> ApplyFinalDamage(
-            CreatureId target,
-            int amount,
-            HealthChangeOriginId origin,
-            RuleSource source
-        )
-        {
-            if (target != Actor)
-                throw new ArgumentException(
-                    "A turn-start adapter may damage only its reached actor.",
-                    nameof(target)
-                );
-            return EncounterHandlerResults.Require(
-                await context.Dispatch(new ApplyDamageOp(target, amount, origin, source)),
-                "turn-start damage"
-            );
-        }
-
         /// <summary>
         /// Atomically commits an ordered final-damage batch and this adapter's completion receipt.
         /// </summary>
@@ -309,26 +275,20 @@ namespace Game.Rules.Runtime
         /// Non-empty, same-source damage entries for the reached actor. Repeated targets are
         /// allowed, but each entry requires a distinct health-change origin.
         /// </param>
-        /// <param name="returnedContribution">
-        /// The contribution that recovery must pass to the next adapter.
-        /// </param>
         /// <returns>The exact damage outcomes in request order.</returns>
         /// <remarks>
         /// Use this boundary when an adapter must perform fallible presentation after damage has
         /// committed. The damage and adapter checkpoint share one reducer transaction, so a later
         /// observer or presentation failure resumes at the next adapter without replaying damage.
         /// After this method resolves, the adapter may perform presentation but must not attempt
-        /// another authoritative mutation before returning <paramref name="returnedContribution"/>.
+        /// another authoritative mutation before returning.
         /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// The batch does not match the exact current adapter progress or its reducer rejects.
         /// </exception>
         public async ValueTask<
             IReadOnlyList<DamageOutcome>
-        > CommitFinalDamageBatchAndCompleteAdapter(
-            IEnumerable<HealthBatchChange> changes,
-            TurnStartContribution returnedContribution
-        )
+        > CommitFinalDamageBatchAndCompleteAdapter(IEnumerable<HealthBatchChange> changes)
         {
             CommitTurnStartDamageBatchOutcome outcome = EncounterHandlerResults.Require(
                 await context.Dispatch(
@@ -338,8 +298,6 @@ namespace Game.Rules.Runtime
                         slot,
                         Actor,
                         adapterIndex,
-                        priorContribution,
-                        returnedContribution,
                         changes
                     )
                 ),
@@ -521,28 +479,11 @@ namespace Game.Rules.Runtime
         ) => new EncounterEvaluationOutcome(snapshot.Encounters[State.Id]);
     }
 
-    /// <summary>Carries final action and reaction regain through ordered turn-start adapters.</summary>
-    public readonly struct TurnStartContribution
+    /// <summary>Marks successful completion of all ordered turn-start adapters.</summary>
+    public readonly struct TurnStartCompletion
     {
-        /// <summary>Gets the non-negative actions to grant if the actor remains eligible.</summary>
-        public int Actions { get; }
-
-        /// <summary>Gets whether the actor regains a reaction for the reached initiative turn.</summary>
-        public bool ReactionAvailable { get; }
-
-        /// <summary>Creates a validated contribution for final resource regain.</summary>
-        /// <param name="actions">The non-negative derived action count.</param>
-        /// <param name="reactionAvailable">Whether the reached turn restores a reaction.</param>
-        public TurnStartContribution(int actions, bool reactionAvailable = true)
-        {
-            if (actions < 0)
-                throw new ArgumentOutOfRangeException(nameof(actions));
-            Actions = actions;
-            ReactionAvailable = reactionAvailable;
-        }
-
-        /// <summary>Gets the normal unmodified three-action contribution.</summary>
-        public static TurnStartContribution Standard => new TurnStartContribution(3);
+        /// <summary>Gets the completed hook marker.</summary>
+        public static TurnStartCompletion Complete => default;
     }
 
     /// <summary>Marks successful completion of the narrow turn-end hook.</summary>
@@ -691,7 +632,7 @@ namespace Game.Rules.Runtime
     }
 
     /// <summary>
-    /// Commits one successfully returned turn-start adapter result at the exact published boundary.
+    /// Commits one successfully completed turn-start adapter at the exact published boundary.
     /// </summary>
     internal sealed class CommitTurnStartAdapterProgressOp : IRuleOp<TurnStartAdapterProgress>
     {
@@ -700,17 +641,13 @@ namespace Game.Rules.Runtime
         public int Slot { get; }
         public CreatureId Actor { get; }
         public int ExpectedNextAdapterIndex { get; }
-        public TurnStartContribution PriorContribution { get; }
-        public TurnStartContribution ReturnedContribution { get; }
 
         public CommitTurnStartAdapterProgressOp(
             EncounterId encounter,
             RoundNumber round,
             int slot,
             CreatureId actor,
-            int expectedNextAdapterIndex,
-            TurnStartContribution priorContribution,
-            TurnStartContribution returnedContribution
+            int expectedNextAdapterIndex
         )
         {
             Encounter = encounter;
@@ -718,8 +655,6 @@ namespace Game.Rules.Runtime
             Slot = slot;
             Actor = actor;
             ExpectedNextAdapterIndex = expectedNextAdapterIndex;
-            PriorContribution = priorContribution;
-            ReturnedContribution = returnedContribution;
         }
     }
 
@@ -753,8 +688,6 @@ namespace Game.Rules.Runtime
             int slot,
             CreatureId actor,
             int expectedNextAdapterIndex,
-            TurnStartContribution priorContribution,
-            TurnStartContribution returnedContribution,
             IEnumerable<HealthBatchChange> changes
         )
         {
@@ -787,8 +720,6 @@ namespace Game.Rules.Runtime
             Slot = slot;
             Actor = actor;
             ExpectedNextAdapterIndex = expectedNextAdapterIndex;
-            PriorContribution = priorContribution;
-            ReturnedContribution = returnedContribution;
             Changes = Array.AsReadOnly(copied);
             Source = copied[0].Source;
         }
@@ -798,8 +729,6 @@ namespace Game.Rules.Runtime
         public int Slot { get; }
         public CreatureId Actor { get; }
         public int ExpectedNextAdapterIndex { get; }
-        public TurnStartContribution PriorContribution { get; }
-        public TurnStartContribution ReturnedContribution { get; }
         public IReadOnlyList<HealthBatchChange> Changes { get; }
         public RuleSource Source { get; }
     }

--- a/Assets/Scripts/Rules/Runtime/EncounterReducers.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterReducers.cs
@@ -288,7 +288,10 @@ namespace Game.Rules.Runtime
                 state.ActiveEffectTimings.Set(timing.Effect, timing);
             foreach (InitiativeEntry entry in encounter.Roster)
             {
-                state.ActionEconomy.Set(entry.Creature, new ActionEconomyState(0, false));
+                state.ActionEconomy.Set(
+                    entry.Creature,
+                    new ActionEconomyState(0, ActionAllowance.None, false)
+                );
                 state.MultipleAttackPenalty.Set(entry.Creature, new MultipleAttackPenaltyState(0));
             }
             facts.Stage(new EncounterStartedFact(encounter));
@@ -428,7 +431,10 @@ namespace Game.Rules.Runtime
                     if (!binding.EffectId.HasValue)
                         StatelessBindingReduction.Record(state, binding);
                 }
-                state.ActionEconomy.Set(entry.Creature, new ActionEconomyState(0, false));
+                state.ActionEconomy.Set(
+                    entry.Creature,
+                    new ActionEconomyState(0, ActionAllowance.None, false)
+                );
                 state.MultipleAttackPenalty.Set(entry.Creature, new MultipleAttackPenaltyState(0));
             }
             state.Encounters.Set(updated.Id, updated);
@@ -697,11 +703,52 @@ namespace Game.Rules.Runtime
                 isTurnStartPending: false
             );
             state.Encounters.Set(updated.Id, updated);
-            state.ActionEconomy.Set(
-                context.Op.Actor,
-                new ActionEconomyState(context.Op.Actions, context.Op.ReactionAvailable)
-            );
+            TurnResourceCommitPlan commit = context.Op.Resources;
+            TurnResourcePlan resources = commit.Resources;
+            if (
+                commit.EffectAdjustment.IsPresent
+                && !TurnResourceEffectReduction.TryCommit(
+                    state,
+                    facts,
+                    context.Op.Actor,
+                    commit.EffectAdjustment,
+                    resources.StunnedConsumed,
+                    out string effectRejection
+                )
+            )
+                return ReductionResult<EncounterAdvanceOutcome>.Reject(effectRejection);
+
+            state.ActionEconomy.Set(context.Op.Actor, resources.Economy);
             state.MultipleAttackPenalty.Set(context.Op.Actor, new MultipleAttackPenaltyState(0));
+            facts.Stage(
+                new ActionResourceGainedFact(
+                    context.Op.Actor,
+                    ActionResourceKind.Standard,
+                    TurnResourcePlanner.StandardActionCount
+                )
+            );
+            if (!resources.GrantedOptionalAction.IsNone)
+            {
+                facts.Stage(
+                    new ActionResourceGainedFact(context.Op.Actor, ActionResourceKind.Optional, 1)
+                );
+            }
+            if (resources.Loss.OptionalAction)
+            {
+                facts.Stage(
+                    new ActionResourceLostFact(context.Op.Actor, ActionResourceKind.Optional, 1)
+                );
+            }
+            if (resources.Loss.StandardActions > 0)
+            {
+                facts.Stage(
+                    new ActionResourceLostFact(
+                        context.Op.Actor,
+                        ActionResourceKind.Standard,
+                        resources.Loss.StandardActions
+                    )
+                );
+            }
             facts.Stage(new TurnBeganFact(turn));
             return ReductionResult<EncounterAdvanceOutcome>.Accept(
                 new EncounterAdvanceOutcome(updated)
@@ -947,7 +994,7 @@ namespace Game.Rules.Runtime
                 );
             state.ActionEconomy.Set(
                 requested.Actor,
-                new ActionEconomyState(0, economy.ReactionAvailable)
+                new ActionEconomyState(0, ActionAllowance.None, economy.ReactionAvailable)
             );
             state.MultipleAttackPenalty.Set(requested.Actor, new MultipleAttackPenaltyState(0));
             EncounterState updated = encounter.Replace(clearCurrentTurn: true);
@@ -996,7 +1043,10 @@ namespace Game.Rules.Runtime
         {
             foreach (InitiativeEntry entry in encounter.Roster)
             {
-                state.ActionEconomy.Set(entry.Creature, new ActionEconomyState(0, false));
+                state.ActionEconomy.Set(
+                    entry.Creature,
+                    new ActionEconomyState(0, ActionAllowance.None, false)
+                );
                 state.MultipleAttackPenalty.Set(entry.Creature, new MultipleAttackPenaltyState(0));
                 state.MovementBudgets.Remove(entry.Creature);
             }
@@ -1043,61 +1093,6 @@ namespace Game.Rules.Runtime
             state.RuleBindings.Remove(EncounterRuleRuntime.OutcomeBindingId(updated.Id));
             facts.Stage(new EncounterOutcomeCommittedFact(updated.Id, actual));
             return ReductionResult<EncounterEndOutcome>.Accept(new EncounterEndOutcome(updated));
-        }
-    }
-
-    internal sealed class SpendEncounterActionsReducer
-        : IOpReducer<CommitEncounterActionsOp, EncounterActionSpendOutcome>
-    {
-        public ReductionResult<EncounterActionSpendOutcome> Reduce(
-            ReductionContext<CommitEncounterActionsOp> context,
-            RulesStateDraft state,
-            FactSink facts
-        )
-        {
-            EncounterState encounter = state
-                .Encounters.Where(pair =>
-                    pair.Value.Phase == EncounterPhase.Active
-                    && pair.Value.CurrentTurn.HasValue
-                    && pair.Value.CurrentTurn.Value.Actor == context.Op.Actor
-                )
-                .Select(pair => pair.Value)
-                .FirstOrDefault();
-            if (encounter == null)
-                return ReductionResult<EncounterActionSpendOutcome>.Reject(
-                    "The actor does not own an active current turn."
-                );
-            if (
-                context.Op.RequiredLivingTargets.Any(target =>
-                    !encounter.Roster.Any(entry => entry.Creature == target)
-                    || !EncounterReduction.IsLiving(state, target)
-                )
-            )
-                return ReductionResult<EncounterActionSpendOutcome>.Reject(
-                    "A selected action target is no longer a living participant in the actor's encounter."
-                );
-            if (
-                !state.ActionEconomy.TryGet(context.Op.Actor, out ActionEconomyState economy)
-                || economy.ActionsRemaining < context.Op.Amount
-            )
-                return ReductionResult<EncounterActionSpendOutcome>.Reject(
-                    "The actor has insufficient authoritative actions."
-                );
-            if (context.Op.Amount == 0)
-                return ReductionResult<EncounterActionSpendOutcome>.Accept(
-                    new EncounterActionSpendOutcome(economy.ActionsRemaining)
-                );
-            int remaining = economy.ActionsRemaining - context.Op.Amount;
-            state.ActionEconomy.Set(
-                context.Op.Actor,
-                new ActionEconomyState(remaining, economy.ReactionAvailable)
-            );
-            facts.Stage(
-                new EncounterActionsSpentFact(context.Op.Actor, context.Op.Amount, remaining)
-            );
-            return ReductionResult<EncounterActionSpendOutcome>.Accept(
-                new EncounterActionSpendOutcome(remaining)
-            );
         }
     }
 }

--- a/Assets/Scripts/Rules/Runtime/EncounterReducers.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterReducers.cs
@@ -718,8 +718,6 @@ namespace Game.Rules.Runtime
             int slot,
             CreatureId actor,
             int expectedNextAdapterIndex,
-            TurnStartContribution priorContribution,
-            TurnStartContribution returnedContribution,
             out EncounterState updated,
             out TurnStartAdapterProgress advanced,
             out string rejection
@@ -746,18 +744,13 @@ namespace Game.Rules.Runtime
                 || encounter.Cursor != slot
                 || encounter.Roster[encounter.Cursor].Creature != actor
                 || progress.NextAdapterIndex != expectedNextAdapterIndex
-                || progress.Contribution.Actions != priorContribution.Actions
-                || progress.Contribution.ReactionAvailable != priorContribution.ReactionAvailable
                 || expectedNextAdapterIndex == int.MaxValue
             )
             {
                 rejection = "Only the exact current turn-start adapter progress can advance.";
                 return false;
             }
-            advanced = new TurnStartAdapterProgress(
-                checked(expectedNextAdapterIndex + 1),
-                returnedContribution
-            );
+            advanced = new TurnStartAdapterProgress(checked(expectedNextAdapterIndex + 1));
             updated = encounter.Replace(turnStartAdapterProgress: advanced);
             rejection = string.Empty;
             return true;
@@ -801,8 +794,6 @@ namespace Game.Rules.Runtime
                     context.Op.Slot,
                     context.Op.Actor,
                     context.Op.ExpectedNextAdapterIndex,
-                    context.Op.PriorContribution,
-                    context.Op.ReturnedContribution,
                     out EncounterState updated,
                     out TurnStartAdapterProgress advanced,
                     out string rejection
@@ -837,8 +828,6 @@ namespace Game.Rules.Runtime
                     context.Op.Slot,
                     context.Op.Actor,
                     context.Op.ExpectedNextAdapterIndex,
-                    context.Op.PriorContribution,
-                    context.Op.ReturnedContribution,
                     out EncounterState updated,
                     out TurnStartAdapterProgress advanced,
                     out string rejection

--- a/Assets/Scripts/Rules/Runtime/EncounterRuleRuntime.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterRuleRuntime.cs
@@ -61,7 +61,7 @@ namespace Game.Rules.Runtime
         /// </summary>
         /// <param name="builder">The shared dispatcher builder that owns all encounter rules.</param>
         /// <param name="turnStartAdapters">
-        /// The spell, aura, and action-contribution adapters to await in exact registration order.
+        /// The completion-only turn-start adapters to await in exact registration order.
         /// </param>
         /// <returns>The same builder so composition can continue.</returns>
         /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
@@ -75,7 +75,7 @@ namespace Game.Rules.Runtime
         /// </summary>
         /// <param name="builder">The shared dispatcher builder that owns all encounter rules.</param>
         /// <param name="turnStartAdapters">
-        /// The spell, aura, and action-contribution adapters to await in exact registration order.
+        /// The completion-only turn-start adapters to await in exact registration order.
         /// </param>
         /// <param name="registry">
         /// The registry used to validate atomic reinforcement effects. Unity enrollment and these
@@ -122,7 +122,7 @@ namespace Game.Rules.Runtime
                 .RegisterHandler<EvaluateEncounterOutcomeOp, EncounterEvaluationOutcome>(
                     new EvaluateEncounterOutcomeHandler()
                 )
-                .RegisterHandler<TurnStartingOp, TurnStartContribution>(
+                .RegisterHandler<TurnStartingOp, TurnStartCompletion>(
                     new TurnStartingHandler(copied),
                     InvocationPolicy.NestedOnly
                 )
@@ -587,6 +587,9 @@ namespace Game.Rules.Runtime
     internal sealed class BeginInitiativeTurnHandler
         : IOpHandler<BeginInitiativeTurnOp, EncounterAdvanceOutcome>
     {
+        private const int StandardTurnActions = 3;
+        private const bool StandardReactionAvailable = true;
+
         public async ValueTask<EncounterAdvanceOutcome> Handle(
             OpFrame<BeginInitiativeTurnOp> frame,
             OpHandlerContext context
@@ -622,7 +625,7 @@ namespace Game.Rules.Runtime
                 "turn-start movement reset"
             );
 
-            TurnStartContribution contribution = EncounterHandlerResults.Require(
+            EncounterHandlerResults.Require(
                 await context.Dispatch(new TurnStartingOp(frame.Op.Encounter, entry.Creature)),
                 "turn-start hook"
             );
@@ -647,8 +650,8 @@ namespace Game.Rules.Runtime
                     new CommitTurnBeginOp(
                         frame.Op.Encounter,
                         entry.Creature,
-                        contribution.Actions,
-                        contribution.ReactionAvailable
+                        StandardTurnActions,
+                        StandardReactionAvailable
                     )
                 ),
                 "turn begin"
@@ -901,14 +904,14 @@ namespace Game.Rules.Runtime
         }
     }
 
-    internal sealed class TurnStartingHandler : IOpHandler<TurnStartingOp, TurnStartContribution>
+    internal sealed class TurnStartingHandler : IOpHandler<TurnStartingOp, TurnStartCompletion>
     {
         private readonly IReadOnlyList<IEncounterTurnStartAdapter> adapters;
 
         public TurnStartingHandler(IEnumerable<IEncounterTurnStartAdapter> adapters) =>
             this.adapters = Array.AsReadOnly(adapters.ToArray());
 
-        public async ValueTask<TurnStartContribution> Handle(
+        public async ValueTask<TurnStartCompletion> Handle(
             OpFrame<TurnStartingOp> frame,
             OpHandlerContext context
         )
@@ -931,7 +934,6 @@ namespace Game.Rules.Runtime
                 throw new InvalidOperationException(
                     "Turn-start adapters require the exact current published boundary progress."
                 );
-            TurnStartContribution contribution = progress.Contribution;
             for (int index = progress.NextAdapterIndex; index < adapters.Count; index++)
             {
                 EncounterTurnStartContext adapterContext = new EncounterTurnStartContext(
@@ -940,11 +942,9 @@ namespace Game.Rules.Runtime
                     encounter.Round,
                     encounter.Cursor,
                     index,
-                    contribution,
                     context
                 );
-                TurnStartContribution returned = await adapters[index]
-                    .Apply(adapterContext, contribution);
+                await adapters[index].Apply(adapterContext);
                 progress = EncounterRuleRuntime
                     .RequireEncounter(context.Snapshot, frame.Op.Encounter)
                     .TurnStartAdapterProgress;
@@ -952,14 +952,9 @@ namespace Game.Rules.Runtime
                 {
                     // The adapter used its atomic mutation-plus-completion boundary. Its durable
                     // checkpoint already owns recovery, so a second progress commit would conflict.
-                    if (
-                        progress == null
-                        || progress.NextAdapterIndex != index + 1
-                        || progress.Contribution.Actions != returned.Actions
-                        || progress.Contribution.ReactionAvailable != returned.ReactionAvailable
-                    )
+                    if (progress == null || progress.NextAdapterIndex != index + 1)
                         throw new InvalidOperationException(
-                            "The atomically completed adapter returned a conflicting contribution."
+                            "The atomically completed adapter has conflicting progress."
                         );
                 }
                 else
@@ -971,19 +966,16 @@ namespace Game.Rules.Runtime
                                 encounter.Round,
                                 encounter.Cursor,
                                 frame.Op.Actor,
-                                index,
-                                contribution,
-                                returned
+                                index
                             )
                         ),
                         "turn-start adapter progress"
                     );
                 }
-                contribution = progress.Contribution;
                 if (!EncounterEndValidation.IsLiving(context.Snapshot, frame.Op.Actor))
                     break;
             }
-            return contribution;
+            return TurnStartCompletion.Complete;
         }
     }
 

--- a/Assets/Scripts/Rules/Runtime/EncounterRuleRuntime.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterRuleRuntime.cs
@@ -88,12 +88,35 @@ namespace Game.Rules.Runtime
             this RuleDispatcherBuilder builder,
             IEnumerable<IEncounterTurnStartAdapter> turnStartAdapters,
             RuleRegistry registry
+        ) =>
+            UseEncounterRules(
+                builder,
+                turnStartAdapters,
+                registry,
+                new TurnResourceStrategy(Array.Empty<ITurnResourceContributionProvider>())
+            );
+
+        /// <summary>
+        /// Registers encounter transitions with explicit adapters, registry, and turn resources.
+        /// </summary>
+        /// <param name="builder">The shared dispatcher builder.</param>
+        /// <param name="turnStartAdapters">Ordered completion-only Unity adapters.</param>
+        /// <param name="registry">The active-effect registry shared by enrollment.</param>
+        /// <param name="turnResources">The explicitly composed generic refresh strategy.</param>
+        /// <returns>The same builder so composition can continue.</returns>
+        public static RuleDispatcherBuilder UseEncounterRules(
+            this RuleDispatcherBuilder builder,
+            IEnumerable<IEncounterTurnStartAdapter> turnStartAdapters,
+            RuleRegistry registry,
+            TurnResourceStrategy turnResources
         )
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
             if (registry == null)
                 throw new ArgumentNullException(nameof(registry));
+            if (turnResources == null)
+                throw new ArgumentNullException(nameof(turnResources));
             IEncounterTurnStartAdapter[] copied =
                 turnStartAdapters?.ToArray()
                 ?? throw new ArgumentNullException(nameof(turnStartAdapters));
@@ -112,7 +135,7 @@ namespace Game.Rules.Runtime
                     new AdvanceEncounterHandler()
                 )
                 .RegisterHandler<BeginInitiativeTurnOp, EncounterAdvanceOutcome>(
-                    new BeginInitiativeTurnHandler()
+                    new BeginInitiativeTurnHandler(turnResources)
                 )
                 .RegisterHandler<EndTurnOp, EncounterAdvanceOutcome>(new EndTurnHandler())
                 .RegisterHandler<SuspendEncounterOp, EncounterSuspensionOutcome>(
@@ -129,9 +152,6 @@ namespace Game.Rules.Runtime
                 .RegisterHandler<TurnEndingOp, TurnEndContribution>(
                     new TurnEndingHandler(),
                     InvocationPolicy.NestedOnly
-                )
-                .RegisterHandler<SpendEncounterActionsOp, EncounterActionSpendOutcome>(
-                    new SpendEncounterActionsHandler()
                 )
                 .RegisterEngineReducer<CommitEncounterStartOp, EncounterStartOutcome>(
                     new CommitEncounterStartReducer(),
@@ -179,10 +199,6 @@ namespace Game.Rules.Runtime
                 )
                 .RegisterEngineReducer<CommitEncounterEndOp, EncounterEndOutcome>(
                     new CommitEncounterEndReducer(),
-                    Source
-                )
-                .RegisterEngineReducer<CommitEncounterActionsOp, EncounterActionSpendOutcome>(
-                    new SpendEncounterActionsReducer(),
                     Source
                 );
         }
@@ -587,8 +603,11 @@ namespace Game.Rules.Runtime
     internal sealed class BeginInitiativeTurnHandler
         : IOpHandler<BeginInitiativeTurnOp, EncounterAdvanceOutcome>
     {
-        private const int StandardTurnActions = 3;
-        private const bool StandardReactionAvailable = true;
+        private readonly TurnResourceStrategy turnResources;
+
+        internal BeginInitiativeTurnHandler(TurnResourceStrategy turnResources) =>
+            this.turnResources =
+                turnResources ?? throw new ArgumentNullException(nameof(turnResources));
 
         public async ValueTask<EncounterAdvanceOutcome> Handle(
             OpFrame<BeginInitiativeTurnOp> frame,
@@ -650,8 +669,7 @@ namespace Game.Rules.Runtime
                     new CommitTurnBeginOp(
                         frame.Op.Encounter,
                         entry.Creature,
-                        StandardTurnActions,
-                        StandardReactionAvailable
+                        turnResources.CreatePlan(context.Snapshot, entry.Creature)
                     )
                 ),
                 "turn begin"
@@ -985,25 +1003,6 @@ namespace Game.Rules.Runtime
             OpFrame<TurnEndingOp> frame,
             OpHandlerContext context
         ) => new ValueTask<TurnEndContribution>(TurnEndContribution.Complete);
-    }
-
-    internal sealed class SpendEncounterActionsHandler
-        : IOpHandler<SpendEncounterActionsOp, EncounterActionSpendOutcome>
-    {
-        public async ValueTask<EncounterActionSpendOutcome> Handle(
-            OpFrame<SpendEncounterActionsOp> frame,
-            OpHandlerContext context
-        ) =>
-            EncounterHandlerResults.Require(
-                await context.Dispatch(
-                    new CommitEncounterActionsOp(
-                        frame.Op.Actor,
-                        frame.Op.Amount,
-                        frame.Op.RequiredLivingTargets
-                    )
-                ),
-                "encounter action spend"
-            );
     }
 
     internal sealed class EncounterOutcomeListener

--- a/Assets/Scripts/Rules/Runtime/EncounterValues.cs
+++ b/Assets/Scripts/Rules/Runtime/EncounterValues.cs
@@ -650,11 +650,11 @@ namespace Game.Rules.Runtime
     }
 
     /// <summary>
-    /// Identifies the next ordered adapter and its current contribution at one published turn start.
+    /// Identifies the next ordered adapter at one published turn start.
     /// </summary>
     /// <remarks>
     /// The enclosing <see cref="EncounterState"/> supplies the exact encounter, round, roster slot,
-    /// and actor. This value carries only the portion that changes after each successfully returned
+    /// and actor. This value carries only the index that changes after each successfully completed
     /// adapter.
     /// </remarks>
     public sealed class TurnStartAdapterProgress : IEquatable<TurnStartAdapterProgress>
@@ -662,42 +662,28 @@ namespace Game.Rules.Runtime
         /// <summary>Gets the first adapter index with work that has not committed.</summary>
         public int NextAdapterIndex { get; }
 
-        /// <summary>Gets the contribution returned by the immediately preceding adapter.</summary>
-        public TurnStartContribution Contribution { get; }
-
-        /// <summary>Gets the initial standard contribution before any adapter runs.</summary>
-        public static TurnStartAdapterProgress Initial =>
-            new TurnStartAdapterProgress(0, TurnStartContribution.Standard);
+        /// <summary>Gets progress before any adapter runs.</summary>
+        public static TurnStartAdapterProgress Initial => new TurnStartAdapterProgress(0);
 
         /// <summary>Creates immutable validated turn-start adapter progress.</summary>
         /// <param name="nextAdapterIndex">The non-negative next adapter index.</param>
-        /// <param name="contribution">The current action contribution.</param>
-        public TurnStartAdapterProgress(int nextAdapterIndex, TurnStartContribution contribution)
+        public TurnStartAdapterProgress(int nextAdapterIndex)
         {
             if (nextAdapterIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(nextAdapterIndex));
             NextAdapterIndex = nextAdapterIndex;
-            Contribution = contribution;
         }
 
         /// <inheritdoc/>
         public bool Equals(TurnStartAdapterProgress other) =>
-            other != null
-            && NextAdapterIndex == other.NextAdapterIndex
-            && Contribution.Actions == other.Contribution.Actions
-            && Contribution.ReactionAvailable == other.Contribution.ReactionAvailable;
+            other != null && NextAdapterIndex == other.NextAdapterIndex;
 
         /// <inheritdoc/>
         public override bool Equals(object obj) =>
             obj is TurnStartAdapterProgress other && Equals(other);
 
         /// <inheritdoc/>
-        public override int GetHashCode() =>
-            HashCode.Combine(
-                NextAdapterIndex,
-                Contribution.Actions,
-                Contribution.ReactionAvailable
-            );
+        public override int GetHashCode() => NextAdapterIndex;
     }
 
     /// <summary>

--- a/Assets/Scripts/Rules/Runtime/InteractRules.cs
+++ b/Assets/Scripts/Rules/Runtime/InteractRules.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Game.Rules.Runtime
+{
+    /// <summary>Defines the rules-native one-action Interact used by combat doors.</summary>
+    public static class InteractActionDefinition
+    {
+        /// <summary>Gets Interact's stable top-level action definition.</summary>
+        public static ActionDefinitionId DefinitionId { get; } = new("interact");
+
+        /// <summary>Gets Interact's immutable one-action manipulate profile.</summary>
+        public static ActionProfile Profile { get; } =
+            ActionProfile.OneAction(new[] { Trait.FromSlug("manipulate") });
+    }
+
+    /// <summary>Requests one rules-native Interact with no caller-supplied privilege.</summary>
+    public sealed class InteractActionOp : ActionOp<InteractOutcome>
+    {
+        /// <summary>Creates an Interact for the exact acting creature.</summary>
+        public InteractActionOp(CreatureId actor)
+            : base(actor, InteractActionDefinition.DefinitionId) { }
+    }
+
+    /// <summary>Reports that Interact completed its authoritative action lifecycle.</summary>
+    public readonly struct InteractOutcome
+    {
+        internal InteractOutcome(CreatureId actor) => Actor = actor;
+
+        /// <summary>Gets the creature that paid for Interact.</summary>
+        public CreatureId Actor { get; }
+    }
+
+    internal sealed class InteractActionHandler : IOpHandler<InteractActionOp, InteractOutcome>
+    {
+        public ValueTask<InteractOutcome> Handle(
+            OpFrame<InteractActionOp> frame,
+            OpHandlerContext context
+        ) => new(new InteractOutcome(frame.Op.Actor));
+    }
+
+    internal sealed class InteractActionValidator : IActionValidator<InteractActionOp>
+    {
+        public ActionValidationResult Validate(
+            OpFrame<InteractActionOp> frame,
+            RulesSnapshot snapshot
+        )
+        {
+            CreatureId actor = frame.Op.Actor;
+            if (!snapshot.Creatures.Contains(actor))
+                return ActionValidationResult.Invalid("The actor is not registered.");
+            if (!snapshot.Health.IsAlive(actor))
+                return ActionValidationResult.Invalid("The actor cannot act.");
+            bool ownsTurn = snapshot.Encounters.Any(pair =>
+                pair.Value.Phase == EncounterPhase.Active
+                && pair.Value.CurrentTurn.HasValue
+                && pair.Value.CurrentTurn.Value.Actor == actor
+            );
+            return ownsTurn
+                ? ActionValidationResult.Valid
+                : ActionValidationResult.Invalid("The actor does not own the active turn.");
+        }
+    }
+
+    /// <summary>Composes the typed Interact action into a dispatcher.</summary>
+    public static class InteractRuleDispatcherExtensions
+    {
+        /// <summary>Adds Interact's handler and pure validator.</summary>
+        public static RuleDispatcherBuilder UseInteractRules(this RuleDispatcherBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+            return builder
+                .RegisterHandler<InteractActionOp, InteractOutcome>(new InteractActionHandler())
+                .RegisterActionValidator(new InteractActionValidator());
+        }
+    }
+}

--- a/Assets/Scripts/Rules/Runtime/InteractRules.cs.meta
+++ b/Assets/Scripts/Rules/Runtime/InteractRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a40db06dd884dd4a7973d8e7335beb8

--- a/Assets/Scripts/Rules/Runtime/RageRules.cs
+++ b/Assets/Scripts/Rules/Runtime/RageRules.cs
@@ -813,7 +813,7 @@ namespace Game.Rules.Runtime
             builder.Define(RageActionDefinition.EffectDefinitionId);
             builder
                 .Define(LifecycleRuleDefinitionId)
-                .Middleware<TurnStartingOp, TurnStartContribution>(
+                .Middleware<TurnStartingOp, TurnStartCompletion>(
                     RuleLifecyclePhase.Prevention,
                     new RetryExpiredRageCleanupMiddleware()
                 )
@@ -1048,12 +1048,12 @@ namespace Game.Rules.Runtime
     /// runtime to recognize Rage-specific tombstones.
     /// </remarks>
     internal sealed class RetryExpiredRageCleanupMiddleware
-        : IOpMiddleware<TurnStartingOp, TurnStartContribution>
+        : IOpMiddleware<TurnStartingOp, TurnStartCompletion>
     {
-        public async ValueTask<OpResult<TurnStartContribution>> Invoke(
+        public async ValueTask<OpResult<TurnStartCompletion>> Invoke(
             OpFrame<TurnStartingOp> frame,
             OpMiddlewareContext context,
-            OpNext<TurnStartContribution> next
+            OpNext<TurnStartCompletion> next
         )
         {
             if (

--- a/Assets/Scripts/Rules/Runtime/RageRules.cs
+++ b/Assets/Scripts/Rules/Runtime/RageRules.cs
@@ -368,6 +368,8 @@ namespace Game.Rules.Runtime
             QuickTemperedTraits
         );
 
+        internal static ActionProfile StandardProfile => RageProfile;
+
         /// <summary>Gets Rage's stable action-definition identity.</summary>
         public static ActionDefinitionId DefinitionId { get; } = new ActionDefinitionId("rage");
 
@@ -716,7 +718,11 @@ namespace Game.Rules.Runtime
                 return ActionAvailability.Unavailable(invalid.Reason);
             if (
                 !snapshot.ActionEconomy.TryGet(actor, out ActionEconomyState economy)
-                || economy.ActionsRemaining < ActionCost.One.Amount
+                || !ActionResourcePayment.CanPay(
+                    economy,
+                    RageActionDefinition.DefinitionId,
+                    RageActionDefinition.StandardProfile
+                )
             )
             {
                 return ActionAvailability.Unavailable("The actor does not have an action.");

--- a/Assets/Scripts/Rules/Runtime/RuleDispatcherBuilder.cs
+++ b/Assets/Scripts/Rules/Runtime/RuleDispatcherBuilder.cs
@@ -17,6 +17,7 @@ namespace Game.Rules.Runtime
             new Dictionary<Type, IRegistration>();
         private readonly Dictionary<Type, List<IActionValidatorRegistration>> actionValidators =
             new Dictionary<Type, List<IActionValidatorRegistration>>();
+        private readonly List<IActionPermission> actionPermissions = new List<IActionPermission>();
         private readonly HashSet<string> engineCompositions = new HashSet<string>(
             StringComparer.Ordinal
         );
@@ -304,6 +305,15 @@ namespace Game.Rules.Runtime
             return this;
         }
 
+        /// <summary>Registers one pure permission rule applied to every action lifecycle.</summary>
+        public RuleDispatcherBuilder RegisterActionPermission(IActionPermission permission)
+        {
+            actionPermissions.Add(
+                permission ?? throw new ArgumentNullException(nameof(permission))
+            );
+            return this;
+        }
+
         /// <summary>
         /// Registers the engine-owned attack, check, save, and modifier-collection handlers with
         /// the standard pure snapshot selectors.
@@ -463,7 +473,7 @@ namespace Game.Rules.Runtime
                 typeof(IActionOpMetadata).IsAssignableFrom(registration.OpType)
             );
             if (
-                (hasActionHandler || actionValidators.Count > 0)
+                (hasActionHandler || actionValidators.Count > 0 || actionPermissions.Count > 0)
                 && !actionRuntimeConfiguration.IsConfigured
             )
             {
@@ -538,7 +548,8 @@ namespace Game.Rules.Runtime
             }
 
             ActionRuntime actionRuntime = actionRuntimeConfiguration.CreateRuntime(
-                actionValidators
+                actionValidators,
+                actionPermissions
             );
             ruleRegistry.ValidateResolvers(completedRegistrations);
             return new RuleDispatcher(

--- a/Assets/Scripts/Rules/Runtime/RuleDispatcherLifecycle.cs
+++ b/Assets/Scripts/Rules/Runtime/RuleDispatcherLifecycle.cs
@@ -48,8 +48,19 @@ namespace Game.Rules.Runtime
 
                 CommitActionCostsOp commitCosts =
                     receiptedAction != null
-                        ? new CommitActionCostsOp(action.Id, action.Actor, profile, receiptedAction)
-                        : new CommitActionCostsOp(action.Id, action.Actor, profile);
+                        ? new CommitActionCostsOp(
+                            action.Id,
+                            action.Actor,
+                            action.DefinitionId,
+                            profile,
+                            receiptedAction
+                        )
+                        : new CommitActionCostsOp(
+                            action.Id,
+                            action.Actor,
+                            action.DefinitionId,
+                            profile
+                        );
                 OpResult<ActionCostsOutcome> costs = await DispatchNested(commitCosts, action.Id);
                 if (costs is InvalidOpResult<ActionCostsOutcome> invalidCosts)
                     return registration.CreateInvalidResult(invalidCosts.Reason);

--- a/Assets/Scripts/Rules/Runtime/SpellcastingRules.cs
+++ b/Assets/Scripts/Rules/Runtime/SpellcastingRules.cs
@@ -190,7 +190,16 @@ namespace Game.Rules.Runtime
                 return ActionAvailability.Unavailable("The spell reference is unknown.");
             if (!definition.Variants.Contains(variant))
                 return ActionAvailability.Unavailable("The spell action variant is unavailable.");
-            if (!snapshot.ActionEconomy.CanSpendActions(actor, variant.Actions))
+            if (
+                !snapshot.ActionEconomy.CanPayAction(
+                    actor,
+                    DefinitionId,
+                    ActionProfile.Create(
+                        ActionCost.FromActions(variant.Actions),
+                        Array.Empty<Trait>()
+                    )
+                )
+            )
                 return ActionAvailability.Unavailable("The caster does not have enough actions.");
             ISpellBook book = catalog.GetSpellBook(actor);
             SpellCastAuthorization binding = book.BindResource(actor, spell);

--- a/Assets/Scripts/Rules/Runtime/StateSlices.cs
+++ b/Assets/Scripts/Rules/Runtime/StateSlices.cs
@@ -25,24 +25,25 @@ namespace Game.Rules.Runtime
         ) => health != null && health.TryGet(creature, out HealthState state) && state.Current > 0;
 
         /// <summary>
-        /// Determines whether a creature can pay a requested number of actions from current state.
+        /// Determines whether a creature can pay one exact action profile from current state.
         /// </summary>
         /// <param name="actionEconomy">The action-economy slice from an authoritative snapshot.</param>
         /// <param name="creature">The creature that would spend the actions.</param>
-        /// <param name="actions">The non-negative number of actions required.</param>
+        /// <param name="definitionId">The trusted top-level action definition.</param>
+        /// <param name="profile">The complete action profile being previewed.</param>
         /// <returns>
-        /// <see langword="true"/> when the request is non-negative, the creature has action-economy
-        /// state, and enough actions remain; otherwise, <see langword="false"/>.
+        /// <see langword="true"/> when the creature has action-economy state and the exact profile
+        /// can pay its standard, optional, reaction, or free-action cost.
         /// </returns>
-        public static bool CanSpendActions(
+        public static bool CanPayAction(
             this StateSliceSnapshot<CreatureId, ActionEconomyState> actionEconomy,
             CreatureId creature,
-            int actions
+            ActionDefinitionId definitionId,
+            ActionProfile profile
         ) =>
-            actions >= 0
-            && actionEconomy != null
+            actionEconomy != null
             && actionEconomy.TryGet(creature, out ActionEconomyState state)
-            && state.ActionsRemaining >= actions;
+            && ActionResourcePayment.CanPay(state, definitionId, profile);
     }
 
     public sealed class StateSliceSnapshot<TKey, TValue>

--- a/Assets/Scripts/Rules/Runtime/StateValues.cs
+++ b/Assets/Scripts/Rules/Runtime/StateValues.cs
@@ -325,24 +325,49 @@ namespace Game.Rules.Runtime
 
     public readonly struct ActionEconomyState : IEquatable<ActionEconomyState>
     {
-        public int ActionsRemaining { get; }
+        private readonly ActionAllowance optionalAction;
+
+        /// <summary>Gets the ordinary actions remaining in the current turn.</summary>
+        public int StandardActionsRemaining { get; }
+
+        /// <summary>
+        /// Gets the optional one-action allowance, or <see cref="ActionAllowance.None"/> when it
+        /// is absent or has already been spent or lost.
+        /// </summary>
+        public ActionAllowance OptionalAction => optionalAction ?? ActionAllowance.None;
+
+        /// <summary>Gets whether the creature's reaction resource is currently available.</summary>
         public bool ReactionAvailable { get; }
 
-        public ActionEconomyState(int actionsRemaining, bool reactionAvailable)
+        /// <summary>Creates one authoritative action-economy value.</summary>
+        /// <param name="standardActionsRemaining">The ordinary actions currently available.</param>
+        /// <param name="optionalAction">
+        /// The optional one-action allowance, or <see cref="ActionAllowance.None"/>.
+        /// </param>
+        /// <param name="reactionAvailable">Whether the reaction resource is available.</param>
+        public ActionEconomyState(
+            int standardActionsRemaining,
+            ActionAllowance optionalAction,
+            bool reactionAvailable
+        )
         {
-            if (actionsRemaining < 0)
-                throw new ArgumentOutOfRangeException(nameof(actionsRemaining));
-            ActionsRemaining = actionsRemaining;
+            if (standardActionsRemaining < 0)
+                throw new ArgumentOutOfRangeException(nameof(standardActionsRemaining));
+            StandardActionsRemaining = standardActionsRemaining;
+            this.optionalAction =
+                optionalAction ?? throw new ArgumentNullException(nameof(optionalAction));
             ReactionAvailable = reactionAvailable;
         }
 
         public bool Equals(ActionEconomyState other) =>
-            ActionsRemaining == other.ActionsRemaining
+            StandardActionsRemaining == other.StandardActionsRemaining
+            && OptionalAction.Equals(other.OptionalAction)
             && ReactionAvailable == other.ReactionAvailable;
 
         public override bool Equals(object obj) => obj is ActionEconomyState other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(ActionsRemaining, ReactionAvailable);
+        public override int GetHashCode() =>
+            HashCode.Combine(StandardActionsRemaining, OptionalAction, ReactionAvailable);
 
         public static bool operator ==(ActionEconomyState left, ActionEconomyState right) =>
             left.Equals(right);

--- a/Assets/Scripts/Rules/Runtime/StrideRules.cs
+++ b/Assets/Scripts/Rules/Runtime/StrideRules.cs
@@ -89,7 +89,7 @@ namespace Game.Rules.Runtime
             }
             if (
                 !snapshot.ActionEconomy.TryGet(actor, out ActionEconomyState economy)
-                || economy.ActionsRemaining < ActionCost.One.Amount
+                || !ActionResourcePayment.CanPay(economy, DefinitionId, Profile)
             )
             {
                 return ActionAvailability.Unavailable("The actor does not have an action.");

--- a/Assets/Scripts/Rules/Runtime/StrikeRules.cs
+++ b/Assets/Scripts/Rules/Runtime/StrikeRules.cs
@@ -538,6 +538,10 @@ namespace Game.Rules.Runtime
     /// <summary>Owns normal Strike availability and stable action identity.</summary>
     public sealed class StrikeActionDefinition
     {
+        private static readonly ActionProfile AvailabilityProfile = ActionProfile.OneAction(
+            Array.Empty<Trait>()
+        );
+
         /// <summary>Gets Strike's stable action definition ID.</summary>
         public static ActionDefinitionId DefinitionId { get; } = new ActionDefinitionId("strike");
 
@@ -558,7 +562,7 @@ namespace Game.Rules.Runtime
                 return ActionAvailability.Unavailable("The actor cannot act.");
             if (
                 !snapshot.ActionEconomy.TryGet(actor, out ActionEconomyState economy)
-                || economy.ActionsRemaining < 1
+                || !ActionResourcePayment.CanPay(economy, DefinitionId, AvailabilityProfile)
             )
                 return ActionAvailability.Unavailable("The actor does not have an action.");
             if (!snapshot.MultipleAttackPenalty.Contains(actor))
@@ -840,7 +844,14 @@ namespace Game.Rules.Runtime
                 return ActionAvailability.Unavailable("The weapon is already loaded.");
             if (
                 !snapshot.ActionEconomy.TryGet(actor, out ActionEconomyState economy)
-                || economy.ActionsRemaining < item.ReloadActions
+                || !ActionResourcePayment.CanPay(
+                    economy,
+                    DefinitionId,
+                    ActionProfile.Create(
+                        ActionCost.FromActions(item.ReloadActions),
+                        Array.Empty<Trait>()
+                    )
+                )
             )
                 return ActionAvailability.Unavailable("The actor cannot afford Reload.");
             if (

--- a/Assets/Scripts/Rules/Runtime/TurnResourcePolicy.cs
+++ b/Assets/Scripts/Rules/Runtime/TurnResourcePolicy.cs
@@ -1,0 +1,588 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Rules.Runtime
+{
+    /// <summary>Distinguishes the ordinary and optional action resources in a turn.</summary>
+    public enum ActionResourceKind
+    {
+        /// <summary>An ordinary action from the creature's standard three-action pool.</summary>
+        Standard,
+
+        /// <summary>The single optional action allowance contributed by Quickened-like rules.</summary>
+        Optional,
+    }
+
+    internal enum StunnedResourcePolicyKind
+    {
+        None,
+        Valued,
+        DurationOnly,
+    }
+
+    /// <summary>Keeps valued and duration-only Stunned planning inputs structurally distinct.</summary>
+    internal readonly struct StunnedResourcePolicy : IEquatable<StunnedResourcePolicy>
+    {
+        private readonly int value;
+
+        private StunnedResourcePolicy(StunnedResourcePolicyKind kind, int value)
+        {
+            Kind = kind;
+            this.value = value;
+        }
+
+        internal static StunnedResourcePolicy None => default;
+        internal static StunnedResourcePolicy DurationOnly =>
+            new StunnedResourcePolicy(StunnedResourcePolicyKind.DurationOnly, 0);
+        internal StunnedResourcePolicyKind Kind { get; }
+        internal int Value =>
+            Kind == StunnedResourcePolicyKind.Valued
+                ? value
+                : throw new InvalidOperationException("Only valued Stunned has a value.");
+
+        internal static StunnedResourcePolicy Valued(int value)
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(value));
+            return new StunnedResourcePolicy(StunnedResourcePolicyKind.Valued, value);
+        }
+
+        public bool Equals(StunnedResourcePolicy other) =>
+            Kind == other.Kind && value == other.value;
+
+        public override bool Equals(object obj) =>
+            obj is StunnedResourcePolicy other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Kind, value);
+    }
+
+    internal enum TurnResourceContributionKind
+    {
+        OptionalAction,
+        StartTurnLoss,
+        Stunned,
+        SuppressReaction,
+    }
+
+    /// <summary>Carries one feature-owned input into generic deterministic turn planning.</summary>
+    public sealed class TurnResourceContribution
+    {
+        private TurnResourceContribution(
+            TurnResourceContributionKind kind,
+            ActionAllowance allowance,
+            int loss,
+            StunnedResourcePolicy stunned
+        )
+        {
+            Kind = kind;
+            Allowance = allowance;
+            Loss = loss;
+            Stunned = stunned;
+        }
+
+        internal TurnResourceContributionKind Kind { get; }
+        internal ActionAllowance Allowance { get; }
+        internal int Loss { get; }
+        internal StunnedResourcePolicy Stunned { get; }
+
+        internal static TurnResourceContribution OptionalAction(ActionAllowance allowance)
+        {
+            if (allowance == null)
+                throw new ArgumentNullException(nameof(allowance));
+            if (allowance.IsNone)
+                throw new ArgumentException(
+                    "An optional action requires an allowance.",
+                    nameof(allowance)
+                );
+            return new TurnResourceContribution(
+                TurnResourceContributionKind.OptionalAction,
+                allowance,
+                0,
+                StunnedResourcePolicy.None
+            );
+        }
+
+        internal static TurnResourceContribution StartTurnLoss(int amount)
+        {
+            if (amount < 0)
+                throw new ArgumentOutOfRangeException(nameof(amount));
+            return new TurnResourceContribution(
+                TurnResourceContributionKind.StartTurnLoss,
+                ActionAllowance.None,
+                amount,
+                StunnedResourcePolicy.None
+            );
+        }
+
+        internal static TurnResourceContribution StunnedBy(StunnedResourcePolicy stunned)
+        {
+            if (stunned.Kind == StunnedResourcePolicyKind.None)
+                throw new ArgumentException("A Stunned policy is required.", nameof(stunned));
+            return new TurnResourceContribution(
+                TurnResourceContributionKind.Stunned,
+                ActionAllowance.None,
+                0,
+                stunned
+            );
+        }
+
+        /// <summary>Suppresses the reaction resource without changing action resources.</summary>
+        public static TurnResourceContribution SuppressReaction() =>
+            new TurnResourceContribution(
+                TurnResourceContributionKind.SuppressReaction,
+                ActionAllowance.None,
+                0,
+                StunnedResourcePolicy.None
+            );
+    }
+
+    /// <summary>Records exactly which granted action resources are removed at turn start.</summary>
+    internal readonly struct TurnResourceLoss : IEquatable<TurnResourceLoss>
+    {
+        internal TurnResourceLoss(int standardActions, bool optionalAction)
+        {
+            if (standardActions < 0 || standardActions > TurnResourcePlanner.StandardActionCount)
+                throw new ArgumentOutOfRangeException(nameof(standardActions));
+            StandardActions = standardActions;
+            OptionalAction = optionalAction;
+        }
+
+        internal int StandardActions { get; }
+        internal bool OptionalAction { get; }
+        internal int Total => StandardActions + (OptionalAction ? 1 : 0);
+
+        public bool Equals(TurnResourceLoss other) =>
+            StandardActions == other.StandardActions && OptionalAction == other.OptionalAction;
+
+        public override bool Equals(object obj) => obj is TurnResourceLoss other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(StandardActions, OptionalAction);
+    }
+
+    /// <summary>Contains the pure result of one turn-resource refresh.</summary>
+    internal sealed class TurnResourcePlan
+    {
+        internal TurnResourcePlan(
+            ActionEconomyState economy,
+            ActionAllowance grantedOptionalAction,
+            TurnResourceLoss loss,
+            int stunnedConsumed,
+            int stunnedRemaining
+        )
+        {
+            Economy = economy;
+            GrantedOptionalAction =
+                grantedOptionalAction
+                ?? throw new ArgumentNullException(nameof(grantedOptionalAction));
+            Loss = loss;
+            StunnedConsumed = stunnedConsumed;
+            StunnedRemaining = stunnedRemaining;
+        }
+
+        internal ActionEconomyState Economy { get; }
+        internal ActionAllowance GrantedOptionalAction { get; }
+        internal TurnResourceLoss Loss { get; }
+        internal int StunnedConsumed { get; }
+        internal int StunnedRemaining { get; }
+    }
+
+    /// <summary>Applies all start-turn grants and losses without reading or mutating rules state.</summary>
+    internal static class TurnResourcePlanner
+    {
+        internal const int StandardActionCount = 3;
+
+        internal static TurnResourcePlan Resolve(
+            IEnumerable<TurnResourceContribution> contributions
+        )
+        {
+            if (contributions == null)
+                throw new ArgumentNullException(nameof(contributions));
+            TurnResourceContribution[] copied = contributions.ToArray();
+            if (copied.Any(contribution => contribution == null))
+                throw new ArgumentException(
+                    "Turn-resource contributions cannot contain null.",
+                    nameof(contributions)
+                );
+
+            ActionAllowance optional = copied
+                .Where(contribution =>
+                    contribution.Kind == TurnResourceContributionKind.OptionalAction
+                )
+                .Select(contribution => contribution.Allowance)
+                .Aggregate(ActionAllowance.None, (current, allowance) => current.Union(allowance));
+            int slowedLoss = copied
+                .Where(contribution =>
+                    contribution.Kind == TurnResourceContributionKind.StartTurnLoss
+                )
+                .Select(contribution => contribution.Loss)
+                .DefaultIfEmpty(0)
+                .Max();
+            StunnedResourcePolicy[] stunned = copied
+                .Where(contribution => contribution.Kind == TurnResourceContributionKind.Stunned)
+                .Select(contribution => contribution.Stunned)
+                .ToArray();
+            if (stunned.Length > 1)
+                throw new ArgumentException(
+                    "Turn planning requires one already-elected Stunned source.",
+                    nameof(contributions)
+                );
+
+            StunnedResourcePolicy elected = stunned.SingleOrDefault();
+            int totalResources = StandardActionCount + (optional.IsNone ? 0 : 1);
+            int requestedLoss = elected.Kind switch
+            {
+                StunnedResourcePolicyKind.DurationOnly => totalResources,
+                StunnedResourcePolicyKind.Valued => Math.Max(slowedLoss, elected.Value),
+                _ => slowedLoss,
+            };
+            int actualLoss = Math.Min(totalResources, requestedLoss);
+            bool optionalLost = !optional.IsNone && actualLoss > 0;
+            int standardLost = actualLoss - (optionalLost ? 1 : 0);
+            int stunnedConsumed =
+                elected.Kind == StunnedResourcePolicyKind.Valued
+                    ? Math.Min(elected.Value, actualLoss)
+                    : 0;
+            int stunnedRemaining =
+                elected.Kind == StunnedResourcePolicyKind.Valued
+                    ? elected.Value - stunnedConsumed
+                    : 0;
+            bool reactionAvailable =
+                elected.Kind != StunnedResourcePolicyKind.DurationOnly
+                && stunnedRemaining == 0
+                && !copied.Any(contribution =>
+                    contribution.Kind == TurnResourceContributionKind.SuppressReaction
+                );
+            ActionEconomyState economy = new(
+                StandardActionCount - standardLost,
+                optionalLost ? ActionAllowance.None : optional,
+                reactionAvailable
+            );
+            return new TurnResourcePlan(
+                economy,
+                optional,
+                new TurnResourceLoss(standardLost, optionalLost),
+                stunnedConsumed,
+                stunnedRemaining
+            );
+        }
+    }
+
+    /// <summary>Creates feature-owned turn-resource contributions from one authoritative snapshot.</summary>
+    public interface ITurnResourceContributionProvider
+    {
+        /// <summary>Reads one actor's immutable turn-resource inputs.</summary>
+        TurnResourceContributionBatch GetContributions(RulesSnapshot snapshot, CreatureId actor);
+    }
+
+    /// <summary>Describes one exact active-effect update or expiration.</summary>
+    internal sealed class TurnResourceEffectChange
+    {
+        internal TurnResourceEffectChange(
+            CreatureId owner,
+            ActiveEffectId effectId,
+            BindingId bindingId,
+            EffectStateVersion expectedVersion,
+            RuleSource source,
+            IEffectState remainingState
+        )
+        {
+            Owner = owner;
+            EffectId = effectId;
+            BindingId = bindingId;
+            ExpectedVersion = expectedVersion;
+            Source = source;
+            RemainingState = remainingState;
+        }
+
+        internal CreatureId Owner { get; }
+        internal ActiveEffectId EffectId { get; }
+        internal BindingId BindingId { get; }
+        internal EffectStateVersion ExpectedVersion { get; }
+        internal RuleSource Source { get; }
+        internal IEffectState RemainingState { get; }
+    }
+
+    /// <summary>Creates exact changes for resource-consuming active effects.</summary>
+    internal interface ITurnResourceEffectAdjustment
+    {
+        bool IsPresent { get; }
+        IReadOnlyList<TurnResourceEffectChange> CreateChanges(int resourcesConsumed);
+    }
+
+    internal sealed class NoTurnResourceEffectAdjustment : ITurnResourceEffectAdjustment
+    {
+        internal static NoTurnResourceEffectAdjustment Instance { get; } = new();
+
+        private NoTurnResourceEffectAdjustment() { }
+
+        public bool IsPresent => false;
+
+        public IReadOnlyList<TurnResourceEffectChange> CreateChanges(int resourcesConsumed) =>
+            throw new InvalidOperationException("No turn-resource effect is selected.");
+    }
+
+    /// <summary>Commits a feature-prepared set of exact active-effect changes atomically.</summary>
+    internal static class TurnResourceEffectReduction
+    {
+        internal static bool TryCommit(
+            RulesStateDraft state,
+            FactSink facts,
+            CreatureId actor,
+            ITurnResourceEffectAdjustment adjustment,
+            int resourcesConsumed,
+            out string rejection
+        )
+        {
+            rejection = string.Empty;
+            if (resourcesConsumed <= 0)
+            {
+                rejection = "A selected turn-resource effect must consume at least one resource.";
+                return false;
+            }
+            IReadOnlyList<TurnResourceEffectChange> changes = adjustment.CreateChanges(
+                resourcesConsumed
+            );
+            if (
+                changes == null
+                || changes.Count == 0
+                || changes.Any(change => change == null)
+                || changes.Select(change => change.EffectId).Distinct().Count() != changes.Count
+                || changes.Select(change => change.BindingId).Distinct().Count() != changes.Count
+            )
+            {
+                rejection = "Turn-resource effect changes must be nonempty and exact.";
+                return false;
+            }
+
+            foreach (TurnResourceEffectChange change in changes)
+            {
+                if (change.Owner != actor)
+                {
+                    rejection = "A turn-resource effect does not belong to the turn actor.";
+                    return false;
+                }
+                if (
+                    !ActiveEffectReduction.TryGetCurrent(
+                        state,
+                        change.EffectId,
+                        change.ExpectedVersion,
+                        true,
+                        out ActiveEffectInstance effect,
+                        out rejection
+                    )
+                    || !ActiveEffectReduction.TryGetAssociatedBinding(
+                        state,
+                        effect,
+                        change.BindingId,
+                        true,
+                        out ActiveRuleBinding binding,
+                        out rejection
+                    )
+                    || !ActiveEffectReduction.TryValidateSourceOwner(
+                        effect,
+                        change.Source,
+                        out rejection
+                    )
+                )
+                    return false;
+                if (binding.Owner != actor)
+                {
+                    rejection = "A turn-resource effect does not belong to the turn actor.";
+                    return false;
+                }
+
+                if (change.RemainingState != null)
+                {
+                    if (change.RemainingState.GetType() != effect.State.GetType())
+                    {
+                        rejection =
+                            "The turn-resource effect replacement has the wrong state type.";
+                        return false;
+                    }
+                    ActiveEffectReduction.CommitStateUpdate(
+                        state,
+                        effect,
+                        change.RemainingState,
+                        facts
+                    );
+                    continue;
+                }
+
+                EffectStateVersion nextVersion = effect.EffectStateVersion.Next();
+                state.ActiveEffects.Set(
+                    effect.Id,
+                    effect.WithStatus(ActiveEffectStatus.Expired, nextVersion)
+                );
+                state.RuleBindings.Set(binding.Id, binding.WithEnabled(false));
+                state.ActiveEffectTimings.Remove(effect.Id);
+                facts.Stage(
+                    new ActiveEffectExpiredFact(
+                        effect.Id,
+                        effect.DefinitionId,
+                        binding.Id,
+                        effect.EffectStateVersion,
+                        nextVersion
+                    )
+                );
+            }
+            return true;
+        }
+    }
+
+    /// <summary>Groups one module's immutable contributions and optional exact effect adjustment.</summary>
+    public sealed class TurnResourceContributionBatch
+    {
+        /// <summary>Creates contributions that do not adjust an active effect.</summary>
+        public TurnResourceContributionBatch(IEnumerable<TurnResourceContribution> contributions)
+            : this(contributions, NoTurnResourceEffectAdjustment.Instance) { }
+
+        internal TurnResourceContributionBatch(
+            IEnumerable<TurnResourceContribution> contributions,
+            ITurnResourceEffectAdjustment effectAdjustment
+        )
+        {
+            Contributions = Array.AsReadOnly(
+                contributions?.ToArray() ?? throw new ArgumentNullException(nameof(contributions))
+            );
+            if (Contributions.Any(contribution => contribution == null))
+                throw new ArgumentException(
+                    "Turn-resource contributions cannot contain null.",
+                    nameof(contributions)
+                );
+            EffectAdjustment =
+                effectAdjustment ?? throw new ArgumentNullException(nameof(effectAdjustment));
+        }
+
+        internal IReadOnlyList<TurnResourceContribution> Contributions { get; }
+        internal ITurnResourceEffectAdjustment EffectAdjustment { get; }
+    }
+
+    /// <summary>Freezes a complete plan plus the exact feature effect adjusted by its loss.</summary>
+    internal sealed class TurnResourceCommitPlan
+    {
+        internal TurnResourceCommitPlan(
+            TurnResourcePlan resources,
+            ITurnResourceEffectAdjustment effectAdjustment
+        )
+        {
+            Resources = resources ?? throw new ArgumentNullException(nameof(resources));
+            EffectAdjustment =
+                effectAdjustment ?? throw new ArgumentNullException(nameof(effectAdjustment));
+        }
+
+        internal TurnResourcePlan Resources { get; }
+        internal ITurnResourceEffectAdjustment EffectAdjustment { get; }
+    }
+
+    /// <summary>Builds one deterministic turn plan from explicitly composed feature providers.</summary>
+    public sealed class TurnResourceStrategy
+    {
+        private readonly IReadOnlyList<ITurnResourceContributionProvider> providers;
+
+        /// <summary>Creates a strategy from providers in deterministic composition order.</summary>
+        public TurnResourceStrategy(IEnumerable<ITurnResourceContributionProvider> providers)
+        {
+            ITurnResourceContributionProvider[] copied =
+                providers?.ToArray() ?? throw new ArgumentNullException(nameof(providers));
+            if (copied.Any(provider => provider == null))
+                throw new ArgumentException(
+                    "Turn-resource providers cannot contain null.",
+                    nameof(providers)
+                );
+            this.providers = Array.AsReadOnly(copied);
+        }
+
+        internal TurnResourceCommitPlan CreatePlan(RulesSnapshot snapshot, CreatureId actor)
+        {
+            if (snapshot == null)
+                throw new ArgumentNullException(nameof(snapshot));
+            if (actor.IsEmpty)
+                throw new ArgumentException("A turn actor is required.", nameof(actor));
+            TurnResourceContributionBatch[] batches = providers
+                .Select(provider => provider.GetContributions(snapshot, actor))
+                .ToArray();
+            if (batches.Any(batch => batch == null))
+                throw new InvalidOperationException("A turn-resource provider returned null.");
+            ITurnResourceEffectAdjustment[] adjustments = batches
+                .Select(batch => batch.EffectAdjustment)
+                .Where(adjustment => adjustment.IsPresent)
+                .ToArray();
+            if (adjustments.Length > 1)
+                throw new InvalidOperationException(
+                    "Only one exact turn-resource effect may be adjusted per turn."
+                );
+            return new TurnResourceCommitPlan(
+                TurnResourcePlanner.Resolve(batches.SelectMany(batch => batch.Contributions)),
+                adjustments.SingleOrDefault() ?? NoTurnResourceEffectAdjustment.Instance
+            );
+        }
+    }
+
+    /// <summary>Plans one trusted action-economy cost for both preview and commit.</summary>
+    public static class ActionResourcePayment
+    {
+        /// <summary>Checks whether the exact top-level action can pay its frozen cost.</summary>
+        public static bool CanPay(
+            ActionEconomyState economy,
+            ActionDefinitionId definitionId,
+            ActionProfile profile
+        ) => TryPay(economy, definitionId, profile, out _, out _);
+
+        internal static bool TryPay(
+            ActionEconomyState economy,
+            ActionDefinitionId definitionId,
+            ActionProfile profile,
+            out ActionEconomyState remaining,
+            out ActionResourceKind? spentResource
+        )
+        {
+            if (definitionId.IsEmpty)
+                throw new ArgumentException(
+                    "An action definition is required.",
+                    nameof(definitionId)
+                );
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+
+            remaining = economy;
+            spentResource = null;
+            ActionCost cost = profile.Cost;
+            if (cost.Kind == ActionCostKind.None || cost.Kind == ActionCostKind.FreeAction)
+                return true;
+            if (cost.Kind == ActionCostKind.Reaction)
+            {
+                if (!economy.ReactionAvailable)
+                    return false;
+                remaining = new ActionEconomyState(
+                    economy.StandardActionsRemaining,
+                    economy.OptionalAction,
+                    false
+                );
+                return true;
+            }
+            if (cost.Kind != ActionCostKind.Actions)
+                throw new InvalidOperationException($"Unsupported action cost kind {cost.Kind}.");
+
+            if (economy.OptionalAction.Allows(definitionId, profile))
+            {
+                remaining = new ActionEconomyState(
+                    economy.StandardActionsRemaining,
+                    ActionAllowance.None,
+                    economy.ReactionAvailable
+                );
+                spentResource = ActionResourceKind.Optional;
+                return true;
+            }
+            if (economy.StandardActionsRemaining < cost.Amount)
+                return false;
+            remaining = new ActionEconomyState(
+                economy.StandardActionsRemaining - cost.Amount,
+                economy.OptionalAction,
+                economy.ReactionAvailable
+            );
+            spentResource = ActionResourceKind.Standard;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Rules/Runtime/TurnResourcePolicy.cs.meta
+++ b/Assets/Scripts/Rules/Runtime/TurnResourcePolicy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bd45f7c677d4d509f98a5e4156a647a

--- a/Assets/Scripts/Rules/Unity/Composition/UnityCombatantEnrollmentPipeline.cs
+++ b/Assets/Scripts/Rules/Unity/Composition/UnityCombatantEnrollmentPipeline.cs
@@ -264,7 +264,7 @@ namespace Game.Rules.Unity.Composition
                 {
                     seed.SeedActionEconomy(
                         combatant.Registration.State.Creature.Id,
-                        new ActionEconomyState(1, false)
+                        new ActionEconomyState(1, ActionAllowance.None, false)
                     );
                 }
                 foreach (IUnityCombatantStateContribution contribution in combatant.State)

--- a/Assets/Scripts/Rules/Unity/Composition/UnityEncounterComposition.cs
+++ b/Assets/Scripts/Rules/Unity/Composition/UnityEncounterComposition.cs
@@ -28,7 +28,7 @@ namespace Game.Rules.Unity.Composition
         void ConfigureDispatcher(RuleDispatcherBuilder builder);
     }
 
-    /// <summary>Contributes one transitional turn-start adapter owned by its feature.</summary>
+    /// <summary>Contributes one completion-only transitional turn-start adapter.</summary>
     internal interface IUnityEncounterTurnStartModule : IUnityEncounterModule
     {
         /// <summary>Creates the adapter installed at this module's deterministic position.</summary>

--- a/Assets/Scripts/Rules/Unity/Composition/UnityEncounterComposition.cs
+++ b/Assets/Scripts/Rules/Unity/Composition/UnityEncounterComposition.cs
@@ -35,6 +35,13 @@ namespace Game.Rules.Unity.Composition
         IEncounterTurnStartAdapter CreateTurnStartAdapter();
     }
 
+    /// <summary>Contributes feature-owned inputs to the generic authoritative turn refresh.</summary>
+    internal interface IUnityEncounterTurnResourceModule : IUnityEncounterModule
+    {
+        /// <summary>Creates this module's stateless snapshot contribution provider.</summary>
+        ITurnResourceContributionProvider CreateTurnResourceProvider();
+    }
+
     /// <summary>Registers encounter-owned observers or disposable runtime adapters.</summary>
     internal interface IUnityEncounterRuntimeModule : IUnityEncounterModule
     {
@@ -349,6 +356,14 @@ namespace Game.Rules.Unity.Composition
                 .OfType<IUnityEncounterTurnStartModule>()
                 .Select(module => module.CreateTurnStartAdapter())
                 .ToArray();
+
+        /// <summary>Builds the generic strategy from providers in exact module order.</summary>
+        internal TurnResourceStrategy CreateTurnResourceStrategy() =>
+            new(
+                modules
+                    .OfType<IUnityEncounterTurnResourceModule>()
+                    .Select(module => module.CreateTurnResourceProvider())
+            );
 
         /// <summary>Configures dispatcher modules in exact module order.</summary>
         internal void ConfigureDispatcher(RuleDispatcherBuilder builder)

--- a/Assets/Scripts/Rules/Unity/Composition/UnityEncounterModuleSet.cs
+++ b/Assets/Scripts/Rules/Unity/Composition/UnityEncounterModuleSet.cs
@@ -81,6 +81,7 @@ namespace Game.Rules.Unity.Composition
             )
                 registryBuilder.Define(definitionId);
             ConditionRuleDefinitions.DefineAll(registryBuilder);
+            SlowedEncounterModule.DefineRules(registryBuilder);
             foreach (
                 IUnityEncounterRegistryModule module in extensions.OfType<IUnityEncounterRegistryModule>()
             )
@@ -93,6 +94,7 @@ namespace Game.Rules.Unity.Composition
                 new RottingAuraEncounterModule(owner),
                 new ConditionEncounterModule(owner, registry, installUnityAuthority),
                 new SlowedEncounterModule(owner),
+                new UnityInteractEncounterModule(),
                 new UnityRageEncounterModule(rageDefinition),
                 new UnityStrikeEncounterModule(
                     strikeContext,
@@ -231,6 +233,8 @@ namespace Game.Rules.Unity.Composition
                 throw new InvalidOperationException(
                     "Reload profiles require the selected item on ReloadActionOp."
                 );
+            if (definitionId == InteractActionDefinition.DefinitionId)
+                return InteractActionDefinition.Profile;
             foreach (IActionCatalog catalog in featureCatalogs)
             {
                 try
@@ -256,5 +260,13 @@ namespace Game.Rules.Unity.Composition
 
         /// <inheritdoc/>
         public ISpellBook GetSpellBook(CreatureId creature) => spellBooks.GetSpellBook(creature);
+    }
+
+    /// <summary>Composes the rules-native Interact action used by combat-world adapters.</summary>
+    internal sealed class UnityInteractEncounterModule : IUnityEncounterDispatcherModule
+    {
+        /// <inheritdoc/>
+        public void ConfigureDispatcher(RuleDispatcherBuilder builder) =>
+            builder.UseInteractRules();
     }
 }

--- a/Assets/Scripts/Rules/Unity/UnityCombatRulesBridge.cs
+++ b/Assets/Scripts/Rules/Unity/UnityCombatRulesBridge.cs
@@ -230,7 +230,11 @@ namespace Game.Rules.Unity
                     .UseActiveEffectRules(modules.Registry)
                     .UseStatelessRuleBindingRules(modules.Registry)
                     .UsePreparedContributions()
-                    .UseEncounterRules(composition.CreateTurnStartAdapters(), modules.Registry)
+                    .UseEncounterRules(
+                        composition.CreateTurnStartAdapters(),
+                        modules.Registry,
+                        composition.CreateTurnResourceStrategy()
+                    )
                     .UseActionLifecycle(modules.ActionCatalog)
                     .UseMovementRules(topologyProvider)
                     .UseStrideRules(strideDefinition);
@@ -453,13 +457,17 @@ namespace Game.Rules.Unity
             return health;
         }
 
-        /// <summary>Gets the current authoritative action count for one controller.</summary>
+        /// <summary>Gets the current authoritative ordinary-action count for one controller.</summary>
         /// <param name="creature">The controller's encounter-stable creature ID.</param>
         /// <returns>The non-negative action count.</returns>
-        public int GetActionsRemaining(CreatureId creature)
+        public int GetStandardActionsRemaining(CreatureId creature)
         {
-            return GetActionEconomy(creature).ActionsRemaining;
+            return GetActionEconomy(creature).StandardActionsRemaining;
         }
+
+        /// <summary>Gets whether one optional action allowance is currently available.</summary>
+        public bool GetOptionalActionAvailable(CreatureId creature) =>
+            !GetActionEconomy(creature).OptionalAction.IsNone;
 
         /// <summary>Gets the required authoritative action-economy slice.</summary>
         public ActionEconomyState GetActionEconomy(CreatureId creature)
@@ -573,14 +581,6 @@ namespace Game.Rules.Unity
                 }
                 ExceptionDispatchInfo.Capture(failure).Throw();
             }
-        }
-
-        /// <summary>Spends authoritative actions for a Unity-hosted encounter action.</summary>
-        /// <param name="creature">The registered creature paying the cost.</param>
-        /// <param name="amount">The positive action count to spend.</param>
-        public void SpendEncounterActions(CreatureId creature, int amount)
-        {
-            DispatchNow(new SpendEncounterActionsOp(creature, amount));
         }
 
         /// <summary>Suspends this encounter without deciding an outcome.</summary>
@@ -1313,7 +1313,7 @@ namespace Game.Rules.Unity
                 .SeedHealth(id, state.Health)
                 .SeedPosition(id, state.Position)
                 .SeedLandSpeed(id, state.LandSpeed)
-                .SeedActionEconomy(id, new ActionEconomyState(0, false))
+                .SeedActionEconomy(id, new ActionEconomyState(0, ActionAllowance.None, false))
                 .SeedMultipleAttackPenalty(id, new MultipleAttackPenaltyState(0));
             foreach (SpellSlotState slot in state.SpellSlots)
                 seed.SeedSpellSlot(slot);

--- a/Assets/Tests/EditMode/ActionMedallionPresenterTests.cs
+++ b/Assets/Tests/EditMode/ActionMedallionPresenterTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+/// <summary>Verifies the player-card action-resource presentation seam.</summary>
+public class ActionMedallionPresenterTests
+{
+    /// <summary>Verifies standard and Quickened fill states are rendered independently.</summary>
+    [TestCase(0, false)]
+    [TestCase(0, true)]
+    [TestCase(1, false)]
+    [TestCase(1, true)]
+    [TestCase(2, false)]
+    [TestCase(2, true)]
+    [TestCase(3, false)]
+    [TestCase(3, true)]
+    public void RenderFillsStandardAndQuickenedMedallionsIndependently(
+        int standardActionsRemaining,
+        bool quickenedResourceAvailable
+    )
+    {
+        VisualElement card = CreateCard();
+
+        ActionMedallionPresenter.Render(card, standardActionsRemaining, quickenedResourceAvailable);
+
+        List<VisualElement> standardMedallions = card.Query<VisualElement>(
+                className: ActionMedallionPresenter.StandardMedallionClass
+            )
+            .ToList();
+        VisualElement quickenedMedallion = card.Q<VisualElement>(
+            className: ActionMedallionPresenter.QuickenedMedallionClass
+        );
+        Assert.That(
+            standardMedallions.Count(medallion =>
+                medallion.ClassListContains(ActionMedallionPresenter.FilledClass)
+            ),
+            Is.EqualTo(standardActionsRemaining)
+        );
+        Assert.That(
+            standardMedallions.Count(medallion =>
+                medallion.ClassListContains(ActionMedallionPresenter.EmptyClass)
+            ),
+            Is.EqualTo(ActionMedallionPresenter.StandardMedallionCount - standardActionsRemaining)
+        );
+        Assert.That(
+            quickenedMedallion.ClassListContains(ActionMedallionPresenter.FilledClass),
+            Is.EqualTo(quickenedResourceAvailable)
+        );
+        Assert.That(
+            quickenedMedallion.ClassListContains(ActionMedallionPresenter.EmptyClass),
+            Is.EqualTo(!quickenedResourceAvailable)
+        );
+        Assert.That(quickenedMedallion.parent, Is.SameAs(card));
+    }
+
+    /// <summary>Verifies spending the Quickened resource empties its persistent fourth slot.</summary>
+    [Test]
+    public void RenderKeepsSpentQuickenedSlotEmptyAndPresent()
+    {
+        VisualElement card = CreateCard();
+        VisualElement quickenedMedallion = card.Q<VisualElement>(
+            className: ActionMedallionPresenter.QuickenedMedallionClass
+        );
+        ActionMedallionPresenter.Render(card, 3, quickenedResourceAvailable: true);
+
+        ActionMedallionPresenter.Render(card, 2, quickenedResourceAvailable: false);
+
+        Assert.That(quickenedMedallion.parent, Is.SameAs(card));
+        Assert.That(
+            quickenedMedallion.ClassListContains(ActionMedallionPresenter.FilledClass),
+            Is.False
+        );
+        Assert.That(
+            quickenedMedallion.ClassListContains(ActionMedallionPresenter.EmptyClass),
+            Is.True
+        );
+        Assert.That(
+            card.Query<VisualElement>(className: ActionMedallionPresenter.StandardMedallionClass)
+                .ToList()
+                .Count(medallion =>
+                    medallion.ClassListContains(ActionMedallionPresenter.FilledClass)
+                ),
+            Is.EqualTo(2)
+        );
+    }
+
+    private static VisualElement CreateCard()
+    {
+        VisualElement card = new();
+        for (int i = 0; i < ActionMedallionPresenter.StandardMedallionCount; i++)
+        {
+            VisualElement medallion = new();
+            medallion.AddToClassList(ActionMedallionPresenter.StandardMedallionClass);
+            card.Add(medallion);
+        }
+
+        VisualElement quickenedMedallion = new();
+        quickenedMedallion.AddToClassList(ActionMedallionPresenter.QuickenedMedallionClass);
+        card.Add(quickenedMedallion);
+        return card;
+    }
+}

--- a/Assets/Tests/EditMode/ActionMedallionPresenterTests.cs.meta
+++ b/Assets/Tests/EditMode/ActionMedallionPresenterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a9e2eeb99364f93b739e6217d80af0f

--- a/Assets/Tests/EditMode/Combat/Exploration/DungeonDoorInteractionPolicyTests.cs
+++ b/Assets/Tests/EditMode/Combat/Exploration/DungeonDoorInteractionPolicyTests.cs
@@ -2,7 +2,7 @@ using Game.Combat.Exploration;
 using Game.DungeonGeneration;
 using NUnit.Framework;
 
-/// <summary>Verifies pure dungeon-door interaction authorization and action costs.</summary>
+/// <summary>Verifies pure dungeon-door geometry and mode validation.</summary>
 public sealed class DungeonDoorInteractionPolicyTests
 {
     /// <summary>Verifies all four cardinal neighbors may open a closed door in exploration.</summary>
@@ -10,7 +10,7 @@ public sealed class DungeonDoorInteractionPolicyTests
     [TestCase(6, 5)]
     [TestCase(5, 4)]
     [TestCase(5, 6)]
-    public void LivingPlayerCharacterMayOpenCardinallyAdjacentDoor(int actorX, int actorZ)
+    public void CardinallyAdjacentClosedDoorIsAllowed(int actorX, int actorZ)
     {
         DungeonDoorInteractionDecision decision = Evaluate(
             DungeonDoorInteractionMode.Exploration,
@@ -42,35 +42,6 @@ public sealed class DungeonDoorInteractionPolicyTests
         );
     }
 
-    /// <summary>Verifies non-player actors cannot open generated dungeon doors.</summary>
-    [Test]
-    public void ActorMustBePlayerCharacter()
-    {
-        DungeonDoorInteractionDecision decision = Evaluate(
-            DungeonDoorInteractionMode.Exploration,
-            actorIsPlayerCharacter: false
-        );
-
-        Assert.That(decision.IsAllowed, Is.False);
-        Assert.That(
-            decision.Rejection,
-            Is.EqualTo(DungeonDoorInteractionRejection.ActorIsNotPlayerCharacter)
-        );
-    }
-
-    /// <summary>Verifies dead player characters cannot open generated dungeon doors.</summary>
-    [Test]
-    public void ActorMustBeAlive()
-    {
-        DungeonDoorInteractionDecision decision = Evaluate(
-            DungeonDoorInteractionMode.Exploration,
-            actorIsAlive: false
-        );
-
-        Assert.That(decision.IsAllowed, Is.False);
-        Assert.That(decision.Rejection, Is.EqualTo(DungeonDoorInteractionRejection.ActorIsDead));
-    }
-
     /// <summary>Verifies opening an already-open door is rejected explicitly.</summary>
     [Test]
     public void DoorMustBeClosed()
@@ -87,59 +58,7 @@ public sealed class DungeonDoorInteractionPolicyTests
         );
     }
 
-    /// <summary>Verifies exploration door opening is free even with no available action points.</summary>
-    [Test]
-    public void ExplorationIsFreeAndDoesNotRequireActionPoints()
-    {
-        DungeonDoorInteractionRequest request = Request(
-            DungeonDoorInteractionMode.Exploration,
-            availableActionPoints: 0
-        );
-
-        DungeonDoorInteractionDecision decision = DungeonDoorInteractionPolicy.Evaluate(request);
-
-        Assert.That(decision.IsAllowed, Is.True);
-        Assert.That(decision.ActionCost, Is.Zero);
-        Assert.That(request.AvailableActionPoints, Is.Zero);
-    }
-
-    /// <summary>Verifies combat door opening is rejected when no action remains.</summary>
-    [Test]
-    public void CombatRequiresOneAvailableAction()
-    {
-        DungeonDoorInteractionDecision decision = Evaluate(
-            DungeonDoorInteractionMode.Combat,
-            availableActionPoints: 0
-        );
-
-        Assert.That(decision.IsAllowed, Is.False);
-        Assert.That(decision.ActionCost, Is.EqualTo(1));
-        Assert.That(
-            decision.Rejection,
-            Is.EqualTo(DungeonDoorInteractionRejection.InsufficientActionPoints)
-        );
-    }
-
-    /// <summary>Verifies one or more available combat actions authorize the exact one-action cost.</summary>
-    [TestCase(1u)]
-    [TestCase(2u)]
-    [TestCase(3u)]
-    public void CombatCostsExactlyOneAction(uint availableActionPoints)
-    {
-        DungeonDoorInteractionRequest request = Request(
-            DungeonDoorInteractionMode.Combat,
-            availableActionPoints: availableActionPoints
-        );
-
-        DungeonDoorInteractionDecision decision = DungeonDoorInteractionPolicy.Evaluate(request);
-
-        Assert.That(decision.IsAllowed, Is.True);
-        Assert.That(decision.ActionCost, Is.EqualTo(1));
-        Assert.That(decision.Rejection, Is.EqualTo(DungeonDoorInteractionRejection.None));
-        Assert.That(request.AvailableActionPoints, Is.EqualTo(availableActionPoints));
-    }
-
-    /// <summary>Verifies undefined and invalid gameplay modes are rejected without a cost.</summary>
+    /// <summary>Verifies undefined gameplay modes are rejected.</summary>
     [TestCase((DungeonDoorInteractionMode)0)]
     [TestCase((DungeonDoorInteractionMode)99)]
     public void ModeMustBeDefined(DungeonDoorInteractionMode mode)
@@ -147,47 +66,20 @@ public sealed class DungeonDoorInteractionPolicyTests
         DungeonDoorInteractionDecision decision = Evaluate(mode);
 
         Assert.That(decision.IsAllowed, Is.False);
-        Assert.That(decision.ActionCost, Is.Zero);
         Assert.That(decision.Rejection, Is.EqualTo(DungeonDoorInteractionRejection.InvalidMode));
     }
 
     private static DungeonDoorInteractionDecision Evaluate(
         DungeonDoorInteractionMode mode,
-        bool actorIsPlayerCharacter = true,
-        bool actorIsAlive = true,
         DungeonCell actorCell = default,
         DungeonCell doorCell = default,
-        bool doorIsOpen = false,
-        uint availableActionPoints = 3
+        bool doorIsOpen = false
     )
     {
         if (actorCell == default && doorCell == default)
             doorCell = new DungeonCell(1, 0);
-
         return DungeonDoorInteractionPolicy.Evaluate(
-            new DungeonDoorInteractionRequest(
-                mode,
-                actorIsPlayerCharacter,
-                actorIsAlive,
-                actorCell,
-                doorCell,
-                doorIsOpen,
-                availableActionPoints
-            )
+            new DungeonDoorInteractionRequest(mode, actorCell, doorCell, doorIsOpen)
         );
     }
-
-    private static DungeonDoorInteractionRequest Request(
-        DungeonDoorInteractionMode mode,
-        uint availableActionPoints
-    ) =>
-        new(
-            mode,
-            actorIsPlayerCharacter: true,
-            actorIsAlive: true,
-            actorCell: new DungeonCell(0, 0),
-            doorCell: new DungeonCell(1, 0),
-            doorIsOpen: false,
-            availableActionPoints
-        );
 }

--- a/Assets/Tests/EditMode/ConditionActionPermissionTests.cs
+++ b/Assets/Tests/EditMode/ConditionActionPermissionTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading.Tasks;
+using Game.Creature.Rules;
+using Game.Rules.Runtime;
+using NUnit.Framework;
+
+/// <summary>Verifies condition-owned permissions reject otherwise-payable typed actions.</summary>
+public sealed class ConditionActionPermissionTests
+{
+    private static readonly CreatureId Actor = new("condition-permission-actor");
+    private static readonly PlayerId Player = new("condition-permission-player");
+    private static readonly ActionDefinitionId Definition = new("condition-permission-action");
+    private static readonly RuleSource Source = RuleSource.FromSlug("condition-permission-test");
+
+    [Test]
+    public async Task StunnedPermissionRejectsOtherwisePayableFreeAction()
+    {
+        ActiveEffectId effectId = new("condition-permission-stunned-effect");
+        BindingId bindingId = new("condition-permission-stunned-binding");
+        ActiveEffectInstance effect = new(
+            effectId,
+            ConditionRuleDefinitions.Stunned,
+            Actor,
+            Source,
+            EffectDuration.Indefinite,
+            new ValuedStunnedConditionState(1)
+        );
+        ActiveRuleBinding binding = new(bindingId, effect.DefinitionId, Actor, effectId, Source, 0);
+        ActionProfile profile = ActionProfile.Create(ActionCost.FreeAction, Array.Empty<Trait>());
+        RecordingHandler handler = new();
+        RuleDispatcher dispatcher = CreateDispatcher(
+            profile,
+            ConditionTurnResourceComposition.CreateActionPermission(),
+            handler,
+            new RulesStateSeed()
+                .SeedCreature(new CreatureState(Actor, Player))
+                .SeedPreparedInputs(Actor, PreparedCreatureInputs.Empty)
+                .SeedActionEconomy(Actor, new ActionEconomyState(0, ActionAllowance.None, true))
+                .SeedActiveEffect(effect)
+                .SeedRuleBinding(binding)
+        );
+        Assert.That(
+            ActionResourcePayment.CanPay(
+                dispatcher.Snapshot.ActionEconomy[Actor],
+                Definition,
+                profile
+            ),
+            Is.True
+        );
+
+        OpResult<bool> result = await dispatcher.Dispatch(new PermissionTestActionOp());
+
+        Assert.That(result, Is.TypeOf<InvalidOpResult<bool>>());
+        Assert.That(
+            ((InvalidOpResult<bool>)result).Reason,
+            Is.EqualTo("A Stunned actor cannot take actions.")
+        );
+        Assert.That(handler.WasCalled, Is.False);
+    }
+
+    [Test]
+    public async Task NoReactionsPermissionRejectsOtherwisePayableReaction()
+    {
+        ActiveRuleBinding binding = new(
+            new BindingId("condition-permission-no-reactions-binding"),
+            SlowedEncounterModule.NoReactionsDefinitionId,
+            Actor,
+            default,
+            Source,
+            0
+        );
+        ActionProfile profile = ActionProfile.Create(ActionCost.Reaction, Array.Empty<Trait>());
+        RecordingHandler handler = new();
+        RuleDispatcher dispatcher = CreateDispatcher(
+            profile,
+            SlowedEncounterModule.CreateNoReactionsActionPermission(),
+            handler,
+            new RulesStateSeed()
+                .SeedCreature(new CreatureState(Actor, Player))
+                .SeedPreparedInputs(Actor, PreparedCreatureInputs.Empty)
+                .SeedActionEconomy(Actor, new ActionEconomyState(0, ActionAllowance.None, true))
+                .SeedRuleBinding(binding)
+        );
+        Assert.That(
+            ActionResourcePayment.CanPay(
+                dispatcher.Snapshot.ActionEconomy[Actor],
+                Definition,
+                profile
+            ),
+            Is.True
+        );
+
+        OpResult<bool> result = await dispatcher.Dispatch(new PermissionTestActionOp());
+
+        Assert.That(result, Is.TypeOf<InvalidOpResult<bool>>());
+        Assert.That(
+            ((InvalidOpResult<bool>)result).Reason,
+            Is.EqualTo("The actor cannot use reactions.")
+        );
+        Assert.That(handler.WasCalled, Is.False);
+        Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ReactionAvailable, Is.True);
+    }
+
+    private static RuleDispatcher CreateDispatcher(
+        ActionProfile profile,
+        IActionPermission permission,
+        RecordingHandler handler,
+        RulesStateSeed seed
+    )
+    {
+        RuleRegistryBuilder registryBuilder = new();
+        registryBuilder.Define(ConditionRuleDefinitions.Stunned);
+        registryBuilder.Define(SlowedEncounterModule.NoReactionsDefinitionId);
+        RuleRegistry registry = registryBuilder.Build();
+        return new RuleDispatcherBuilder(new InMemoryRulesStore(seed))
+            .RegisterHandler<PermissionTestActionOp, bool>(handler)
+            .RegisterActionPermission(permission)
+            .UseRuleRegistry(registry)
+            .UseActionLifecycle(new FixedCatalog(profile))
+            .Build();
+    }
+
+    private sealed class PermissionTestActionOp : ActionOp<bool>
+    {
+        internal PermissionTestActionOp()
+            : base(ConditionActionPermissionTests.Actor, Definition) { }
+    }
+
+    private sealed class RecordingHandler : IOpHandler<PermissionTestActionOp, bool>
+    {
+        internal bool WasCalled { get; private set; }
+
+        public ValueTask<bool> Handle(
+            OpFrame<PermissionTestActionOp> frame,
+            OpHandlerContext context
+        )
+        {
+            WasCalled = true;
+            return new ValueTask<bool>(true);
+        }
+    }
+
+    private sealed class FixedCatalog : IActionCatalog
+    {
+        private readonly ActionProfile profile;
+
+        internal FixedCatalog(ActionProfile profile) =>
+            this.profile = profile ?? throw new ArgumentNullException(nameof(profile));
+
+        public ActionProfile GetBaseProfile(ActionDefinitionId definitionId)
+        {
+            if (definitionId != Definition)
+                throw new InvalidOperationException("The test action definition is unknown.");
+            return profile;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ConditionActionPermissionTests.cs.meta
+++ b/Assets/Tests/EditMode/ConditionActionPermissionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2867952155f4bf0b51a77eabf1c68ab

--- a/Assets/Tests/EditMode/ConditionUnityIntegrationTests.cs
+++ b/Assets/Tests/EditMode/ConditionUnityIntegrationTests.cs
@@ -76,7 +76,10 @@ public sealed class ConditionUnityIntegrationTests
         );
         Assert.That(result.Amount, Is.EqualTo(8));
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(12));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(1));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(1)
+        );
         ConditionSelection<IEffectState> deafened = ConditionSelectors
             .GetActiveInstances(bridge.Snapshot, targetId, ConditionRuleDefinitions.Deafened)
             .Single();
@@ -152,7 +155,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(roll.roll, Is.EqualTo(attack.AttackRoll.Values.Single()));
         Assert.That(roll.total, Is.EqualTo(attack.AttackRoll.Total + attack.AttackModifier));
         Assert.That(roll.degree, Is.EqualTo(Game.Creature.DegreeOfSuccess.Success));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(1));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(1)
+        );
         Assert.That(bridge.Snapshot.MultipleAttackPenalty[casterId].AttackCount, Is.EqualTo(1));
         Assert.That(
             rolls.SpellRequests,
@@ -224,7 +230,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(result.Success, Is.True, result.Message);
         Assert.That(result.Amount, Is.EqualTo(8));
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(12));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(1));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(1)
+        );
         Assert.That(
             ConditionSelectors.GetActiveInstances(
                 bridge.Snapshot,
@@ -274,7 +283,10 @@ public sealed class ConditionUnityIntegrationTests
 
         Assert.That(actual, Is.SameAs(expected));
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(12));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(1));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(1)
+        );
         Assert.That(bridge.Snapshot.MultipleAttackPenalty[casterId].AttackCount, Is.Zero);
         long committedVersion = bridge.Snapshot.Version;
 
@@ -290,7 +302,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(retry.Amount, Is.EqualTo(8));
         Assert.That(bridge.Snapshot.Version, Is.EqualTo(committedVersion));
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(12));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(1));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(1)
+        );
         Assert.That(observer.Count, Is.EqualTo(1));
         AssertSingleHauntingHymnResolution(retry, rolls, spellRolls);
         bridge.ReleaseOwnership();
@@ -324,7 +339,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(result.Success, Is.False);
         Assert.That(result.Message, Does.Contain("same creature more than once"));
         Assert.That(bridge.Snapshot.Version, Is.EqualTo(before.Version));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(3));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(3)
+        );
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(20));
         bridge.ReleaseOwnership();
     }
@@ -358,7 +376,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(result.Success, Is.False);
         Assert.That(result.Message, Does.Contain("combine creature targets with an area"));
         Assert.That(bridge.Snapshot.Version, Is.EqualTo(before.Version));
-        Assert.That(bridge.Snapshot.ActionEconomy[casterId].ActionsRemaining, Is.EqualTo(3));
+        Assert.That(
+            bridge.Snapshot.ActionEconomy[casterId].StandardActionsRemaining,
+            Is.EqualTo(3)
+        );
         Assert.That(bridge.Snapshot.Health[targetId].Current, Is.EqualTo(20));
         bridge.ReleaseOwnership();
     }
@@ -938,9 +959,477 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(caster.Controller.ActionPoints, Is.EqualTo(actions));
     }
 
+    [Test]
+    public void QuickenedInteractSpendsOptionalResourceBeforeStandardActions()
+    {
+        CreatureFixture actor = CreateCreature("Quickened Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Quickened Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Quickened,
+                    "quickened-interact",
+                    new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.True);
+        Assert.That(actor.Controller.TryCommitInteract(), Is.True);
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(3));
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.False);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void MidTurnStunnedTwoLosesOptionalThenOneStandardAndPreservesReaction()
+    {
+        CreatureFixture actor = CreateCreature("Quickened Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Quickened Stunned Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Quickened,
+                    "quickened-midturn-stunned",
+                    new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+
+        OpResult<ConditionApplicationOutcome> applied = bridge.Dispatch(
+            new ApplyConditionOp(
+                "Stunned",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-stunned-two"),
+                EffectDuration.Indefinite,
+                new ValuedStunnedConditionState(2)
+            )
+        );
+
+        Assert.That(applied, Is.TypeOf<ResolvedOpResult<ConditionApplicationOutcome>>());
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(2));
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.False);
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        Assert.That(ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out _), Is.False);
+        Assert.That(actor.Controller.TryCommitInteract(), Is.True);
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(1));
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void TurnStartStunnedOneAndSlowedTwoLoseTwoAndExpireOnlyStunned()
+    {
+        CreatureFixture actor = CreateCreature("Stunned Slowed Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Stunned Slowed Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Slowed,
+                    "start-slowed-two",
+                    new SlowedConditionState(2)
+                ),
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Stunned,
+                    "start-stunned-one",
+                    new ValuedStunnedConditionState(1)
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        CountingFactObserver<ActionResourceLostFact> losses = new();
+        using IDisposable registration = GetDispatcher(bridge).RegisterFactObserver(losses);
+
+        bridge.BeginTurn(actorId, 1);
+
+        Assert.That(losses.Count, Is.EqualTo(1));
+        Assert.That(losses.Last.Resource, Is.EqualTo(ActionResourceKind.Standard));
+        Assert.That(losses.Last.Amount, Is.EqualTo(2));
+        Assert.That(ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out _), Is.False);
+        Assert.That(
+            ConditionSelectors.TryGetSlowed(bridge.Snapshot, actorId, out var slowed),
+            Is.True
+        );
+        Assert.That(slowed.State.Value, Is.EqualTo(2));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void StunnedFourCarriesOneThenExpiresWithoutDoubleChargingNextRefresh()
+    {
+        CreatureFixture actor = CreateCreature("Stunned Four Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Stunned Four Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Stunned,
+                    "start-stunned-four",
+                    new ValuedStunnedConditionState(4)
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+
+        bridge.BeginTurn(actorId, 0);
+
+        Assert.That(
+            ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out var remaining),
+            Is.True
+        );
+        Assert.That(((ValuedStunnedConditionState)remaining.State).Value, Is.EqualTo(1));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.False);
+
+        bridge.BeginTurn(actorId, 2);
+
+        Assert.That(ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out _), Is.False);
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void StunnedTwoAndOneUseHighestLossAndBothAdjustWithoutSumming()
+    {
+        CreatureFixture actor = CreateCreature("Multiple Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Multiple Stunned Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Stunned,
+                    "stunned-two-source",
+                    new ValuedStunnedConditionState(2)
+                ),
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Stunned,
+                    "stunned-one-source",
+                    new ValuedStunnedConditionState(1)
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        Assert.That(
+            ConditionSelectors
+                .GetActiveInstances(bridge.Snapshot, actorId, ConditionRuleDefinitions.Stunned)
+                .ToArray(),
+            Has.Length.EqualTo(2)
+        );
+
+        bridge.BeginTurn(actorId, 1);
+
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(1));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        Assert.That(
+            ConditionSelectors.GetActiveInstances(
+                bridge.Snapshot,
+                actorId,
+                ConditionRuleDefinitions.Stunned
+            ),
+            Is.Empty
+        );
+        Assert.That(actor.Controller.TryCommitInteract(), Is.True);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void DurationOnlyStunnedLosesAllResourcesAndSuppressesReaction()
+    {
+        CreatureFixture actor = CreateCreature("Duration Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Duration Stunned Opponent", "Enemies", 0);
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Stunned,
+                    "duration-stunned",
+                    DurationOnlyStunnedConditionState.Instance
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+
+        bridge.BeginTurn(actorId, 0);
+
+        Assert.That(
+            ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out var stunned),
+            Is.True
+        );
+        Assert.That(stunned.State, Is.TypeOf<DurationOnlyStunnedConditionState>());
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.False);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void DurationOnlyStunnedGainedMidTurnImmediatelySuppressesEveryResource()
+    {
+        CreatureFixture actor = CreateCreature("Midturn Duration Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature(
+            "Midturn Duration Stunned Opponent",
+            "Enemies",
+            0
+        );
+        actor.Conditions.RestoreApplications(
+            new[]
+            {
+                Persisted(
+                    actor.GameObject,
+                    ConditionRuleDefinitions.Quickened,
+                    "quickened-midturn-duration-stunned",
+                    QuickenedConditionState.Unrestricted
+                ),
+            }
+        );
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.True);
+
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Stunned",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-duration-stunned"),
+                EffectDuration.Indefinite,
+                DurationOnlyStunnedConditionState.Instance
+            )
+        );
+
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.Zero);
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.False);
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.False);
+        Assert.That(
+            ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out var stunned),
+            Is.True
+        );
+        Assert.That(stunned.State, Is.TypeOf<DurationOnlyStunnedConditionState>());
+        Assert.That(actor.Controller.TryCommitInteract(), Is.False);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void SlowedGainedMidTurnChangesOnlyTheNextTurnRefresh()
+    {
+        CreatureFixture actor = CreateCreature("Delayed Slowed Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Delayed Slowed Opponent", "Enemies", 0);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Slowed",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-slowed-four"),
+                EffectDuration.Indefinite,
+                new SlowedConditionState(4)
+            )
+        );
+
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(3));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        bridge.BeginTurn(actorId, 0);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void QuickenedGainedMidTurnGrantsItsOptionalResourceAtNextRefresh()
+    {
+        CreatureFixture actor = CreateCreature("Delayed Quickened Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Delayed Quickened Opponent", "Enemies", 0);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Quickened",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-quickened-interact"),
+                EffectDuration.Indefinite,
+                new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+            )
+        );
+
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.False);
+        bridge.BeginTurn(actorId, 3);
+        Assert.That(actor.Controller.OptionalActionAvailable, Is.True);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void MidTurnStunnedOneLosesOnlyOneRemainingResourceAndDoesNotChargeNextTurn()
+    {
+        CreatureFixture actor = CreateCreature("Midturn Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Midturn Stunned Opponent", "Enemies", 0);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+        Assert.That(actor.Controller.TryCommitInteract(), Is.True);
+
+        OpResult<ConditionApplicationOutcome> applied = bridge.Dispatch(
+            new ApplyConditionOp(
+                "Stunned",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-stunned-one"),
+                EffectDuration.Indefinite,
+                new ValuedStunnedConditionState(1)
+            )
+        );
+
+        Assert.That(applied, Is.TypeOf<ResolvedOpResult<ConditionApplicationOutcome>>());
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(1));
+        Assert.That(ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out _), Is.False);
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        bridge.BeginTurn(actorId, 3);
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(3));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void MidTurnStunnedFourPersistsAndBlocksSubsequentTypedActions()
+    {
+        CreatureFixture actor = CreateCreature("Persistent Stunned Actor", "Heroes", 100);
+        CreatureFixture opponent = CreateCreature("Persistent Stunned Opponent", "Enemies", 0);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new[] { actor.Controller, opponent.Controller },
+            CreateTiles()
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+        Assert.That(actor.Controller.TryCommitInteract(), Is.True);
+
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Stunned",
+                actorId,
+                actorId,
+                RuleSource.FromSlug("midturn-stunned-four"),
+                EffectDuration.Indefinite,
+                new ValuedStunnedConditionState(4)
+            )
+        );
+
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.Zero);
+        Assert.That(
+            ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out var stunned),
+            Is.True
+        );
+        Assert.That(((ValuedStunnedConditionState)stunned.State).Value, Is.EqualTo(2));
+        Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.False);
+        Assert.That(actor.Controller.TryCommitInteract(), Is.False);
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.Zero);
+        bridge.ReleaseOwnership();
+    }
+
+    [Test]
+    public void DisabledOwnerListenerCannotBorrowAnotherActorsBindingToDrainStunned()
+    {
+        CreatureFixture actor = CreateCreature("Disabled Stunned Listener", "Heroes", 100);
+        CreatureFixture other = CreateCreature("Other Stunned Listener", "Enemies", 0);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.CreateForTests(
+            new[] { actor.Controller, other.Controller },
+            CreateTiles(),
+            new RandomRollService(),
+            new IUnityEncounterModule[] { new StatelessBindingLifecycleRequestModule() }
+        );
+        CreatureId actorId = bridge.GetCreatureId(actor.Creature);
+        bridge.BeginTurn(actorId, 3);
+        BindingId listenerId = new($"condition-turn-resources-{actorId.Value}");
+        ActiveRuleBinding listener = bridge.Snapshot.RuleBindings[listenerId];
+        CreatureId otherId = bridge.GetCreatureId(other.Creature);
+        BindingId otherListenerId = new($"condition-turn-resources-{otherId.Value}");
+        Assert.That(bridge.Snapshot.RuleBindings[otherListenerId].IsEnabled, Is.True);
+        Assert.That(
+            bridge.Dispatch(
+                new DisableStatelessBindingRequestOp(
+                    listener.Id,
+                    listener.CreationOrder,
+                    listener.Source
+                )
+            ),
+            Is.TypeOf<ResolvedOpResult<StatelessRuleBindingEnabledOutcome>>()
+        );
+
+        Assert.That(
+            bridge.Dispatch(
+                new ApplyConditionOp(
+                    "Stunned",
+                    actorId,
+                    actorId,
+                    RuleSource.FromSlug("disabled-owner-midturn-stunned"),
+                    EffectDuration.Indefinite,
+                    new ValuedStunnedConditionState(1)
+                )
+            ),
+            Is.TypeOf<ResolvedOpResult<ConditionApplicationOutcome>>()
+        );
+
+        Assert.That(bridge.GetStandardActionsRemaining(actorId), Is.EqualTo(3));
+        Assert.That(ConditionSelectors.TryGetStunned(bridge.Snapshot, actorId, out _), Is.True);
+        Assert.That(bridge.Snapshot.RuleBindings[otherListenerId].IsEnabled, Is.True);
+        bridge.ReleaseOwnership();
+    }
+
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler")]
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler-rotting-aura")]
-    public void AuthoredZombieSlowImportsEnrollsAndReplaysWithoutResourceAuthority(string path)
+    public void AuthoredZombieSlowEnrollsStableSlowedAndNoReactionRules(string path)
     {
         CreatureFixture zombie = CreateCreatureFromJson(path, "Enemies", 100);
         CreatureFixture opponent = CreateCreature("Zombie Opponent", "Heroes", 0);
@@ -977,9 +1466,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(authored.Binding.Id.Value, Is.EqualTo($"{authoredIdentity}-binding"));
         Assert.That(authored.Effect.Duration, Is.EqualTo(EffectDuration.Indefinite));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
-        first.BeginTurn(zombieId, 3);
-        Assert.That(first.GetActionEconomy(zombieId).ReactionAvailable, Is.True);
-        Assert.That(zombie.Controller.Reacted, Is.False);
+        first.BeginTurn(zombieId, 2);
+        Assert.That(first.GetActionEconomy(zombieId).StandardActionsRemaining, Is.EqualTo(2));
+        Assert.That(first.GetActionEconomy(zombieId).ReactionAvailable, Is.False);
+        Assert.That(zombie.Controller.Reacted, Is.True);
 
         first.ReleaseOwnership();
         Assert.That(zombie.Conditions.CaptureApplications(), Has.Count.EqualTo(2));
@@ -998,13 +1488,14 @@ public sealed class ConditionUnityIntegrationTests
                 .Effect.Id.Value,
             Is.EqualTo($"{authoredIdentity}-effect")
         );
-        replay.BeginTurn(replayId, 3);
-        Assert.That(replay.GetActionEconomy(replayId).ReactionAvailable, Is.True);
+        replay.BeginTurn(replayId, 2);
+        Assert.That(replay.GetActionEconomy(replayId).StandardActionsRemaining, Is.EqualTo(2));
+        Assert.That(replay.GetActionEconomy(replayId).ReactionAvailable, Is.False);
     }
 
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler")]
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler-rotting-aura")]
-    public void ReinforcementZombieSlowUsesTheSameEnrollmentWithoutResourceAuthority(string path)
+    public void ReinforcementZombieSlowUsesTheSameAuthoritativeEnrollment(string path)
     {
         CreatureFixture initial = CreateCreature("Reinforcement Initial", "Heroes", 100);
         CreatureFixture opponent = CreateCreature("Reinforcement Opponent", "Enemies", 50);
@@ -1023,14 +1514,17 @@ public sealed class ConditionUnityIntegrationTests
             .Single();
         Assert.That(authored.Source, Is.EqualTo(RuleSource.FromSlug("authored-passive-slow")));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
-        bridge.BeginTurn(zombieId, 3);
-        Assert.That(bridge.GetActionEconomy(zombieId).ReactionAvailable, Is.True);
-        Assert.That(zombie.Controller.Reacted, Is.False);
+        bridge.BeginTurn(zombieId, 2);
+        Assert.That(bridge.GetActionEconomy(zombieId).StandardActionsRemaining, Is.EqualTo(2));
+        Assert.That(bridge.GetActionEconomy(zombieId).ReactionAvailable, Is.False);
+        Assert.That(zombie.Controller.Reacted, Is.True);
     }
 
     [TestCase("ordinary-slowed")]
     [TestCase("authored-passive-slow")]
-    public void OrdinaryOrFakeIdentitySlowedHasNoTurnResourceAuthority(string source)
+    public void EveryActiveSlowedSourceReducesStandardActionsWithoutSuppressingReaction(
+        string source
+    )
     {
         CreatureFixture actor = CreateCreature("Ordinary Slowed", "Heroes", 100);
         CreatureFixture opponent = CreateCreature("Ordinary Slowed Opponent", "Enemies", 0);
@@ -1052,9 +1546,9 @@ public sealed class ConditionUnityIntegrationTests
         );
         CreatureId actorId = bridge.GetCreatureId(actor.Creature);
 
-        bridge.BeginTurn(actorId, 3);
+        bridge.BeginTurn(actorId, 2);
 
-        Assert.That(bridge.GetActionEconomy(actorId).ActionsRemaining, Is.EqualTo(3));
+        Assert.That(bridge.GetActionEconomy(actorId).StandardActionsRemaining, Is.EqualTo(2));
         Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
         Assert.That(actor.Controller.Reacted, Is.False);
         bridge.ReleaseOwnership();
@@ -2083,9 +2577,10 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(authored.Source, Is.EqualTo(RuleSource.FromSlug("authored-passive-slow")));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
         Assert.That(actor.Conditions.ActiveConditionNames, Does.Contain("slowed"));
-        first.BeginTurn(actorId, 3);
-        Assert.That(first.GetActionEconomy(actorId).ReactionAvailable, Is.True);
-        Assert.That(actor.Controller.Reacted, Is.False);
+        first.BeginTurn(actorId, 2);
+        Assert.That(first.GetActionEconomy(actorId).StandardActionsRemaining, Is.EqualTo(2));
+        Assert.That(first.GetActionEconomy(actorId).ReactionAvailable, Is.False);
+        Assert.That(actor.Controller.Reacted, Is.True);
         Assert.That(actor.Conditions.CaptureApplications(), Is.Empty);
 
         Assert.DoesNotThrow(() => first.ReleaseOwnership());
@@ -3463,6 +3958,59 @@ public sealed class ConditionUnityIntegrationTests
                 owner.FailuresRemaining--;
                 throw new InvalidOperationException("Injected late installation failure.");
             }
+        }
+    }
+
+    private sealed class StatelessBindingLifecycleRequestModule : IUnityEncounterDispatcherModule
+    {
+        public void ConfigureDispatcher(RuleDispatcherBuilder builder) =>
+            builder.RegisterHandler<
+                DisableStatelessBindingRequestOp,
+                StatelessRuleBindingEnabledOutcome
+            >(new DisableStatelessBindingRequestHandler());
+    }
+
+    private sealed class DisableStatelessBindingRequestOp
+        : IRuleOp<StatelessRuleBindingEnabledOutcome>
+    {
+        internal DisableStatelessBindingRequestOp(
+            BindingId binding,
+            long expectedCreationOrder,
+            RuleSource source
+        )
+        {
+            Binding = binding;
+            ExpectedCreationOrder = expectedCreationOrder;
+            Source = source;
+        }
+
+        internal BindingId Binding { get; }
+        internal long ExpectedCreationOrder { get; }
+        internal RuleSource Source { get; }
+    }
+
+    private sealed class DisableStatelessBindingRequestHandler
+        : IOpHandler<DisableStatelessBindingRequestOp, StatelessRuleBindingEnabledOutcome>
+    {
+        public async ValueTask<StatelessRuleBindingEnabledOutcome> Handle(
+            OpFrame<DisableStatelessBindingRequestOp> frame,
+            OpHandlerContext context
+        )
+        {
+            OpResult<StatelessRuleBindingEnabledOutcome> result = await context.Dispatch(
+                new DisableStatelessRuleBindingOp(
+                    frame.Op.Binding,
+                    frame.Op.ExpectedCreationOrder,
+                    frame.Op.Source
+                )
+            );
+            if (result is ResolvedOpResult<StatelessRuleBindingEnabledOutcome> resolved)
+                return resolved.Value;
+            if (result is InvalidOpResult<StatelessRuleBindingEnabledOutcome> invalid)
+                throw new InvalidOperationException(invalid.Reason);
+            throw new InvalidOperationException(
+                "The stateless binding lifecycle request did not resolve."
+            );
         }
     }
 

--- a/Assets/Tests/EditMode/ConditionUnityIntegrationTests.cs
+++ b/Assets/Tests/EditMode/ConditionUnityIntegrationTests.cs
@@ -940,7 +940,7 @@ public sealed class ConditionUnityIntegrationTests
 
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler")]
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler-rotting-aura")]
-    public void AuthoredZombieSlowImportsEnrollsReplaysAndSuppressesReactions(string path)
+    public void AuthoredZombieSlowImportsEnrollsAndReplaysWithoutResourceAuthority(string path)
     {
         CreatureFixture zombie = CreateCreatureFromJson(path, "Enemies", 100);
         CreatureFixture opponent = CreateCreature("Zombie Opponent", "Heroes", 0);
@@ -977,9 +977,9 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(authored.Binding.Id.Value, Is.EqualTo($"{authoredIdentity}-binding"));
         Assert.That(authored.Effect.Duration, Is.EqualTo(EffectDuration.Indefinite));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
-        first.BeginTurn(zombieId, 2);
-        Assert.That(first.GetActionEconomy(zombieId).ReactionAvailable, Is.False);
-        Assert.That(zombie.Controller.Reacted, Is.True);
+        first.BeginTurn(zombieId, 3);
+        Assert.That(first.GetActionEconomy(zombieId).ReactionAvailable, Is.True);
+        Assert.That(zombie.Controller.Reacted, Is.False);
 
         first.ReleaseOwnership();
         Assert.That(zombie.Conditions.CaptureApplications(), Has.Count.EqualTo(2));
@@ -998,13 +998,13 @@ public sealed class ConditionUnityIntegrationTests
                 .Effect.Id.Value,
             Is.EqualTo($"{authoredIdentity}-effect")
         );
-        replay.BeginTurn(replayId, 2);
-        Assert.That(replay.GetActionEconomy(replayId).ReactionAvailable, Is.False);
+        replay.BeginTurn(replayId, 3);
+        Assert.That(replay.GetActionEconomy(replayId).ReactionAvailable, Is.True);
     }
 
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler")]
     [TestCase("DataFiles/pathfinder-monster-core/zombie-shambler-rotting-aura")]
-    public void ReinforcementZombieSlowUsesTheSameEnrollmentAndTurnAuthority(string path)
+    public void ReinforcementZombieSlowUsesTheSameEnrollmentWithoutResourceAuthority(string path)
     {
         CreatureFixture initial = CreateCreature("Reinforcement Initial", "Heroes", 100);
         CreatureFixture opponent = CreateCreature("Reinforcement Opponent", "Enemies", 50);
@@ -1023,14 +1023,14 @@ public sealed class ConditionUnityIntegrationTests
             .Single();
         Assert.That(authored.Source, Is.EqualTo(RuleSource.FromSlug("authored-passive-slow")));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
-        bridge.BeginTurn(zombieId, 2);
-        Assert.That(bridge.GetActionEconomy(zombieId).ReactionAvailable, Is.False);
-        Assert.That(zombie.Controller.Reacted, Is.True);
+        bridge.BeginTurn(zombieId, 3);
+        Assert.That(bridge.GetActionEconomy(zombieId).ReactionAvailable, Is.True);
+        Assert.That(zombie.Controller.Reacted, Is.False);
     }
 
     [TestCase("ordinary-slowed")]
     [TestCase("authored-passive-slow")]
-    public void OrdinaryOrFakeIdentitySlowedReducesActionsWithoutSuppressingReaction(string source)
+    public void OrdinaryOrFakeIdentitySlowedHasNoTurnResourceAuthority(string source)
     {
         CreatureFixture actor = CreateCreature("Ordinary Slowed", "Heroes", 100);
         CreatureFixture opponent = CreateCreature("Ordinary Slowed Opponent", "Enemies", 0);
@@ -1052,9 +1052,9 @@ public sealed class ConditionUnityIntegrationTests
         );
         CreatureId actorId = bridge.GetCreatureId(actor.Creature);
 
-        bridge.BeginTurn(actorId, 2);
+        bridge.BeginTurn(actorId, 3);
 
-        Assert.That(bridge.GetActionEconomy(actorId).ActionsRemaining, Is.EqualTo(2));
+        Assert.That(bridge.GetActionEconomy(actorId).ActionsRemaining, Is.EqualTo(3));
         Assert.That(bridge.GetActionEconomy(actorId).ReactionAvailable, Is.True);
         Assert.That(actor.Controller.Reacted, Is.False);
         bridge.ReleaseOwnership();
@@ -2083,9 +2083,9 @@ public sealed class ConditionUnityIntegrationTests
         Assert.That(authored.Source, Is.EqualTo(RuleSource.FromSlug("authored-passive-slow")));
         Assert.That(authored.Effect.GetState<SlowedConditionState>().Value, Is.EqualTo(1));
         Assert.That(actor.Conditions.ActiveConditionNames, Does.Contain("slowed"));
-        first.BeginTurn(actorId, 2);
-        Assert.That(first.GetActionEconomy(actorId).ReactionAvailable, Is.False);
-        Assert.That(actor.Controller.Reacted, Is.True);
+        first.BeginTurn(actorId, 3);
+        Assert.That(first.GetActionEconomy(actorId).ReactionAvailable, Is.True);
+        Assert.That(actor.Controller.Reacted, Is.False);
         Assert.That(actor.Conditions.CaptureApplications(), Is.Empty);
 
         Assert.DoesNotThrow(() => first.ReleaseOwnership());

--- a/Assets/Tests/EditMode/EncounterLifecycleTestExtensions.cs
+++ b/Assets/Tests/EditMode/EncounterLifecycleTestExtensions.cs
@@ -6,6 +6,15 @@ using NUnit.Framework;
 /// <summary>Runs older Unity integration fixtures through exact encounter turn authority.</summary>
 internal static class EncounterLifecycleTestExtensions
 {
+    /// <summary>Commits the typed one-action Interact used to spend fixture resources.</summary>
+    internal static bool TryCommitInteract(this ActionController controller)
+    {
+        if (controller == null)
+            throw new ArgumentNullException(nameof(controller));
+        return controller.TryGetCombatRules(out UnityCombatRulesBridge bridge, out CreatureId actor)
+            && bridge.Dispatch(new InteractActionOp(actor)) is ResolvedOpResult<InteractOutcome>;
+    }
+
     /// <summary>Starts or advances a real encounter until the requested actor owns the turn.</summary>
     internal static void BeginTurn(
         this UnityCombatRulesBridge bridge,
@@ -48,6 +57,6 @@ internal static class EncounterLifecycleTestExtensions
         Assert.That(encounter.Phase, Is.EqualTo(EncounterPhase.Active));
         Assert.That(encounter.CurrentTurn.HasValue, Is.True);
         Assert.That(encounter.CurrentTurn.Value.Actor, Is.EqualTo(actor));
-        Assert.That(bridge.GetActionsRemaining(actor), Is.EqualTo(expectedActions));
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.EqualTo(expectedActions));
     }
 }

--- a/Assets/Tests/EditMode/Pf2eRulesTests.cs
+++ b/Assets/Tests/EditMode/Pf2eRulesTests.cs
@@ -969,28 +969,36 @@ public class Pf2eRulesTests
     )
     {
         RulesStateSeed seed = new RulesStateSeed().SeedPreparedInputs(actor, package.Inputs);
-        foreach (KeyValuePair<BindingId, ActiveRuleBinding> binding in sourceSnapshot.RuleBindings)
+        ActiveRuleBinding[] actorBindings = sourceSnapshot
+            .RuleBindings.Select(pair => pair.Value)
+            .Where(binding => binding.Owner == actor)
+            .Select(mapBinding)
+            .ToArray();
+        foreach (ActiveRuleBinding binding in actorBindings)
         {
-            if (binding.Value.Owner == actor)
-            {
-                seed.SeedRuleBinding(mapBinding(binding.Value));
-                if (
-                    binding.Value.EffectId.HasValue
-                    && sourceSnapshot.ActiveEffects.TryGet(
-                        binding.Value.EffectId.Value,
-                        out ActiveEffectInstance effect
-                    )
+            seed.SeedRuleBinding(binding);
+            if (
+                binding.EffectId.HasValue
+                && sourceSnapshot.ActiveEffects.TryGet(
+                    binding.EffectId.Value,
+                    out ActiveEffectInstance effect
                 )
-                    seed.SeedActiveEffect(effect);
+            )
+            {
+                seed.SeedActiveEffect(effect);
             }
         }
         RuleRegistryBuilder registryBuilder = new();
+        HashSet<RuleDefinitionId> registeredDefinitions = new();
         foreach (PreparedRuleDefinitionSpec definition in package.Definitions)
-            registryBuilder.Define(definition);
-        foreach (KeyValuePair<BindingId, ActiveRuleBinding> binding in sourceSnapshot.RuleBindings)
         {
-            if (!package.Definitions.Any(value => value.Id == binding.Value.DefinitionId))
-                registryBuilder.Define(binding.Value.DefinitionId);
+            if (registeredDefinitions.Add(definition.Id))
+                registryBuilder.Define(definition);
+        }
+        foreach (ActiveRuleBinding binding in actorBindings)
+        {
+            if (registeredDefinitions.Add(binding.DefinitionId))
+                registryBuilder.Define(binding.DefinitionId);
         }
         RuleRegistry registry = registryBuilder.Build();
         return new RuleDispatcherBuilder(new InMemoryRulesStore(seed))

--- a/Assets/Tests/EditMode/RulesRuntime/ActionLifecycleTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/ActionLifecycleTests.cs
@@ -62,7 +62,7 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(handler.WasCalled, Is.True);
             Assert.That(handler.Profile, Is.SameAs(profile));
-            Assert.That(handler.ActionsRemaining, Is.EqualTo(2));
+            Assert.That(handler.StandardActionsRemaining, Is.EqualTo(2));
             Assert.That(handler.SpellSlotsRemaining, Is.EqualTo(1));
             Assert.That(handler.FocusPointsRemaining, Is.EqualTo(1));
             Assert.That(handler.AmmunitionRemaining, Is.EqualTo(3));
@@ -74,6 +74,7 @@ namespace Game.Rules.Runtime.Tests
                     new[]
                     {
                         typeof(ActionCostSpentFact),
+                        typeof(ActionResourceSpentFact),
                         typeof(SpellSlotSpentFact),
                         typeof(FocusPointsSpentFact),
                         typeof(AmmunitionSpentFact),
@@ -91,6 +92,7 @@ namespace Game.Rules.Runtime.Tests
                         new FactId(3),
                         new FactId(4),
                         new FactId(5),
+                        new FactId(6),
                     }
                 )
             );
@@ -148,7 +150,10 @@ namespace Game.Rules.Runtime.Tests
                 Is.EqualTo("target is not legal")
             );
             Assert.That(result.Facts, Is.Empty);
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.Version, Is.Zero);
             Assert.That(handler.WasCalled, Is.False);
             Assert.That(middleware.Calls, Is.Zero);
@@ -170,7 +175,7 @@ namespace Game.Rules.Runtime.Tests
             );
             InMemoryRulesStore store = new InMemoryRulesStore(
                 new RulesStateSeed()
-                    .SeedActionEconomy(Actor, new ActionEconomyState(3, true))
+                    .SeedActionEconomy(Actor, new ActionEconomyState(3, ActionAllowance.None, true))
                     .SeedSpellSlot(new SpellSlotState(SpellPool, Actor, 1, 1))
             );
             RecordingActionHandler handler = new RecordingActionHandler(true);
@@ -188,7 +193,7 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(result.Facts, Is.Empty);
             Assert.That(
-                store.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3),
                 "An earlier draft action spend must roll back with the later slot rejection."
             );
@@ -245,9 +250,13 @@ namespace Game.Rules.Runtime.Tests
             OpResult<TestActionOutcome> result = await dispatcher.Dispatch(new TestActionOp());
 
             Assert.That(result, Is.TypeOf<InterruptedOpResult<TestActionOutcome>>());
-            Assert.That(result.Facts, Has.Count.EqualTo(1));
-            Assert.That(result.Facts.Single(), Is.TypeOf<ActionCostSpentFact>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(result.Facts, Has.Count.EqualTo(2));
+            Assert.That(result.Facts.OfType<ActionCostSpentFact>().Single(), Is.Not.Null);
+            Assert.That(result.Facts.OfType<ActionResourceSpentFact>().Single(), Is.Not.Null);
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             Assert.That(store.Snapshot.Version, Is.EqualTo(1));
             Assert.That(handler.WasCalled, Is.False);
             Assert.That(middleware.Calls, Is.EqualTo(1));
@@ -288,7 +297,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(costsCommitted.DefinitionId, Is.EqualTo(ActionDefinition));
             Assert.That(first.Facts.OfType<ActionReceiptCommittedFact>().Count(), Is.EqualTo(1));
             Assert.That(handler.Calls, Is.EqualTo(1));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             long committedVersion = store.Snapshot.Version;
 
             ResolvedOpResult<TestActionOutcome> retry = RequireResolved(
@@ -298,7 +310,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(retry.Value.DomainSucceeded, Is.True);
             Assert.That(retry.Facts, Is.Empty);
             Assert.That(store.Snapshot.Version, Is.EqualTo(committedVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(handler.Calls, Is.EqualTo(1));
         }
 
@@ -325,7 +340,7 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(result.Facts, Is.Empty);
             Assert.That(handler.WasCalled, Is.True);
-            Assert.That(handler.ActionsRemaining, Is.EqualTo(3));
+            Assert.That(handler.StandardActionsRemaining, Is.EqualTo(3));
         }
 
         [Test]
@@ -351,7 +366,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(resolver.StartingActions, Is.EqualTo(3));
             Assert.That(validator.Profile, Is.SameAs(effectiveProfile));
             Assert.That(handler.Profile, Is.SameAs(effectiveProfile));
-            Assert.That(handler.ActionsRemaining, Is.EqualTo(2));
+            Assert.That(handler.StandardActionsRemaining, Is.EqualTo(2));
         }
 
         [Test]
@@ -406,7 +421,10 @@ namespace Game.Rules.Runtime.Tests
             foreach (ActionCostExpectation expectation in cases)
             {
                 InMemoryRulesStore store = new InMemoryRulesStore(
-                    new RulesStateSeed().SeedActionEconomy(Actor, new ActionEconomyState(3, true))
+                    new RulesStateSeed().SeedActionEconomy(
+                        Actor,
+                        new ActionEconomyState(3, ActionAllowance.None, true)
+                    )
                 );
                 ActionProfile profile = ActionProfile.Create(
                     expectation.Cost,
@@ -427,8 +445,8 @@ namespace Game.Rules.Runtime.Tests
                     $"{expectation.Cost.Kind} should resolve."
                 );
                 Assert.That(
-                    store.Snapshot.ActionEconomy[Actor].ActionsRemaining,
-                    Is.EqualTo(expectation.ActionsRemaining)
+                    store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                    Is.EqualTo(expectation.StandardActionsRemaining)
                 );
                 Assert.That(
                     store.Snapshot.ActionEconomy[Actor].ReactionAvailable,
@@ -481,7 +499,7 @@ namespace Game.Rules.Runtime.Tests
             InvalidOperationException costsError = Assert.ThrowsAsync<InvalidOperationException>(
                 async () =>
                     await dispatcher.Dispatch(
-                        new CommitActionCostsOp(new OpId(500), Actor, profile)
+                        new CommitActionCostsOp(new OpId(500), Actor, ActionDefinition, profile)
                     )
             );
 
@@ -577,7 +595,10 @@ namespace Game.Rules.Runtime.Tests
             );
 
             Assert.That(error.Message, Does.Contain("cannot replace a begun action"));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             Assert.That(handler.WasCalled, Is.False);
             Assert.That(
                 listener.Calls,
@@ -598,7 +619,7 @@ namespace Game.Rules.Runtime.Tests
             );
             return new InMemoryRulesStore(
                 new RulesStateSeed()
-                    .SeedActionEconomy(Actor, new ActionEconomyState(3, true))
+                    .SeedActionEconomy(Actor, new ActionEconomyState(3, ActionAllowance.None, true))
                     .SeedSpellSlot(new SpellSlotState(SpellPool, Actor, 2, 2))
                     .SeedFocusPoints(Actor, new FocusPointState(2, 3))
                     .SeedAmmunition(new AmmunitionState(Ammunition, Actor, 5))
@@ -676,13 +697,13 @@ namespace Game.Rules.Runtime.Tests
             )
             {
                 Cost = cost;
-                ActionsRemaining = actionsRemaining;
+                StandardActionsRemaining = actionsRemaining;
                 ReactionAvailable = reactionAvailable;
                 EmitsFact = emitsFact;
             }
 
             public ActionCost Cost { get; }
-            public int ActionsRemaining { get; }
+            public int StandardActionsRemaining { get; }
             public bool ReactionAvailable { get; }
             public bool EmitsFact { get; }
         }
@@ -799,7 +820,7 @@ namespace Game.Rules.Runtime.Tests
             )
             {
                 Calls++;
-                StartingActions = snapshot.ActionEconomy[action.Actor].ActionsRemaining;
+                StartingActions = snapshot.ActionEconomy[action.Actor].StandardActionsRemaining;
                 return effectiveProfile;
             }
         }
@@ -861,7 +882,7 @@ namespace Game.Rules.Runtime.Tests
 
             public bool WasCalled { get; private set; }
             public ActionProfile Profile { get; private set; }
-            public int ActionsRemaining { get; private set; }
+            public int StandardActionsRemaining { get; private set; }
             public int SpellSlotsRemaining { get; private set; }
             public int FocusPointsRemaining { get; private set; }
             public int AmmunitionRemaining { get; private set; }
@@ -874,11 +895,11 @@ namespace Game.Rules.Runtime.Tests
             {
                 WasCalled = true;
                 Profile = frame.ActionProfile;
-                ActionsRemaining = context.Snapshot.ActionEconomy.TryGet(
+                StandardActionsRemaining = context.Snapshot.ActionEconomy.TryGet(
                     Actor,
                     out ActionEconomyState economy
                 )
-                    ? economy.ActionsRemaining
+                    ? economy.StandardActionsRemaining
                     : -1;
                 SpellSlotsRemaining = context.Snapshot.SpellSlots.TryGet(
                     SpellPool,

--- a/Assets/Tests/EditMode/RulesRuntime/CastSpellRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/CastSpellRulesTests.cs
@@ -81,7 +81,10 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(catalog.SpellBookLookups, Is.Zero);
             Assert.That(store.Snapshot.Version, Is.EqualTo(initialVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.EqualTo(1));
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(store.Snapshot.ActionReceipts, Is.Empty);
@@ -118,7 +121,10 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<ResolvedOpResult<CastSpellOutcome>>());
             Assert.That(catalog.SpellBookLookups, Is.EqualTo(2));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             ActionProfile firstProfile = dispatcher
                 .Trace.OrderedFrames.Single(frame => frame.OpType == typeof(CastSpellActionOp))
                 .ActionProfile;
@@ -173,7 +179,10 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(catalog.SpellBookLookups, Is.EqualTo(1));
             Assert.That(store.Snapshot.Version, Is.EqualTo(initialVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(store.Snapshot.ActionReceipts, Is.Empty);
         }
@@ -200,7 +209,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(result, Is.TypeOf<ResolvedOpResult<CastSpellOutcome>>());
             CastSpellOutcome outcome = ((ResolvedOpResult<CastSpellOutcome>)result).Value;
             Assert.That(outcome.CreatedEffects, Has.Count.EqualTo(1));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             ActiveEffectInstance effect = store.Snapshot.ActiveEffects[
                 outcome.CreatedEffects.Single()
             ];
@@ -232,7 +244,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(((ResolvedOpResult<CastSpellOutcome>)exactRetry).Value, Is.SameAs(outcome));
             Assert.That(exactRetry.Facts, Is.Empty);
             Assert.That(store.Snapshot.Version, Is.EqualTo(committedVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.ActiveEffects, Has.Count.EqualTo(1));
             Assert.That(observer.Calls, Is.EqualTo(1));
         }
@@ -319,7 +334,10 @@ namespace Game.Rules.Runtime.Tests
                 await dispatcher.Dispatch(operation)
             );
 
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.Zero);
             Assert.That(
                 store.Snapshot.ActionReceipts[invocation],
@@ -369,7 +387,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(retry.Facts.OfType<ActionCostsCommittedFact>(), Is.Empty);
             Assert.That(retry.Facts.OfType<ActiveEffectRemovedFact>().Count(), Is.EqualTo(1));
             Assert.That(retry.Facts.OfType<ActiveEffectCreatedFact>().Count(), Is.EqualTo(1));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.Zero);
             Assert.That(
                 store.Snapshot.ActionReceipts[invocation],
@@ -434,7 +455,10 @@ namespace Game.Rules.Runtime.Tests
             );
 
             Assert.That(error.Message, Does.Contain("already exists"));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(
                 store.Snapshot.ActionReceipts[invocation],
                 Is.TypeOf<CostsCommittedActionReceipt>()
@@ -537,7 +561,10 @@ namespace Game.Rules.Runtime.Tests
             );
 
             Assert.That(error.Message, Does.Contain("active-instance invariant violated"));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.EqualTo(1));
             Assert.That(store.Snapshot.ActionReceipts.Contains(invocation), Is.False);
             Assert.That(MatchingLightEffects(store.Snapshot, Actor), Has.Count.EqualTo(5));
@@ -665,7 +692,10 @@ namespace Game.Rules.Runtime.Tests
                 Does.Contain(expectedReason)
             );
             Assert.That(store.Snapshot.Version, Is.EqualTo(initialVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(store.Snapshot.ActionReceipts, Is.Empty);
             Assert.That(result.Facts, Is.Empty);
@@ -688,7 +718,10 @@ namespace Game.Rules.Runtime.Tests
                 )
             );
             Assert.That(wrongRank, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(wrongRank.Facts, Is.Empty);
             Assert.That(typeof(CastSpellActionOp).GetProperty("Authorization"), Is.Null);
             Assert.That(typeof(CastSpellActionOp).GetProperty("SlotPool"), Is.Null);
@@ -710,9 +743,12 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(shortResult, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
             Assert.That(unprepared, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
-            Assert.That(shortStore.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
             Assert.That(
-                unpreparedStore.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                shortStore.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
+            Assert.That(
+                unpreparedStore.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(shortResult.Facts, Is.Empty);
@@ -736,7 +772,10 @@ namespace Game.Rules.Runtime.Tests
             );
 
             Assert.That(result, Is.TypeOf<ResolvedOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.Zero);
             Assert.That(result.Facts.OfType<ActionCostSpentFact>().Count(), Is.EqualTo(1));
             Assert.That(result.Facts.OfType<SpellSlotSpentFact>().Count(), Is.EqualTo(1));
@@ -751,7 +790,10 @@ namespace Game.Rules.Runtime.Tests
             OpResult<CastSpellOutcome> result = await dispatcher.Dispatch(Cast());
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.EqualTo(1));
             Assert.That(store.Snapshot.SpellSlots[AlternateRankedPool].Remaining, Is.EqualTo(1));
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
@@ -795,7 +837,10 @@ namespace Game.Rules.Runtime.Tests
             OpResult<CastSpellOutcome> result = await dispatcher.Dispatch(operation);
 
             Assert.That(result, Is.TypeOf<InterruptedOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.ActiveEffects.Count, Is.Zero);
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.Zero);
             Assert.That(result.Facts.OfType<ActionCostSpentFact>().Count(), Is.EqualTo(1));
@@ -846,7 +891,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(retry, Is.TypeOf<InterruptedOpResult<CastSpellOutcome>>());
             Assert.That(retry.Facts, Is.Empty);
             Assert.That(store.Snapshot.Version, Is.EqualTo(interruptedVersion));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.SpellSlots[RankedPool].Remaining, Is.Zero);
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(middleware.Calls, Is.EqualTo(1));
@@ -898,7 +946,10 @@ namespace Game.Rules.Runtime.Tests
             {
                 seed.SeedCreature(new CreatureState(OtherActor, OtherPlayer))
                     .SeedHealth(OtherActor, new HealthState(10, 10))
-                    .SeedActionEconomy(OtherActor, new ActionEconomyState(3, true))
+                    .SeedActionEconomy(
+                        OtherActor,
+                        new ActionEconomyState(3, ActionAllowance.None, true)
+                    )
                     .SeedStatistics(CreatureStatisticsState.Empty(OtherActor));
             }
             foreach (
@@ -917,7 +968,10 @@ namespace Game.Rules.Runtime.Tests
             new RulesStateSeed()
                 .SeedCreature(new CreatureState(Actor, Player))
                 .SeedHealth(Actor, new HealthState(10, 10))
-                .SeedActionEconomy(Actor, new ActionEconomyState(actions, true))
+                .SeedActionEconomy(
+                    Actor,
+                    new ActionEconomyState(actions, ActionAllowance.None, true)
+                )
                 .SeedStatistics(CreatureStatisticsState.Empty(Actor));
 
         private static ActiveEffectRegistration[] CreateFourMatchingLightRegistrations() =>
@@ -1073,7 +1127,10 @@ namespace Game.Rules.Runtime.Tests
                 );
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(result.Facts, Is.Empty);
         }

--- a/Assets/Tests/EditMode/RulesRuntime/ConditionAuthoritativeRuntimeTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/ConditionAuthoritativeRuntimeTests.cs
@@ -853,6 +853,8 @@ namespace Game.Rules.Runtime.Tests
                 3
             );
             RulesStateSeed restrictedSeed = new RulesStateSeed()
+                .SeedCreature(new CreatureState(Owner, new PlayerId("condition-owner-player")))
+                .SeedPreparedInputs(Owner, PreparedCreatureInputs.Empty)
                 .SeedActiveEffect(stride.Effect)
                 .SeedRuleBinding(stride.Binding)
                 .SeedActiveEffect(strike.Effect)

--- a/Assets/Tests/EditMode/RulesRuntime/ConditionAuthoritativeRuntimeTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/ConditionAuthoritativeRuntimeTests.cs
@@ -826,6 +826,67 @@ namespace Game.Rules.Runtime.Tests
         }
 
         [Test]
+        public void QuickenedAllowanceSelectorUnionsSourcesAndUnrestrictedDominates()
+        {
+            ActiveEffectRegistration stride = Registration(
+                "quickened-stride",
+                Owner,
+                ConditionRuleDefinitions.Quickened,
+                RuleSource.FromSlug("stride-source"),
+                new QuickenedConditionState(new[] { new ActionDefinitionId("stride") }),
+                2
+            );
+            ActiveEffectRegistration strike = Registration(
+                "quickened-strike",
+                Owner,
+                ConditionRuleDefinitions.Quickened,
+                RuleSource.FromSlug("strike-source"),
+                new QuickenedConditionState(new[] { new ActionDefinitionId("strike") }),
+                1
+            );
+            ActiveEffectRegistration unrestricted = Registration(
+                "quickened-unrestricted",
+                Owner,
+                ConditionRuleDefinitions.Quickened,
+                RuleSource.FromSlug("unrestricted-source"),
+                QuickenedConditionState.Unrestricted,
+                3
+            );
+            RulesStateSeed restrictedSeed = new RulesStateSeed()
+                .SeedActiveEffect(stride.Effect)
+                .SeedRuleBinding(stride.Binding)
+                .SeedActiveEffect(strike.Effect)
+                .SeedRuleBinding(strike.Binding);
+
+            Assert.That(
+                ConditionSelectors.GetQuickenedAllowance(new InMemoryRulesStore().Snapshot, Owner),
+                Is.SameAs(ActionAllowance.None)
+            );
+            Assert.That(
+                ConditionSelectors.GetQuickenedAllowance(
+                    new InMemoryRulesStore(restrictedSeed).Snapshot,
+                    Owner
+                ),
+                Is.EqualTo(
+                    ActionAllowance.Restricted(
+                        new[] { new ActionDefinitionId("stride"), new ActionDefinitionId("strike") }
+                    )
+                )
+            );
+
+            restrictedSeed
+                .SeedActiveEffect(unrestricted.Effect)
+                .SeedRuleBinding(unrestricted.Binding);
+            Assert.That(
+                ConditionSelectors.GetQuickenedAllowance(
+                    new InMemoryRulesStore(restrictedSeed).Snapshot,
+                    Owner
+                ),
+                Is.SameAs(ActionAllowance.Unrestricted)
+            );
+        }
+
+        [Test]
         public async Task StunnedQuickenedAndMarkerSelectorsComposeActiveSources()
         {
             InMemoryRulesStore store = CreateStoreWithRegisteredCreatures();
@@ -869,7 +930,7 @@ namespace Game.Rules.Runtime.Tests
             );
 
             ConditionSelectors.TryGetStunned(store.Snapshot, Owner, out stunned);
-            QuickenedAllowance restricted = ConditionSelectors.GetQuickenedAllowance(
+            ActionAllowance restricted = ConditionSelectors.GetQuickenedAllowance(
                 store.Snapshot,
                 Owner
             );

--- a/Assets/Tests/EditMode/RulesRuntime/ConditionContractTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/ConditionContractTests.cs
@@ -7,6 +7,113 @@ namespace Game.Rules.Runtime.Tests
 {
     public sealed class ConditionContractTests
     {
+        [Test]
+        public void ActionAllowanceRequiresValidRestrictedDefinitionsAndCopiesInput()
+        {
+            ActionDefinitionId stride = new ActionDefinitionId("stride");
+            List<ActionDefinitionId> input = new List<ActionDefinitionId> { stride };
+
+            ActionAllowance allowance = ActionAllowance.Restricted(input);
+            input.Clear();
+
+            Assert.That(allowance.AllowedActions, Is.EqualTo(new[] { stride }));
+            Assert.That(allowance.IsRestricted, Is.True);
+            Assert.That(allowance.Allows(stride), Is.True);
+            Assert.That(allowance.Allows(new ActionDefinitionId("strike")), Is.False);
+            Assert.That(ActionAllowance.None.IsNone, Is.True);
+            Assert.That(ActionAllowance.None.Allows(stride), Is.False);
+            Assert.That(ActionAllowance.Unrestricted.Allows(stride), Is.True);
+            Assert.Throws<ArgumentNullException>(() => ActionAllowance.Restricted(null));
+            Assert.Throws<ArgumentException>(() =>
+                ActionAllowance.Restricted(Array.Empty<ActionDefinitionId>())
+            );
+            Assert.Throws<ArgumentException>(() =>
+                ActionAllowance.Restricted(new[] { default(ActionDefinitionId) })
+            );
+            Assert.Throws<ArgumentException>(() => allowance.Allows(default));
+            Assert.Throws<ArgumentNullException>(() => allowance.Allows(stride, null));
+            Assert.Throws<NotSupportedException>(() =>
+                ((IList<ActionDefinitionId>)allowance.AllowedActions).Add(
+                    new ActionDefinitionId("step")
+                )
+            );
+        }
+
+        [Test]
+        public void RestrictedActionAllowancePaysOnlyAnAllowedSingleAction()
+        {
+            ActionDefinitionId stride = new ActionDefinitionId("stride");
+            ActionAllowance allowance = ActionAllowance.Restricted(new[] { stride });
+
+            Assert.That(
+                allowance.Allows(stride, ActionProfile.OneAction(Array.Empty<Trait>())),
+                Is.True
+            );
+            Assert.That(
+                allowance.Allows(
+                    stride,
+                    ActionProfile.Create(ActionCost.Two, Array.Empty<Trait>())
+                ),
+                Is.False
+            );
+            Assert.That(
+                allowance.Allows(
+                    stride,
+                    ActionProfile.Create(ActionCost.Three, Array.Empty<Trait>())
+                ),
+                Is.False
+            );
+            Assert.That(
+                allowance.Allows(
+                    new ActionDefinitionId("activity-containing-stride"),
+                    ActionProfile.OneAction(Array.Empty<Trait>())
+                ),
+                Is.False
+            );
+        }
+
+        [Test]
+        public void ActionAllowanceCanonicalOrderingDefinesEqualityAndHashing()
+        {
+            ActionDefinitionId stride = new ActionDefinitionId("stride");
+            ActionDefinitionId strike = new ActionDefinitionId("strike");
+            ActionAllowance first = ActionAllowance.Restricted(new[] { strike, stride, strike });
+            ActionAllowance second = ActionAllowance.Restricted(new[] { stride, strike });
+
+            Assert.That(first.AllowedActions, Is.EqualTo(new[] { stride, strike }));
+            Assert.That(first, Is.EqualTo(second));
+            Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+            Assert.That(first == second, Is.True);
+            Assert.That(first, Is.Not.EqualTo(ActionAllowance.None));
+            Assert.That(ActionAllowance.None, Is.Not.EqualTo(ActionAllowance.Unrestricted));
+        }
+
+        [Test]
+        public void ActionAllowanceUnionCombinesRestrictionsAndUnrestrictedDominates()
+        {
+            ActionAllowance stride = ActionAllowance.Restricted(
+                new[] { new ActionDefinitionId("stride") }
+            );
+            ActionAllowance strike = ActionAllowance.Restricted(
+                new[] { new ActionDefinitionId("strike") }
+            );
+            ActionAllowance combined = stride.Union(strike);
+
+            Assert.That(
+                combined.AllowedActions,
+                Is.EqualTo(
+                    new[] { new ActionDefinitionId("stride"), new ActionDefinitionId("strike") }
+                )
+            );
+            Assert.That(ActionAllowance.None.Union(stride), Is.SameAs(stride));
+            Assert.That(stride.Union(ActionAllowance.None), Is.SameAs(stride));
+            Assert.That(
+                combined.Union(ActionAllowance.Unrestricted),
+                Is.SameAs(ActionAllowance.Unrestricted)
+            );
+            Assert.Throws<ArgumentNullException>(() => stride.Union(null));
+        }
+
         [TestCase("Off-Guard", "condition-off-guard")]
         [TestCase("off guard", "condition-off-guard")]
         [TestCase("Flat-Footed", "condition-off-guard")]
@@ -122,6 +229,10 @@ namespace Game.Rules.Runtime.Tests
             QuickenedConditionState state = new QuickenedConditionState(input);
             input.Clear();
 
+            Assert.That(
+                state.Allowance,
+                Is.EqualTo(ActionAllowance.Restricted(new[] { strike, stride }))
+            );
             Assert.That(state.AllowedActions, Is.EqualTo(new[] { stride, strike }));
             Assert.That(state.Allows(stride), Is.True);
             Assert.That(state.Allows(new ActionDefinitionId("cast-spell")), Is.False);

--- a/Assets/Tests/EditMode/RulesRuntime/EncounterRuntimeTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/EncounterRuntimeTests.cs
@@ -280,7 +280,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(begun.CurrentTurn.Value.Actor, Is.EqualTo(Hero));
             Assert.That(begun.IsTurnStartPending, Is.False);
             Assert.That(begun.TurnStartAdapterProgress, Is.Null);
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Hero].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Hero].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(first.Calls, Is.EqualTo(1));
             Assert.That(second.Calls, Is.EqualTo(2));
             Assert.That(third.Actors, Is.EqualTo(new[] { Hero }));
@@ -516,7 +519,7 @@ namespace Game.Rules.Runtime.Tests
         }
 
         [Test]
-        public async Task TurnStartClearsStaleMovementThenEndTurnResetsActionsMapAndWrapsRoundOnce()
+        public async Task TurnStartClearsStaleMovementThenEndTurnResetsMapAndWrapsRoundOnce()
         {
             MovementBudgetState budget = new MovementBudgetState(
                 new MovementBudgetId(new OpId(99)),
@@ -544,7 +547,6 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(dispatcher.Snapshot.MovementBudgets.Contains(Hero), Is.False);
             Assert.That(movementResets.Calls, Is.EqualTo(1));
             await dispatcher.Dispatch(new AdvanceMultipleAttackPenaltyOp(Hero));
-            await dispatcher.Dispatch(new SpendEncounterActionsOp(Hero, 1));
 
             EncounterState enemyTurn = Resolved(
                 await dispatcher.Dispatch(new EndTurnOp(started.CurrentTurn.Value))
@@ -557,7 +559,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(secondHeroTurn.CurrentTurn.Value.Actor, Is.EqualTo(Hero));
             Assert.That(
                 dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(3, true))
+                Is.EqualTo(new ActionEconomyState(3, ActionAllowance.None, true))
             );
             Assert.That(dispatcher.Snapshot.MultipleAttackPenalty[Hero].AttackCount, Is.Zero);
             Assert.That(dispatcher.Snapshot.MovementBudgets.Contains(Hero), Is.False);
@@ -576,7 +578,7 @@ namespace Game.Rules.Runtime.Tests
             );
             RulesStateSeed seed = BaseSeed()
                 .SeedEncounter(active)
-                .SeedActionEconomy(Hero, new ActionEconomyState(3, true))
+                .SeedActionEconomy(Hero, new ActionEconomyState(3, ActionAllowance.None, true))
                 .SeedMultipleAttackPenalty(Hero, new MultipleAttackPenaltyState(1))
                 .SeedMovementBudget(Hero, budget);
             RuleDispatcher dispatcher = CreateDispatcher(new ScriptedRollService(), seed);
@@ -588,96 +590,6 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(dispatcher.Snapshot.MovementBudgets.Contains(Hero), Is.False);
             Assert.That(movementResets.Calls, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task ZeroCostActionAuthorizationRequiresExactTurnWithoutSpendMutation()
-        {
-            RuleDispatcher dispatcher = CreateDispatcher(new ScriptedRollService(20, 10));
-            CountingFactObserver<EncounterActionsSpentFact> spends =
-                new CountingFactObserver<EncounterActionsSpentFact>();
-            dispatcher.RegisterFactObserver<EncounterActionsSpentFact>(spends);
-            EncounterState started = Resolved(
-                await dispatcher.Dispatch(
-                    Start(
-                        new EncounterParticipant(Hero, Players, 0),
-                        new EncounterParticipant(Enemy, Enemies, 0)
-                    )
-                )
-            ).Value.State;
-
-            EncounterActionSpendOutcome authorized = Resolved(
-                await dispatcher.Dispatch(new SpendEncounterActionsOp(Hero, 0))
-            ).Value;
-
-            Assert.That(authorized.Remaining, Is.EqualTo(3));
-            Assert.That(
-                dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(3, true))
-            );
-            Assert.That(spends.Calls, Is.Zero);
-
-            EncounterState advanced = Resolved(
-                await dispatcher.Dispatch(new EndTurnOp(started.CurrentTurn.Value))
-            ).Value.State;
-            InvalidOperationException rejected = Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                    await dispatcher.Dispatch(new SpendEncounterActionsOp(Hero, 0))
-            );
-
-            Assert.That(rejected.Message, Does.Contain("does not own an active current turn"));
-            Assert.That(advanced.CurrentTurn.Value.Actor, Is.EqualTo(Enemy));
-            Assert.That(spends.Calls, Is.Zero);
-        }
-
-        [Test]
-        public async Task TargetAwareActionSpendRejectsAnyCommittedDefeatAtomically()
-        {
-            RuleDispatcher dispatcher = CreateDispatcher(new ScriptedRollService(20, 10, 5));
-            CountingFactObserver<EncounterActionsSpentFact> spends =
-                new CountingFactObserver<EncounterActionsSpentFact>();
-            dispatcher.RegisterFactObserver<EncounterActionsSpentFact>(spends);
-            await dispatcher.Dispatch(
-                Start(
-                    new EncounterParticipant(Hero, Players, 0),
-                    new EncounterParticipant(Enemy, Enemies, 0),
-                    new EncounterParticipant(Reinforcement, Enemies, 0)
-                )
-            );
-            await dispatcher.Dispatch(
-                new ApplyDamageOp(
-                    Enemy,
-                    10,
-                    new HealthChangeOriginId("target-aware-defeat"),
-                    Source
-                )
-            );
-
-            InvalidOperationException rejected = Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                    await dispatcher.Dispatch(
-                        new SpendEncounterActionsOp(
-                            Hero,
-                            1,
-                            new[] { Reinforcement, Enemy, Reinforcement }
-                        )
-                    )
-            );
-
-            Assert.That(rejected.Message, Does.Contain("no longer a living participant"));
-            Assert.That(
-                dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(3, true))
-            );
-            Assert.That(spends.Calls, Is.Zero);
-
-            EncounterActionSpendOutcome livingTargetSpend = Resolved(
-                await dispatcher.Dispatch(
-                    new SpendEncounterActionsOp(Hero, 1, new[] { Reinforcement })
-                )
-            ).Value;
-            Assert.That(livingTargetSpend.Remaining, Is.EqualTo(2));
-            Assert.That(spends.Calls, Is.EqualTo(1));
         }
 
         [Test]
@@ -777,7 +689,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(observer.ActionsAtFact, Is.EqualTo(3));
             Assert.That(
                 dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(3, true))
+                Is.EqualTo(new ActionEconomyState(3, ActionAllowance.None, true))
             );
         }
 
@@ -926,7 +838,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(dispatcher.Snapshot.Health[Hero].Current, Is.EqualTo(1));
             Assert.That(
                 dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(0, false))
+                Is.EqualTo(new ActionEconomyState(0, ActionAllowance.None, false))
             );
             Assert.That(state.Phase, Is.EqualTo(EncounterPhase.Active));
             Assert.That(state.Outcome, Is.Null);
@@ -1120,7 +1032,10 @@ namespace Game.Rules.Runtime.Tests
                     seed.SeedLandSpeed(Reinforcement, new GridDistance(30));
                     break;
                 case JoinRegistrationCollision.ActionEconomy:
-                    seed.SeedActionEconomy(Reinforcement, new ActionEconomyState(2, true));
+                    seed.SeedActionEconomy(
+                        Reinforcement,
+                        new ActionEconomyState(2, ActionAllowance.None, true)
+                    );
                     break;
                 case JoinRegistrationCollision.MultipleAttackPenalty:
                     seed.SeedMultipleAttackPenalty(
@@ -2316,7 +2231,7 @@ namespace Game.Rules.Runtime.Tests
             RulesStateSeed seed = BaseSeed()
                 .SeedHealth(Hero, new HealthState(0, 10))
                 .SeedHealth(Enemy, new HealthState(0, 10))
-                .SeedActionEconomy(Hero, new ActionEconomyState(0, false))
+                .SeedActionEconomy(Hero, new ActionEconomyState(0, ActionAllowance.None, false))
                 .SeedMultipleAttackPenalty(Hero, new MultipleAttackPenaltyState(0))
                 .SeedEncounter(active);
             RuleDispatcher dispatcher = CreateDispatcher(new ScriptedRollService(), seed);
@@ -2358,7 +2273,7 @@ namespace Game.Rules.Runtime.Tests
             if (omitActionEconomy)
                 seed.SeedMultipleAttackPenalty(Hero, new MultipleAttackPenaltyState(0));
             else
-                seed.SeedActionEconomy(Hero, new ActionEconomyState(3, true));
+                seed.SeedActionEconomy(Hero, new ActionEconomyState(3, ActionAllowance.None, true));
             RuleDispatcher dispatcher = CreateDispatcher(new ScriptedRollService(), seed);
             RulesSnapshot before = dispatcher.Snapshot;
 
@@ -3524,7 +3439,7 @@ namespace Game.Rules.Runtime.Tests
 
             public ValueTask OnFactCommitted(TurnBeganFact fact, RulesSnapshot snapshot)
             {
-                ActionsAtFact = snapshot.ActionEconomy[fact.Turn.Actor].ActionsRemaining;
+                ActionsAtFact = snapshot.ActionEconomy[fact.Turn.Actor].StandardActionsRemaining;
                 order.Add("fact");
                 return default;
             }

--- a/Assets/Tests/EditMode/RulesRuntime/EncounterRuntimeTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/EncounterRuntimeTests.cs
@@ -136,10 +136,7 @@ namespace Game.Rules.Runtime.Tests
                 1,
                 null,
                 isTurnStartPending: true,
-                turnStartAdapterProgress: new TurnStartAdapterProgress(
-                    1,
-                    new TurnStartContribution(2)
-                )
+                turnStartAdapterProgress: new TurnStartAdapterProgress(1)
             );
 
             RulesSnapshot snapshot = new InMemoryRulesStore(
@@ -251,13 +248,9 @@ namespace Game.Rules.Runtime.Tests
                 null,
                 isTurnStartPending: true
             );
-            DamageAndContributionTurnStartAdapter first = new DamageAndContributionTurnStartAdapter(
-                Hero,
-                1,
-                2
-            );
+            DamageTurnStartAdapter first = new DamageTurnStartAdapter(Hero, 1);
             ThrowOnceTurnStartAdapter second = new ThrowOnceTurnStartAdapter();
-            RecordingTurnStartAdapter third = new RecordingTurnStartAdapter("third", actions: 1);
+            RecordingTurnStartAdapter third = new RecordingTurnStartAdapter("third");
             RuleDispatcher dispatcher = CreateDispatcher(
                 new ScriptedRollService(),
                 BaseSeed().SeedEncounter(pending),
@@ -274,7 +267,6 @@ namespace Game.Rules.Runtime.Tests
             EncounterState checkpoint = dispatcher.Snapshot.Encounters[Encounter];
             Assert.That(checkpoint.IsTurnStartPending, Is.True);
             Assert.That(checkpoint.TurnStartAdapterProgress.NextAdapterIndex, Is.EqualTo(1));
-            Assert.That(checkpoint.TurnStartAdapterProgress.Contribution.Actions, Is.EqualTo(2));
             Assert.That(dispatcher.Snapshot.Health[Hero].Current, Is.EqualTo(9));
             Assert.That(first.Calls, Is.EqualTo(1));
             Assert.That(second.Calls, Is.EqualTo(1));
@@ -288,7 +280,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(begun.CurrentTurn.Value.Actor, Is.EqualTo(Hero));
             Assert.That(begun.IsTurnStartPending, Is.False);
             Assert.That(begun.TurnStartAdapterProgress, Is.Null);
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Hero].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(dispatcher.Snapshot.ActionEconomy[Hero].ActionsRemaining, Is.EqualTo(3));
             Assert.That(first.Calls, Is.EqualTo(1));
             Assert.That(second.Calls, Is.EqualTo(2));
             Assert.That(third.Actors, Is.EqualTo(new[] { Hero }));
@@ -346,7 +338,6 @@ namespace Game.Rules.Runtime.Tests
         [TestCase("slot")]
         [TestCase("actor")]
         [TestCase("index")]
-        [TestCase("contribution")]
         public async Task TurnStartProgressReducerRejectsEveryExactMismatchWithoutMutation(
             string mismatch
         )
@@ -373,11 +364,7 @@ namespace Game.Rules.Runtime.Tests
                 mismatch == "round" ? RoundNumber.First.Next() : RoundNumber.First,
                 mismatch == "slot" ? 1 : 0,
                 mismatch == "actor" ? Enemy : Hero,
-                mismatch == "index" ? 1 : 0,
-                mismatch == "contribution"
-                    ? new TurnStartContribution(2)
-                    : TurnStartContribution.Standard,
-                new TurnStartContribution(2)
+                mismatch == "index" ? 1 : 0
             );
 
             OpResult<TurnStartAdapterProgress> result = Resolved(
@@ -764,7 +751,7 @@ namespace Game.Rules.Runtime.Tests
         }
 
         [Test]
-        public async Task OrderedStartAdaptersSetFinalActionsBeforeTurnBeganFact()
+        public async Task OrderedStartAdaptersCompleteBeforeStandardTurnBeganFact()
         {
             List<string> order = new List<string>();
             RuleDispatcher dispatcher = CreateDispatcher(
@@ -773,7 +760,7 @@ namespace Game.Rules.Runtime.Tests
                 {
                     new RecordingTurnStartAdapter("spell", order),
                     new RecordingTurnStartAdapter("aura", order),
-                    new RecordingTurnStartAdapter("slowed", order, 2),
+                    new RecordingTurnStartAdapter("last", order),
                 }
             );
             TurnBeganSnapshotObserver observer = new TurnBeganSnapshotObserver(order);
@@ -786,11 +773,11 @@ namespace Game.Rules.Runtime.Tests
                 )
             );
 
-            Assert.That(order, Is.EqualTo(new[] { "spell", "aura", "slowed", "fact" }));
-            Assert.That(observer.ActionsAtFact, Is.EqualTo(2));
+            Assert.That(order, Is.EqualTo(new[] { "spell", "aura", "last", "fact" }));
+            Assert.That(observer.ActionsAtFact, Is.EqualTo(3));
             Assert.That(
                 dispatcher.Snapshot.ActionEconomy[Hero],
-                Is.EqualTo(new ActionEconomyState(2, true))
+                Is.EqualTo(new ActionEconomyState(3, true))
             );
         }
 
@@ -3343,32 +3330,21 @@ namespace Game.Rules.Runtime.Tests
         {
             private readonly string label;
             private readonly IList<string> order;
-            private readonly int? actions;
             private readonly List<CreatureId> actors = new List<CreatureId>();
 
-            public RecordingTurnStartAdapter(
-                string label,
-                IList<string> order = null,
-                int? actions = null
-            )
+            public RecordingTurnStartAdapter(string label, IList<string> order = null)
             {
                 this.label = label;
                 this.order = order;
-                this.actions = actions;
             }
 
             public IReadOnlyList<CreatureId> Actors => actors;
 
-            public ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public ValueTask Apply(EncounterTurnStartContext context)
             {
                 actors.Add(context.Actor);
                 order?.Add(label);
-                return new ValueTask<TurnStartContribution>(
-                    actions.HasValue ? new TurnStartContribution(actions.Value) : current
-                );
+                return default;
             }
         }
 
@@ -3380,55 +3356,57 @@ namespace Game.Rules.Runtime.Tests
 
             public int Calls { get; private set; }
 
-            public async ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public async ValueTask Apply(EncounterTurnStartContext context)
             {
                 if (context.Actor != target)
-                    return current;
+                    return;
                 Calls++;
                 HealthState health = context.Snapshot.Health[context.Actor];
-                await context.ApplyFinalDamage(
-                    context.Actor,
-                    health.Current + health.Temporary,
-                    new HealthChangeOriginId("lethal-turn-start"),
-                    Source
+                await context.CommitFinalDamageBatchAndCompleteAdapter(
+                    new[]
+                    {
+                        new HealthBatchChange(
+                            HealthBatchChangeKind.Damage,
+                            context.Actor,
+                            health.Current + health.Temporary,
+                            new HealthChangeOriginId("lethal-turn-start"),
+                            Source
+                        ),
+                    }
                 );
-                return current;
             }
         }
 
-        private sealed class DamageAndContributionTurnStartAdapter : IEncounterTurnStartAdapter
+        private sealed class DamageTurnStartAdapter : IEncounterTurnStartAdapter
         {
             private readonly CreatureId actor;
             private readonly int damage;
-            private readonly int actions;
 
-            public DamageAndContributionTurnStartAdapter(CreatureId actor, int damage, int actions)
+            public DamageTurnStartAdapter(CreatureId actor, int damage)
             {
                 this.actor = actor;
                 this.damage = damage;
-                this.actions = actions;
             }
 
             public int Calls { get; private set; }
 
-            public async ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public async ValueTask Apply(EncounterTurnStartContext context)
             {
                 if (context.Actor != actor)
-                    return current;
+                    return;
                 Calls++;
-                await context.ApplyFinalDamage(
-                    actor,
-                    damage,
-                    new HealthChangeOriginId("turn-start-progress-damage"),
-                    Source
+                await context.CommitFinalDamageBatchAndCompleteAdapter(
+                    new[]
+                    {
+                        new HealthBatchChange(
+                            HealthBatchChangeKind.Damage,
+                            actor,
+                            damage,
+                            new HealthChangeOriginId("turn-start-progress-damage"),
+                            Source
+                        ),
+                    }
                 );
-                return new TurnStartContribution(actions);
             }
         }
 
@@ -3436,15 +3414,12 @@ namespace Game.Rules.Runtime.Tests
         {
             public int Calls { get; private set; }
 
-            public ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public ValueTask Apply(EncounterTurnStartContext context)
             {
                 Calls++;
                 if (Calls == 1)
                     throw new InvalidOperationException("Injected turn-start adapter failure.");
-                return new ValueTask<TurnStartContribution>(current);
+                return default;
             }
         }
 

--- a/Assets/Tests/EditMode/RulesRuntime/MovementPathRuleTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/MovementPathRuleTests.cs
@@ -617,7 +617,7 @@ namespace Game.Rules.Runtime.Tests
                 new RulesStateSeed()
                     .SeedPosition(Mover, origin)
                     .SeedMovementBudget(Mover, budget)
-                    .SeedActionEconomy(Mover, new ActionEconomyState(2, true))
+                    .SeedActionEconomy(Mover, new ActionEconomyState(2, ActionAllowance.None, true))
             );
             RuleDispatcher dispatcher = CreateDispatcher(
                 store,
@@ -635,7 +635,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(store.Snapshot.MovementBudgets[Mover], Is.EqualTo(budget));
             Assert.That(
                 store.Snapshot.ActionEconomy[Mover],
-                Is.EqualTo(new ActionEconomyState(2, true))
+                Is.EqualTo(new ActionEconomyState(2, ActionAllowance.None, true))
             );
             Assert.That(fact.OriginOpId, Is.EqualTo(fact.RootOpId));
             Assert.That(fact.Kind, Is.EqualTo(RelocationKind.FromSlug("test-relocation")));
@@ -769,7 +769,7 @@ namespace Game.Rules.Runtime.Tests
         {
             RulesStateSeed seed = new RulesStateSeed()
                 .SeedPosition(Mover, moverPosition)
-                .SeedActionEconomy(Mover, new ActionEconomyState(3, true));
+                .SeedActionEconomy(Mover, new ActionEconomyState(3, ActionAllowance.None, true));
             if (!budgetId.IsEmpty)
             {
                 seed.SeedMovementBudget(

--- a/Assets/Tests/EditMode/RulesRuntime/MovementPermissionTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/MovementPermissionTests.cs
@@ -728,7 +728,7 @@ namespace Game.Rules.Runtime.Tests
                 .SeedPosition(Mover, Origin)
                 .SeedPosition(Occupant, Occupied)
                 .SeedPosition(OtherOccupant, new GridPosition(4, 0, 4))
-                .SeedActionEconomy(Mover, new ActionEconomyState(3, true));
+                .SeedActionEconomy(Mover, new ActionEconomyState(3, ActionAllowance.None, true));
             if (seedMiddleware)
             {
                 seed.SeedRuleBinding(

--- a/Assets/Tests/EditMode/RulesRuntime/RageRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/RageRulesTests.cs
@@ -382,7 +382,10 @@ namespace Game.Tests.EditMode.RulesRuntime
             );
 
             Assert.That(RageRules.IsRaging(dispatcher.Snapshot, Actor), Is.True);
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             Assert.That(dispatcher.Snapshot.Health[Actor].Temporary, Is.EqualTo(3));
             Assert.That(
                 dispatcher.Snapshot.Health[Actor].TemporarySource,
@@ -402,7 +405,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 new RageActionOp(Actor)
             );
             Assert.That(duplicate, Is.TypeOf<InvalidOpResult<RageStartOutcome>>());
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
         }
 
         [Test]
@@ -587,8 +593,14 @@ namespace Game.Tests.EditMode.RulesRuntime
                 await unowned.Dispatch(new RageActionOp(Actor)),
                 Is.TypeOf<InvalidOpResult<RageStartOutcome>>()
             );
-            Assert.That(fatigued.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
-            Assert.That(unowned.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                fatigued.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
+            Assert.That(
+                unowned.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
         }
 
         [Test]
@@ -618,7 +630,10 @@ namespace Game.Tests.EditMode.RulesRuntime
             );
 
             Assert.That(RageRules.IsRaging(allowed.Snapshot, Actor), Is.True);
-            Assert.That(allowed.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                allowed.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(RageRules.IsRaging(encumbered.Snapshot, Actor), Is.False);
             Assert.That(RageRules.IsRaging(heavy.Snapshot, Actor), Is.False);
             Assert.That(RageRules.IsRaging(armoredException.Snapshot, Actor), Is.True);
@@ -633,7 +648,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 await allowed.Dispatch(new RageActionOp(Actor)),
                 Is.TypeOf<ResolvedOpResult<RageStartOutcome>>()
             );
-            Assert.That(allowed.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                allowed.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
         }
 
         [Test]
@@ -1785,12 +1803,18 @@ namespace Game.Tests.EditMode.RulesRuntime
             );
             RuleDispatcher dispatcher = CreateDispatcher(provider);
             await dispatcher.Dispatch(new RageActionOp(Actor));
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
 
             ResolvedOpResult<RageEndOutcome> ended = RequireResolved(
                 await dispatcher.Dispatch(new EndRageOp(Actor))
             );
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             ResolvedOpResult<RageStartOutcome> restarted = RequireResolved(
                 await dispatcher.Dispatch(new RageActionOp(Actor))
             );
@@ -2167,7 +2191,7 @@ namespace Game.Tests.EditMode.RulesRuntime
                 .SeedCreature(new CreatureState(Enemy, Opposition))
                 .SeedHealth(Actor, actorHealth ?? new HealthState(10, 10))
                 .SeedHealth(Enemy, new HealthState(10, 10))
-                .SeedActionEconomy(Actor, new ActionEconomyState(3, true));
+                .SeedActionEconomy(Actor, new ActionEconomyState(3, ActionAllowance.None, true));
             SeedPreparedActor(seed, registryBuilder, Actor, provider.State);
             foreach (
                 ActiveRuleBinding binding in RageRules.CreateInitialBindings(Actor, provider.State)
@@ -2356,7 +2380,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 seed.SeedCreature(new CreatureState(pair.Key, player))
                     .SeedPreparedInputs(pair.Key, PreparedInputsFor(pair.Value))
                     .SeedHealth(pair.Key, new HealthState(10, 10))
-                    .SeedActionEconomy(pair.Key, new ActionEconomyState(3, true))
+                    .SeedActionEconomy(
+                        pair.Key,
+                        new ActionEconomyState(3, ActionAllowance.None, true)
+                    )
                     .SeedMultipleAttackPenalty(pair.Key, new MultipleAttackPenaltyState(0));
                 foreach (
                     ActiveRuleBinding binding in RageRules.CreateInitialBindings(

--- a/Assets/Tests/EditMode/RulesRuntime/RageRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/RageRulesTests.cs
@@ -3518,15 +3518,12 @@ namespace Game.Tests.EditMode.RulesRuntime
             internal IReadOnlyList<bool> ObservedRaging => observedRaging;
             internal IReadOnlyList<bool> ObservedRageState => observedRageState;
 
-            public ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public ValueTask Apply(EncounterTurnStartContext context)
             {
                 observedActors.Add(context.Actor);
                 observedRaging.Add(RageRules.IsRaging(context.Snapshot, context.Actor));
                 observedRageState.Add(HasOwnedRageState(context.Snapshot, context.Actor));
-                return new ValueTask<TurnStartContribution>(current);
+                return default;
             }
         }
 
@@ -4042,17 +4039,14 @@ namespace Game.Tests.EditMode.RulesRuntime
             public bool WasRaging { get; private set; }
             public int TemporaryHitPoints { get; private set; } = -1;
 
-            public ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public ValueTask Apply(EncounterTurnStartContext context)
             {
                 if (context.Actor != actor)
-                    return new ValueTask<TurnStartContribution>(current);
+                    return default;
                 Calls++;
                 WasRaging = RageRules.IsRaging(context.Snapshot, actor);
                 TemporaryHitPoints = context.Snapshot.Health[actor].Temporary;
-                return new ValueTask<TurnStartContribution>(current);
+                return default;
             }
         }
 
@@ -4068,25 +4062,28 @@ namespace Game.Tests.EditMode.RulesRuntime
 
             public void Enable() => enabled = true;
 
-            public async ValueTask<TurnStartContribution> Apply(
-                EncounterTurnStartContext context,
-                TurnStartContribution current
-            )
+            public async ValueTask Apply(EncounterTurnStartContext context)
             {
                 if (!enabled || context.Actor != actor)
-                    return current;
+                    return;
                 ActorTurnCalls++;
                 if (ActorTurnCalls != 10)
-                    return current;
+                    return;
 
                 TemporaryHitPointsBeforeDamage = context.Snapshot.Health[actor].Temporary;
-                await context.ApplyFinalDamage(
-                    actor,
-                    1,
-                    new HealthChangeOriginId("rage-expiration-turn-start"),
-                    RuleSource.FromSlug("rage-expiration-turn-start-test")
+                RuleSource source = RuleSource.FromSlug("rage-expiration-turn-start-test");
+                await context.CommitFinalDamageBatchAndCompleteAdapter(
+                    new[]
+                    {
+                        new HealthBatchChange(
+                            HealthBatchChangeKind.Damage,
+                            actor,
+                            1,
+                            new HealthChangeOriginId("rage-expiration-turn-start"),
+                            source
+                        ),
+                    }
                 );
-                return current;
             }
         }
     }

--- a/Assets/Tests/EditMode/RulesRuntime/RulesRuntimeTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/RulesRuntimeTests.cs
@@ -56,17 +56,41 @@ namespace Game.Rules.Runtime.Tests
         }
 
         [Test]
-        public void ActionEconomySnapshotRequiresPresentStateAndEnoughRemainingActions()
+        public void ActionEconomySnapshotRequiresPresentStateAndExactPayableProfile()
         {
             CreatureId missing = new CreatureId("missing-creature");
             RulesSnapshot snapshot = new InMemoryRulesStore(
-                new RulesStateSeed().SeedActionEconomy(Creature, new ActionEconomyState(2, true))
+                new RulesStateSeed().SeedActionEconomy(
+                    Creature,
+                    new ActionEconomyState(2, ActionAllowance.None, true)
+                )
             ).Snapshot;
 
-            Assert.That(snapshot.ActionEconomy.CanSpendActions(Creature, 2), Is.True);
-            Assert.That(snapshot.ActionEconomy.CanSpendActions(Creature, 3), Is.False);
-            Assert.That(snapshot.ActionEconomy.CanSpendActions(Creature, -1), Is.False);
-            Assert.That(snapshot.ActionEconomy.CanSpendActions(missing, 0), Is.False);
+            ActionDefinitionId definition = new("test-action");
+            Assert.That(
+                snapshot.ActionEconomy.CanPayAction(
+                    Creature,
+                    definition,
+                    ActionProfile.Create(ActionCost.Two, Array.Empty<Trait>())
+                ),
+                Is.True
+            );
+            Assert.That(
+                snapshot.ActionEconomy.CanPayAction(
+                    Creature,
+                    definition,
+                    ActionProfile.Create(ActionCost.Three, Array.Empty<Trait>())
+                ),
+                Is.False
+            );
+            Assert.That(
+                snapshot.ActionEconomy.CanPayAction(
+                    missing,
+                    definition,
+                    ActionProfile.OneAction(Array.Empty<Trait>())
+                ),
+                Is.False
+            );
         }
 
         [Test]
@@ -113,7 +137,7 @@ namespace Game.Rules.Runtime.Tests
                 .SeedCreature(new CreatureState(Creature, player, callerTraits))
                 .SeedHealth(Creature, new HealthState(20, 20))
                 .SeedPosition(Creature, new GridPosition(1, 0, 2))
-                .SeedActionEconomy(Creature, new ActionEconomyState(3, true))
+                .SeedActionEconomy(Creature, new ActionEconomyState(3, ActionAllowance.None, true))
                 .SeedSpellSlot(spellSlot)
                 .SeedFocusPoints(Creature, new FocusPointState(1, 3))
                 .SeedAmmunition(ammunition)
@@ -134,7 +158,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(snapshot.Creatures[Creature].Traits, Has.Count.EqualTo(1));
             Assert.That(snapshot.Health[Creature].Current, Is.EqualTo(20));
             Assert.That(snapshot.Positions[Creature], Is.EqualTo(new GridPosition(1, 0, 2)));
-            Assert.That(snapshot.ActionEconomy[Creature].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(snapshot.ActionEconomy[Creature].StandardActionsRemaining, Is.EqualTo(3));
             Assert.That(snapshot.SpellSlots[spellSlot.Id], Is.EqualTo(spellSlot));
             Assert.That(snapshot.FocusPoints[Creature], Is.EqualTo(new FocusPointState(1, 3)));
             Assert.That(snapshot.Ammunition[ammunition.Item], Is.EqualTo(ammunition));
@@ -525,7 +549,10 @@ namespace Game.Rules.Runtime.Tests
                 seed.SeedPosition(default, new GridPosition(0, 0, 0))
             );
             Assert.Throws<ArgumentException>(() =>
-                seed.SeedActionEconomy(default, new ActionEconomyState(3, true))
+                seed.SeedActionEconomy(
+                    default,
+                    new ActionEconomyState(3, ActionAllowance.None, true)
+                )
             );
             Assert.Throws<ArgumentException>(() => seed.SeedSpellSlot(default));
             Assert.Throws<ArgumentException>(() =>

--- a/Assets/Tests/EditMode/RulesRuntime/SpellAttackRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/SpellAttackRulesTests.cs
@@ -76,7 +76,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(attack.Damage.Single().Sources, Does.Contain("divine-lance"));
             Assert.That(attack.FinalDamage, Is.EqualTo(5));
             Assert.That(store.Snapshot.Health[Target].Current, Is.EqualTo(25));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.MultipleAttackPenalty[Actor].AttackCount, Is.EqualTo(1));
             DamageAppliedFact damage = result.Facts.OfType<DamageAppliedFact>().Single();
             Assert.That(damage.Creature, Is.EqualTo(Target));
@@ -116,7 +119,10 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(actual, Is.SameAs(expected));
             Assert.That(store.Snapshot.Health[Target].Current, Is.EqualTo(25));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.MultipleAttackPenalty[Actor].AttackCount, Is.EqualTo(1));
             Assert.That(observer.ObservedHealthAtDamage, Is.EqualTo(25));
             Assert.That(observer.ObservedMapAtDamage, Is.EqualTo(1));
@@ -141,7 +147,10 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(retry.Facts, Is.Empty);
             Assert.That(store.Snapshot.Version, Is.EqualTo(committedVersion));
             Assert.That(store.Snapshot.Health[Target].Current, Is.EqualTo(25));
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.MultipleAttackPenalty[Actor].AttackCount, Is.EqualTo(1));
             Assert.That(observer.ActionCosts, Is.EqualTo(1));
             Assert.That(observer.DamageApplications, Is.EqualTo(1));
@@ -392,7 +401,10 @@ namespace Game.Rules.Runtime.Tests
             OpResult<CastSpellOutcome> result = await dispatcher.Dispatch(operation);
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(store.Snapshot.Health[Target].Current, Is.EqualTo(30));
             Assert.That(store.Snapshot.MultipleAttackPenalty[Actor].AttackCount, Is.Zero);
             Assert.That(result.Facts, Is.Empty);
@@ -423,7 +435,10 @@ namespace Game.Rules.Runtime.Tests
             OpResult<CastSpellOutcome> result = await dispatcher.Dispatch(Cast(Target));
 
             Assert.That(result, Is.TypeOf<InterruptedOpResult<CastSpellOutcome>>());
-            Assert.That(store.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                store.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
             Assert.That(store.Snapshot.Health[Target].Current, Is.EqualTo(30));
             Assert.That(store.Snapshot.MultipleAttackPenalty[Actor].AttackCount, Is.Zero);
             Assert.That(provider.CaptureCalls, Is.Zero);
@@ -508,7 +523,10 @@ namespace Game.Rules.Runtime.Tests
                 .SeedPreparedInputs(Actor, PreparedInputs(actorImmunities))
                 .SeedPreparedInputs(Target, PreparedInputs(targetImmunities))
                 .SeedPreparedInputs(DeadTarget, PreparedCreatureInputs.Empty)
-                .SeedActionEconomy(Actor, new ActionEconomyState(actions, true))
+                .SeedActionEconomy(
+                    Actor,
+                    new ActionEconomyState(actions, ActionAllowance.None, true)
+                )
                 .SeedStatistics(
                     new CreatureStatisticsState(
                         Actor,

--- a/Assets/Tests/EditMode/RulesRuntime/SpellSaveRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/SpellSaveRulesTests.cs
@@ -102,7 +102,7 @@ namespace Game.Rules.Runtime.Tests
             );
             Assert.That(runtime.Store.Snapshot.Health[Target].Current, Is.EqualTo(12));
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(1)
             );
             Assert.That(resolved.Facts.OfType<ActionCostSpentFact>().Count(), Is.EqualTo(1));
@@ -139,7 +139,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(condition.BlockedReason, Does.Contain("immune to deafened"));
             Assert.That(runtime.Store.Snapshot.Health[Target].Current, Is.EqualTo(12));
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(1)
             );
             Assert.That(runtime.Store.Snapshot.ActiveEffects, Is.Empty);
@@ -313,7 +313,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(actual, Is.SameAs(expected));
             Assert.That(runtime.Store.Snapshot.Health[Target].Current, Is.EqualTo(12));
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(1)
             );
             Assert.That(runtime.Store.Snapshot.ActiveEffects, Has.Count.EqualTo(1));
@@ -346,7 +346,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(failure.Message, Does.Contain("absent from the encounter registry"));
             Assert.That(runtime.Store.Snapshot.Health[Target].Current, Is.EqualTo(20));
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Store.Snapshot.ActiveEffects, Is.Empty);
@@ -374,7 +374,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(runtime.Store.Snapshot.ActiveEffects, Is.Empty);
             Assert.That(runtime.Store.Snapshot.RuleBindings, Is.Empty);
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Rolls.Remaining, Is.EqualTo(2));
@@ -397,7 +397,7 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Rolls.Remaining, Is.EqualTo(2));
@@ -420,7 +420,7 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Rolls.Remaining, Is.EqualTo(2));
@@ -450,7 +450,7 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Rolls.Remaining, Is.EqualTo(2));
@@ -515,7 +515,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(invalid, Is.TypeOf<InvalidOpResult<CastSpellOutcome>>());
             Assert.That(corrected.Value.Saves.Single().FinalDamage, Is.EqualTo(8));
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(1)
             );
         }
@@ -543,7 +543,7 @@ namespace Game.Rules.Runtime.Tests
                 Does.Contain("no authoritative statistics")
             );
             Assert.That(
-                runtime.Store.Snapshot.ActionEconomy[Caster].ActionsRemaining,
+                runtime.Store.Snapshot.ActionEconomy[Caster].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Rolls.Remaining, Is.EqualTo(2));
@@ -643,7 +643,7 @@ namespace Game.Rules.Runtime.Tests
                     )
                 )
                 .SeedHealth(OtherTarget, new HealthState(20, 20))
-                .SeedActionEconomy(Caster, new ActionEconomyState(3, true))
+                .SeedActionEconomy(Caster, new ActionEconomyState(3, ActionAllowance.None, true))
                 .SeedStatistics(
                     new CreatureStatisticsState(
                         Target,

--- a/Assets/Tests/EditMode/RulesRuntime/StrideRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/StrideRulesTests.cs
@@ -35,7 +35,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 dispatcher.Snapshot.Positions[Actor],
                 Is.EqualTo(new GridPosition(2, 0, 0))
             );
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             Assert.That(resolved.Facts.OfType<ActionCostSpentFact>().Count(), Is.EqualTo(1));
             Assert.That(resolved.Facts.OfType<TokenMovedFact>().Count(), Is.EqualTo(2));
         }
@@ -60,7 +63,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 dispatcher.Snapshot.Positions[Actor],
                 Is.EqualTo(new GridPosition(0, 0, 0))
             );
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(result.Facts, Is.Empty);
         }
 
@@ -99,7 +105,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 new StrideActionOp(Actor, path)
             );
             Assert.That(enemyResult, Is.TypeOf<InvalidOpResult<MovePathOutcome>>());
-            Assert.That(enemy.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                enemy.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
         }
 
         [TestCase(2)]
@@ -131,7 +140,10 @@ namespace Game.Tests.EditMode.RulesRuntime
                 dispatcher.Snapshot.Positions[Actor],
                 Is.EqualTo(new GridPosition(secondOccupiedX + 1, 0, 0))
             );
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
             Assert.That(
                 result.Facts.OfType<OccupiedSpaceTraversedFact>().Select(fact => fact.Occupant),
                 Is.EqualTo(new[] { Other, SecondOther })
@@ -196,7 +208,10 @@ namespace Game.Tests.EditMode.RulesRuntime
 
             Assert.That(first.Value.DistanceSpent, Is.EqualTo(new GridDistance(5)));
             Assert.That(second.Value.DistanceSpent, Is.EqualTo(new GridDistance(10)));
-            Assert.That(dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining, Is.EqualTo(1));
+            Assert.That(
+                dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
+                Is.EqualTo(1)
+            );
         }
 
         private static RulesStateSeed SeedActor(int speedFeet = 25) =>
@@ -204,7 +219,7 @@ namespace Game.Tests.EditMode.RulesRuntime
                 .SeedCreature(new CreatureState(Actor, Party))
                 .SeedPosition(Actor, new GridPosition(0, 0, 0))
                 .SeedLandSpeed(Actor, new GridDistance(speedFeet))
-                .SeedActionEconomy(Actor, new ActionEconomyState(3, true));
+                .SeedActionEconomy(Actor, new ActionEconomyState(3, ActionAllowance.None, true));
 
         private static RuleDispatcher CreateDispatcher(
             IGridTopologyProvider topology,

--- a/Assets/Tests/EditMode/RulesRuntime/StrikeRulesTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/StrikeRulesTests.cs
@@ -54,7 +54,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(resolved.Value.FinalDamage, Is.EqualTo(6));
             Assert.That(runtime.Dispatcher.Snapshot.Health[Target].Current, Is.EqualTo(14));
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(2)
             );
             Assert.That(
@@ -157,7 +157,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(result.Value.Hit, Is.False);
             Assert.That(runtime.Dispatcher.Snapshot.Health[Target].Current, Is.EqualTo(20));
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(2)
             );
             Assert.That(
@@ -240,7 +240,7 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<StrikeResolution>>());
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(
@@ -289,7 +289,7 @@ namespace Game.Rules.Runtime.Tests
                 Does.Contain("Armor Class")
             );
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Dispatcher.Snapshot.Ammunition[Ammo].Remaining, Is.EqualTo(2));
@@ -345,7 +345,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(blocked, Is.TypeOf<InvalidOpResult<StrikeResolution>>());
             Assert.That(runtime.Dispatcher.Snapshot.Ammunition[Ammo].Remaining, Is.EqualTo(1));
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(2)
             );
 
@@ -358,7 +358,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(runtime.Dispatcher.Snapshot.Equipment[Weapon].IsLoaded, Is.True);
             Assert.That(runtime.Dispatcher.Snapshot.Ammunition[Ammo].Remaining, Is.EqualTo(1));
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(1)
             );
         }
@@ -383,7 +383,7 @@ namespace Game.Rules.Runtime.Tests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<EquipmentState>>());
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Dispatcher.Snapshot.Equipment[Weapon].IsLoaded, Is.False);
@@ -417,7 +417,7 @@ namespace Game.Rules.Runtime.Tests
             Assert.That(result, Is.TypeOf<InvalidOpResult<EquipmentState>>());
             Assert.That(((InvalidOpResult<EquipmentState>)result).Reason, Does.Contain(reason));
             Assert.That(
-                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].ActionsRemaining,
+                runtime.Dispatcher.Snapshot.ActionEconomy[Actor].StandardActionsRemaining,
                 Is.EqualTo(3)
             );
             Assert.That(runtime.Dispatcher.Snapshot.Equipment[Weapon].IsLoaded, Is.False);
@@ -586,8 +586,8 @@ namespace Game.Rules.Runtime.Tests
             seed.SeedCreature(new CreatureState(Target, new PlayerId("enemies")))
                 .SeedHealth(Actor, new HealthState(actorHp, 20))
                 .SeedHealth(Target, new HealthState(targetHp, targetHp))
-                .SeedActionEconomy(Actor, new ActionEconomyState(3, true))
-                .SeedActionEconomy(Target, new ActionEconomyState(0, true))
+                .SeedActionEconomy(Actor, new ActionEconomyState(3, ActionAllowance.None, true))
+                .SeedActionEconomy(Target, new ActionEconomyState(0, ActionAllowance.None, true))
                 .SeedEquipment(new EquipmentState(item.Item, item.Definition, Actor, true, loaded));
             if (seedMap)
                 seed.SeedMultipleAttackPenalty(Actor, new MultipleAttackPenaltyState(0));

--- a/Assets/Tests/EditMode/RulesRuntime/TurnResourcePolicyTests.cs
+++ b/Assets/Tests/EditMode/RulesRuntime/TurnResourcePolicyTests.cs
@@ -1,0 +1,189 @@
+using System;
+using NUnit.Framework;
+
+namespace Game.Rules.Runtime.Tests
+{
+    /// <summary>Verifies pure turn refresh and exact action-resource payment policy.</summary>
+    public sealed class TurnResourcePolicyTests
+    {
+        private static readonly ActionDefinitionId Stride = new("stride");
+        private static readonly ActionDefinitionId Strike = new("strike");
+        private static readonly ActionProfile OneAction = ActionProfile.OneAction(
+            Array.Empty<Trait>()
+        );
+
+        [TestCase(1, 2)]
+        [TestCase(2, 1)]
+        [TestCase(3, 0)]
+        [TestCase(4, 0)]
+        public void SlowedUsesHighestValueAndClampsStandardActions(int slowed, int expected)
+        {
+            TurnResourcePlan plan = Resolve(
+                TurnResourceContribution.StartTurnLoss(slowed),
+                TurnResourceContribution.StartTurnLoss(Math.Max(0, slowed - 1))
+            );
+
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.EqualTo(expected));
+            Assert.That(plan.Economy.OptionalAction, Is.SameAs(ActionAllowance.None));
+            Assert.That(plan.Economy.ReactionAvailable, Is.True);
+        }
+
+        [Test]
+        public void StunnedAndSlowedUseMaximumWhileStunnedConsumesOnlyItsValue()
+        {
+            TurnResourcePlan plan = Resolve(
+                TurnResourceContribution.StartTurnLoss(2),
+                TurnResourceContribution.StunnedBy(StunnedResourcePolicy.Valued(1))
+            );
+
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.EqualTo(1));
+            Assert.That(plan.StunnedConsumed, Is.EqualTo(1));
+            Assert.That(plan.StunnedRemaining, Is.Zero);
+            Assert.That(plan.Economy.ReactionAvailable, Is.True);
+        }
+
+        [Test]
+        public void StunnedFourLeavesOneAndSuppressesReactionWithoutQuickened()
+        {
+            TurnResourcePlan plan = Resolve(
+                TurnResourceContribution.StunnedBy(StunnedResourcePolicy.Valued(4))
+            );
+
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.Zero);
+            Assert.That(plan.StunnedConsumed, Is.EqualTo(3));
+            Assert.That(plan.StunnedRemaining, Is.EqualTo(1));
+            Assert.That(plan.Economy.ReactionAvailable, Is.False);
+        }
+
+        [Test]
+        public void DurationOnlyStunnedLosesEverythingAndSuppressesReactionWithoutConsumption()
+        {
+            TurnResourcePlan plan = Resolve(
+                TurnResourceContribution.OptionalAction(ActionAllowance.Unrestricted),
+                TurnResourceContribution.StunnedBy(StunnedResourcePolicy.DurationOnly)
+            );
+
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.Zero);
+            Assert.That(plan.Economy.OptionalAction.IsNone, Is.True);
+            Assert.That(plan.Loss.OptionalAction, Is.True);
+            Assert.That(plan.Loss.StandardActions, Is.EqualTo(3));
+            Assert.That(plan.StunnedConsumed, Is.Zero);
+            Assert.That(plan.Economy.ReactionAvailable, Is.False);
+        }
+
+        [Test]
+        public void QuickenedSourcesUnionOnceAndUnrestrictedDominates()
+        {
+            TurnResourcePlan restricted = Resolve(
+                TurnResourceContribution.OptionalAction(
+                    ActionAllowance.Restricted(new[] { Stride })
+                ),
+                TurnResourceContribution.OptionalAction(
+                    ActionAllowance.Restricted(new[] { Strike })
+                )
+            );
+            TurnResourcePlan unrestricted = Resolve(
+                TurnResourceContribution.OptionalAction(restricted.Economy.OptionalAction),
+                TurnResourceContribution.OptionalAction(ActionAllowance.Unrestricted)
+            );
+
+            Assert.That(restricted.Economy.OptionalAction.Allows(Stride), Is.True);
+            Assert.That(restricted.Economy.OptionalAction.Allows(Strike), Is.True);
+            Assert.That(
+                unrestricted.Economy.OptionalAction,
+                Is.SameAs(ActionAllowance.Unrestricted)
+            );
+        }
+
+        [Test]
+        public void StartTurnLossRemovesOptionalBeforeStandard()
+        {
+            TurnResourcePlan plan = Resolve(
+                TurnResourceContribution.OptionalAction(ActionAllowance.Unrestricted),
+                TurnResourceContribution.StartTurnLoss(1)
+            );
+
+            Assert.That(plan.Loss.OptionalAction, Is.True);
+            Assert.That(plan.Loss.StandardActions, Is.Zero);
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.EqualTo(3));
+            Assert.That(plan.Economy.OptionalAction.IsNone, Is.True);
+        }
+
+        [Test]
+        public void EligibleOneActionSpendsOptionalBeforeStandard()
+        {
+            ActionEconomyState economy = new(3, ActionAllowance.Restricted(new[] { Stride }), true);
+
+            bool paid = ActionResourcePayment.TryPay(
+                economy,
+                Stride,
+                OneAction,
+                out ActionEconomyState remaining,
+                out ActionResourceKind? resource
+            );
+
+            Assert.That(paid, Is.True);
+            Assert.That(resource, Is.EqualTo(ActionResourceKind.Optional));
+            Assert.That(remaining.StandardActionsRemaining, Is.EqualTo(3));
+            Assert.That(remaining.OptionalAction.IsNone, Is.True);
+        }
+
+        [Test]
+        public void IneligibleAndMultiActionCostsUseOnlyStandardActions()
+        {
+            ActionEconomyState economy = new(3, ActionAllowance.Restricted(new[] { Stride }), true);
+
+            Assert.That(
+                ActionResourcePayment.TryPay(
+                    economy,
+                    Strike,
+                    OneAction,
+                    out ActionEconomyState ineligible,
+                    out ActionResourceKind? ineligibleResource
+                ),
+                Is.True
+            );
+            Assert.That(ineligibleResource, Is.EqualTo(ActionResourceKind.Standard));
+            Assert.That(ineligible.StandardActionsRemaining, Is.EqualTo(2));
+            Assert.That(ineligible.OptionalAction.IsNone, Is.False);
+
+            Assert.That(
+                ActionResourcePayment.TryPay(
+                    economy,
+                    Stride,
+                    ActionProfile.Create(ActionCost.Two, Array.Empty<Trait>()),
+                    out ActionEconomyState multi,
+                    out ActionResourceKind? multiResource
+                ),
+                Is.True
+            );
+            Assert.That(multiResource, Is.EqualTo(ActionResourceKind.Standard));
+            Assert.That(multi.StandardActionsRemaining, Is.EqualTo(1));
+            Assert.That(multi.OptionalAction.IsNone, Is.False);
+        }
+
+        [Test]
+        public void IndependentReactionSuppressionDoesNotChangeActionResources()
+        {
+            TurnResourcePlan plan = Resolve(TurnResourceContribution.SuppressReaction());
+
+            Assert.That(plan.Economy.StandardActionsRemaining, Is.EqualTo(3));
+            Assert.That(plan.Economy.OptionalAction.IsNone, Is.True);
+            Assert.That(plan.Economy.ReactionAvailable, Is.False);
+        }
+
+        [Test]
+        public void DefaultActionEconomyProjectsNoOptionalActionWithStableValueEquality()
+        {
+            ActionEconomyState projected = default;
+            ActionEconomyState explicitNone = new(0, ActionAllowance.None, false);
+
+            Assert.That(projected.OptionalAction, Is.SameAs(ActionAllowance.None));
+            Assert.That(projected, Is.EqualTo(explicitNone));
+            Assert.That(projected.GetHashCode(), Is.EqualTo(explicitNone.GetHashCode()));
+        }
+
+        private static TurnResourcePlan Resolve(params TurnResourceContribution[] contributions) =>
+            TurnResourcePlanner.Resolve(contributions);
+    }
+}

--- a/Assets/Tests/EditMode/RulesRuntime/TurnResourcePolicyTests.cs.meta
+++ b/Assets/Tests/EditMode/RulesRuntime/TurnResourcePolicyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59a47bf2db97414086ec4af4043f0ab7

--- a/Assets/Tests/EditMode/UnityCombatRulesBridgeTests.cs
+++ b/Assets/Tests/EditMode/UnityCombatRulesBridgeTests.cs
@@ -3439,15 +3439,12 @@ public sealed class UnityCombatRulesBridgeTests
 
         internal void FailNextTurnBeganFact(Exception failure) => turnBeganFailure = failure;
 
-        public ValueTask<TurnStartContribution> Apply(
-            EncounterTurnStartContext context,
-            TurnStartContribution current
-        )
+        public ValueTask Apply(EncounterTurnStartContext context)
         {
             AdapterCalls++;
             if (adapterFailures.Count > 0)
                 throw adapterFailures.Dequeue();
-            return new ValueTask<TurnStartContribution>(current);
+            return default;
         }
 
         public ValueTask OnFactCommitted(TurnBeganFact fact, RulesSnapshot currentSnapshot)
@@ -3490,10 +3487,7 @@ public sealed class UnityCombatRulesBridgeTests
 
     private sealed class RecordingTurnStartAdapter : IEncounterTurnStartAdapter
     {
-        public ValueTask<TurnStartContribution> Apply(
-            EncounterTurnStartContext context,
-            TurnStartContribution current
-        ) => new ValueTask<TurnStartContribution>(current);
+        public ValueTask Apply(EncounterTurnStartContext context) => default;
     }
 
     private sealed class BridgeTestActionController : ActionController

--- a/Assets/Tests/EditMode/UnityCombatRulesBridgeTests.cs
+++ b/Assets/Tests/EditMode/UnityCombatRulesBridgeTests.cs
@@ -936,7 +936,7 @@ public sealed class UnityCombatRulesBridgeTests
     }
 
     [Test]
-    public void DetachedControllerProjectsNeutralCombatStateAndRejectsPositiveAuthority()
+    public void DetachedControllerProjectsNeutralCombatStateAndRejectsTurnStartup()
     {
         GameObject creatureObject = new GameObject("detached-controller");
         try
@@ -951,8 +951,6 @@ public sealed class UnityCombatRulesBridgeTests
             Assert.That(controller.ActionPoints, Is.Zero);
             Assert.That(controller.Reacted, Is.False);
             Assert.That(controller.StrikePenalty, Is.Zero);
-            Assert.DoesNotThrow(() => controller.SpendActions(0));
-            Assert.Throws<InvalidOperationException>(() => controller.SpendActions(1));
             Assert.Throws<InvalidOperationException>(() => controller.StartTurn());
         }
         finally
@@ -1531,7 +1529,7 @@ public sealed class UnityCombatRulesBridgeTests
 
             Assert.That(result, Is.TypeOf<ResolvedOpResult<MovePathOutcome>>());
             Assert.That(bridge.Snapshot.Positions[id], Is.EqualTo(new GridPosition(2, 0, 0)));
-            Assert.That(bridge.Snapshot.ActionEconomy[id].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(bridge.Snapshot.ActionEconomy[id].StandardActionsRemaining, Is.EqualTo(2));
             Assert.That(controller.ActionPoints, Is.EqualTo(2));
         }
         finally
@@ -1696,7 +1694,7 @@ public sealed class UnityCombatRulesBridgeTests
             Assert.That(observer.Facts[1].From, Is.EqualTo(new GridPosition(1, 0, 0)));
             Assert.That(observer.Facts[1].To, Is.EqualTo(new GridPosition(2, 0, 0)));
             Assert.That(bridge.Snapshot.Positions[id], Is.EqualTo(new GridPosition(2, 0, 0)));
-            Assert.That(bridge.Snapshot.ActionEconomy[id].ActionsRemaining, Is.Zero);
+            Assert.That(bridge.Snapshot.ActionEconomy[id].StandardActionsRemaining, Is.Zero);
             Assert.That(
                 controller.ActionPoints,
                 Is.Zero,
@@ -1781,7 +1779,10 @@ public sealed class UnityCombatRulesBridgeTests
                 : string.Empty;
             Assert.That(forward, Is.TypeOf<ResolvedOpResult<MovePathOutcome>>(), forwardFailure);
             Assert.That(bridge.Snapshot.Positions[moverId], Is.EqualTo(new GridPosition(2, 0, 0)));
-            Assert.That(bridge.Snapshot.ActionEconomy[moverId].ActionsRemaining, Is.EqualTo(2));
+            Assert.That(
+                bridge.Snapshot.ActionEconomy[moverId].StandardActionsRemaining,
+                Is.EqualTo(2)
+            );
 
             bridge.BeginTurn(occupantId, 3);
             OpResult<MovePathOutcome> reverse = await bridge.DispatchStride(
@@ -1797,7 +1798,10 @@ public sealed class UnityCombatRulesBridgeTests
                 bridge.Snapshot.Positions[occupantId],
                 Is.EqualTo(new GridPosition(1, 0, 0))
             );
-            Assert.That(bridge.Snapshot.ActionEconomy[occupantId].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                bridge.Snapshot.ActionEconomy[occupantId].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(occupant.ActionPoints, Is.EqualTo(3));
         }
         finally
@@ -1863,7 +1867,10 @@ public sealed class UnityCombatRulesBridgeTests
 
             Assert.That(result, Is.TypeOf<InvalidOpResult<MovePathOutcome>>());
             Assert.That(bridge.Snapshot.Positions[moverId], Is.EqualTo(new GridPosition(0, 0, 0)));
-            Assert.That(bridge.Snapshot.ActionEconomy[moverId].ActionsRemaining, Is.EqualTo(3));
+            Assert.That(
+                bridge.Snapshot.ActionEconomy[moverId].StandardActionsRemaining,
+                Is.EqualTo(3)
+            );
             Assert.That(mover.ActionPoints, Is.EqualTo(3));
             Assert.That(result.Facts, Is.Empty);
         }

--- a/Assets/Tests/PlayMode/DungeonEncounterCombatPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/DungeonEncounterCombatPlayModeTests.cs
@@ -900,6 +900,128 @@ public sealed class DungeonEncounterCombatPlayModeTests
         );
     }
 
+    [UnityTest]
+    public IEnumerator MindlessController_OptionalSpendCountsAsProgressBeforeStandards()
+    {
+        GameObject aiObject = Create("Quickened Progress AI");
+        CreatureComponent aiCreature = aiObject.AddComponent<CreatureComponent>();
+        aiCreature.name = "Quickened Progress AI";
+        aiCreature.speed = 25;
+        aiCreature.InitializeHealthBeforeEncounter(10, 10);
+        Team aiTeam = aiObject.AddComponent<Team>();
+        aiTeam.Name = "Enemies";
+        SequencedMindlessController ai = aiObject.AddComponent<SequencedMindlessController>();
+        CombatantFixture opponent = CreateCombatant("Quickened Progress Opponent", "Players", 0);
+        Tile[,] tiles = CreateMindlessTiles(2);
+        ai.RebindGrid(new MindlessTestGridBinding(tiles));
+        TestEntityAction interact = new(
+            "Typed Interact",
+            1,
+            () => Assert.That(ai.TryCommitInteract(), Is.True)
+        );
+        ai.ConfigureDecisions(interact, null);
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new ActionController[] { ai, opponent.Controller },
+            tiles,
+            new ScriptedRollService(20, 10)
+        );
+        CreatureId actor = bridge.GetCreatureId(aiCreature);
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Quickened",
+                actor,
+                actor,
+                RuleSource.FromSlug("mindless-quickened-interact"),
+                EffectDuration.Indefinite,
+                new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+            )
+        );
+        ai.enabled = false;
+        bridge.BeginTurn(actor, 3);
+        ai.enabled = true;
+
+        ai.StartTurn();
+        yield return new WaitUntil(() => ai.EndTurnCount == 1);
+
+        Assert.That(ai.DecisionCount, Is.EqualTo(2));
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.EqualTo(3));
+        Assert.That(bridge.GetOptionalActionAvailable(actor), Is.False);
+        bridge.ReleaseOwnership();
+    }
+
+    [UnityTest]
+    public IEnumerator MindlessController_AvailableOptionalResourceDrivesSelectionAtZeroStandards()
+    {
+        GameObject aiObject = Create("Quickened Only AI");
+        CreatureComponent aiCreature = aiObject.AddComponent<CreatureComponent>();
+        aiCreature.name = "Quickened Only AI";
+        aiCreature.speed = 25;
+        aiCreature.InitializeHealthBeforeEncounter(10, 10);
+        Team aiTeam = aiObject.AddComponent<Team>();
+        aiTeam.Name = "Enemies";
+        SequencedMindlessController ai = aiObject.AddComponent<SequencedMindlessController>();
+        CombatantFixture opponent = CreateCombatant("Quickened Only Opponent", "Players", 0);
+        Tile[,] tiles = CreateMindlessTiles(2);
+        ai.RebindGrid(new MindlessTestGridBinding(tiles));
+        UnityCombatRulesBridge bridge = UnityCombatRulesBridge.Create(
+            new ActionController[] { ai, opponent.Controller },
+            tiles,
+            new ScriptedRollService(20, 10)
+        );
+        CreatureId actor = bridge.GetCreatureId(aiCreature);
+        bridge.Dispatch(
+            new ApplyConditionOp(
+                "Quickened",
+                actor,
+                actor,
+                RuleSource.FromSlug("mindless-quickened-stride"),
+                EffectDuration.Indefinite,
+                new QuickenedConditionState(new[] { StrideActionDefinition.DefinitionId })
+            )
+        );
+        ai.enabled = false;
+        bridge.BeginTurn(actor, 3);
+        Assert.That(ai.TryCommitInteract(), Is.True);
+        Assert.That(ai.TryCommitInteract(), Is.True);
+        Assert.That(ai.TryCommitInteract(), Is.True);
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.Zero);
+        Assert.That(bridge.GetOptionalActionAvailable(actor), Is.True);
+        TestEntityAction stride = new(
+            "Typed Stride",
+            1,
+            () =>
+                Assert.That(
+                    bridge.Dispatch(
+                        new StrideActionOp(
+                            actor,
+                            new MovementPath(
+                                new GridPosition(0, 0, 0),
+                                new[] { new GridPosition(1, 0, 0) }
+                            )
+                        )
+                    ),
+                    Is.TypeOf<ResolvedOpResult<MovePathOutcome>>()
+                ),
+            false,
+            controller =>
+                controller.TryGetCombatRules(
+                    out UnityCombatRulesBridge activeBridge,
+                    out CreatureId activeActor
+                )
+                && activeBridge.GetStrideAvailability(activeActor) is AvailableActionAvailability
+        );
+        ai.ConfigureDecisions(stride);
+        ai.enabled = true;
+
+        ai.StartTurn();
+        yield return new WaitUntil(() => ai.EndTurnCount == 1);
+
+        Assert.That(ai.DecisionCount, Is.EqualTo(1));
+        Assert.That(bridge.GetOptionalActionAvailable(actor), Is.False);
+        Assert.That(bridge.Snapshot.Positions[actor], Is.EqualTo(new GridPosition(1, 0, 0)));
+        bridge.ReleaseOwnership();
+    }
+
     /// <summary>
     /// Verifies active encounter AI preserves directional TeamRules friendship for distinct teams.
     /// </summary>
@@ -964,6 +1086,14 @@ public sealed class DungeonEncounterCombatPlayModeTests
         team.Name = teamName;
         manager.AddCombatant(controller);
         return new CombatantFixture(gameObject, creature, conditions, controller);
+    }
+
+    private static Tile[,] CreateMindlessTiles(int width)
+    {
+        Tile[,] tiles = new Tile[width, 1];
+        for (int x = 0; x < width; x++)
+            tiles[x, 0] = new Tile();
+        return tiles;
     }
 
     private GameObject Create(string name)
@@ -1077,6 +1207,32 @@ public sealed class DungeonEncounterCombatPlayModeTests
         }
     }
 
+    private sealed class SequencedMindlessController : MindlessController
+    {
+        private readonly Queue<EntityAction> decisions = new();
+
+        public int DecisionCount { get; private set; }
+        public int EndTurnCount { get; private set; }
+
+        public void ConfigureDecisions(params EntityAction[] nextDecisions)
+        {
+            decisions.Clear();
+            foreach (EntityAction decision in nextDecisions)
+                decisions.Enqueue(decision);
+        }
+
+        protected override EntityAction SelectNextAction()
+        {
+            DecisionCount++;
+            return decisions.Count == 0 ? null : decisions.Dequeue();
+        }
+
+        public override void EndTurn()
+        {
+            EndTurnCount++;
+        }
+    }
+
     private sealed class TestGridBinding : GridAPIPrivate
     {
         private readonly Tile[,] tiles =
@@ -1130,30 +1286,35 @@ public sealed class DungeonEncounterCombatPlayModeTests
     {
         private readonly Action invocation;
         private readonly bool isExplorationAction;
+        private readonly Func<ActionController, bool> availability;
 
         public TestEntityAction(
             string name,
             uint cost,
             Action invocation,
-            bool isExplorationAction = false
+            bool isExplorationAction = false,
+            Func<ActionController, bool> availability = null
         )
             : base(cost)
         {
             ActionName = name;
             this.invocation = invocation;
             this.isExplorationAction = isExplorationAction;
+            this.availability = availability;
         }
 
         public override string ActionName { get; }
 
         public override bool IsExplorationAction => isExplorationAction;
 
+        public override bool IsAvailable(ActionController controller) =>
+            availability?.Invoke(controller) ?? base.IsAvailable(controller);
+
         /// <inheritdoc/>
         public override void Invoke(GameObject target)
         {
             ActionController controller = target.GetComponent<ActionController>();
             invocation();
-            PayCost(controller);
             controller.IsTakingAction = false;
         }
     }

--- a/Assets/Tests/PlayMode/DungeonExplorationRuntimePlayModeTests.cs
+++ b/Assets/Tests/PlayMode/DungeonExplorationRuntimePlayModeTests.cs
@@ -11,6 +11,7 @@ using Game.DungeonGeneration;
 using Game.KayKit;
 using Game.Rules;
 using Game.Rules.Runtime;
+using Game.Rules.Unity;
 using GridPrivate;
 using GridPublic;
 using NUnit.Framework;
@@ -779,6 +780,64 @@ public sealed class DungeonExplorationRuntimePlayModeTests
         Assert.That(current.Creature.IsDefeated, Is.True);
         Assert.That(fixture.Runtime.TryOpenDoor(deadActorDoor.Cell), Is.False);
         Assert.That(fixture.Doors[deadActorDoor.Cell].Controller.IsOpen, Is.False);
+        yield break;
+    }
+
+    /// <summary>
+    /// Verifies an invalidated door cell rejects before typed Interact can spend either resource.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator CombatDoorInvalidatedBeforeInteractionDoesNotSpendTurnResources()
+    {
+        DoorSpec door = new("door-invalidated", new DungeonCell(2, 1));
+        RuntimeFixture fixture = CreateRuntimeFixture(
+            new[] { new Vector3Int(1, 0, 1) },
+            doors: new[] { door },
+            configurePartyBeforeInitialization: party =>
+                party[0].GetComponent<CreatureComponent>().initiative = 1000
+        );
+        Combatant enemy = CreateCombatant(
+            "Invalidated Door Enemy",
+            "Enemies",
+            new Vector3Int(7, 0, 7),
+            initiative: 0,
+            addToken: false
+        );
+        manager.StartDungeonCombat(new[] { fixture.Party[0].Controller, enemy.Controller });
+        Combatant current = fixture.Party[0];
+        Assert.That(
+            current.Controller.TryGetCombatRules(
+                out UnityCombatRulesBridge bridge,
+                out CreatureId actor
+            ),
+            Is.True
+        );
+        Assert.That(
+            bridge.Dispatch(
+                new ApplyConditionOp(
+                    "Quickened",
+                    actor,
+                    actor,
+                    RuleSource.FromSlug("door-invalidation-quickened-interact"),
+                    EffectDuration.Indefinite,
+                    new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+                )
+            ),
+            Is.TypeOf<ResolvedOpResult<ConditionApplicationOutcome>>()
+        );
+        bridge.BeginTurn(actor, 3);
+
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.EqualTo(3));
+        Assert.That(bridge.GetOptionalActionAvailable(actor), Is.True);
+
+        fixture.Grid.GridData[door.Cell.X, door.Cell.Z] = TileType.Ground;
+
+        Assert.That(fixture.Runtime.TryOpenDoor(door.Cell), Is.False);
+        Assert.That(fixture.Doors[door.Cell].Controller.IsOpen, Is.False);
+        Assert.That(fixture.Doors[door.Cell].ClosedVisual.activeSelf, Is.True);
+        Assert.That(fixture.Doors[door.Cell].OpenVisual.activeSelf, Is.False);
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.EqualTo(3));
+        Assert.That(bridge.GetOptionalActionAvailable(actor), Is.True);
         yield break;
     }
 

--- a/Assets/Tests/PlayMode/EncounterLifecycleTestExtensions.cs
+++ b/Assets/Tests/PlayMode/EncounterLifecycleTestExtensions.cs
@@ -6,6 +6,15 @@ using NUnit.Framework;
 /// <summary>Runs Unity PlayMode integration fixtures through exact encounter turn authority.</summary>
 internal static class EncounterLifecycleTestExtensions
 {
+    /// <summary>Commits the typed one-action Interact used to spend fixture resources.</summary>
+    internal static bool TryCommitInteract(this ActionController controller)
+    {
+        if (controller == null)
+            throw new ArgumentNullException(nameof(controller));
+        return controller.TryGetCombatRules(out UnityCombatRulesBridge bridge, out CreatureId actor)
+            && bridge.Dispatch(new InteractActionOp(actor)) is ResolvedOpResult<InteractOutcome>;
+    }
+
     /// <summary>Starts or advances a real encounter until the requested actor owns the turn.</summary>
     internal static void BeginTurn(
         this UnityCombatRulesBridge bridge,
@@ -48,6 +57,6 @@ internal static class EncounterLifecycleTestExtensions
         Assert.That(encounter.Phase, Is.EqualTo(EncounterPhase.Active));
         Assert.That(encounter.CurrentTurn.HasValue, Is.True);
         Assert.That(encounter.CurrentTurn.Value.Actor, Is.EqualTo(actor));
-        Assert.That(bridge.GetActionsRemaining(actor), Is.EqualTo(expectedActions));
+        Assert.That(bridge.GetStandardActionsRemaining(actor), Is.EqualTo(expectedActions));
     }
 }

--- a/Assets/Tests/PlayMode/SpellcastingPresentationPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/SpellcastingPresentationPlayModeTests.cs
@@ -320,7 +320,8 @@ public sealed class SpellcastingPresentationPlayModeTests
         CreatureId actor = bridge.GetCreatureId(controller);
 
         bridge.BeginTurn(actor, 3);
-        bridge.SpendEncounterActions(actor, 2);
+        Assert.That(controller.TryCommitInteract(), Is.True);
+        Assert.That(controller.TryCommitInteract(), Is.True);
         controller.IsTakingAction = true;
         light.Invoke(cleric.gameObject);
         yield return null;

--- a/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
+++ b/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
@@ -123,19 +123,30 @@ namespace TestsUI
 
             VisualElement card = cardHolder.ElementAt(playerCardIndex);
             List<VisualElement> medallions = null;
+            List<VisualElement> standardMedallions = null;
+            VisualElement quickenedMedallion = null;
             yield return WaitUntilWithTimeout(
                 timeout,
                 () =>
                 {
                     medallions = card.Query<VisualElement>(className: "action-medallion").ToList();
-                    return medallions.Count == 3;
+                    standardMedallions = card.Query<VisualElement>(
+                            className: "action-medallion--standard"
+                        )
+                        .ToList();
+                    quickenedMedallion = card.Q<VisualElement>(
+                        className: "action-medallion--quickened"
+                    );
+                    return medallions.Count == 4
+                        && standardMedallions.Count == 3
+                        && quickenedMedallion != null;
                 }
             );
 
             Assert.AreEqual(
-                3,
+                4,
                 medallions.Count,
-                "Player card should show exactly three action medallions."
+                "Player card should show three standard medallions and one Quickened medallion."
             );
             Assert.IsNull(
                 card.Q<Label>("DESC"),
@@ -166,24 +177,39 @@ namespace TestsUI
                     timeout,
                     () =>
                     {
-                        medallions = card.Query<VisualElement>(className: "action-medallion")
+                        standardMedallions = card.Query<VisualElement>(
+                                className: "action-medallion--standard"
+                            )
                             .ToList();
-                        return CountMedallionsWithClass(medallions, "action-medallion--filled")
-                            == (int)actionPoints;
+                        return CountMedallionsWithClass(
+                                standardMedallions,
+                                "action-medallion--filled"
+                            ) == (int)actionPoints
+                            && quickenedMedallion.ClassListContains("action-medallion--empty");
                     }
                 );
 
-                int filledCount = CountMedallionsWithClass(medallions, "action-medallion--filled");
-                int emptyCount = CountMedallionsWithClass(medallions, "action-medallion--empty");
+                int filledCount = CountMedallionsWithClass(
+                    standardMedallions,
+                    "action-medallion--filled"
+                );
+                int emptyCount = CountMedallionsWithClass(
+                    standardMedallions,
+                    "action-medallion--empty"
+                );
                 Assert.AreEqual(
                     (int)actionPoints,
                     filledCount,
                     $"Expected {actionPoints} filled action medallions."
                 );
                 Assert.AreEqual(
-                    3 - (int)actionPoints,
+                    ActionMedallionPresenter.StandardMedallionCount - (int)actionPoints,
                     emptyCount,
-                    $"Expected {3 - (int)actionPoints} empty action medallions."
+                    $"Expected {ActionMedallionPresenter.StandardMedallionCount - (int)actionPoints} empty standard action medallions."
+                );
+                Assert.IsFalse(
+                    quickenedMedallion.ClassListContains("action-medallion--filled"),
+                    "The integration placeholder must not fill the Quickened medallion."
                 );
                 Assert.AreEqual(
                     containerWidth,
@@ -435,7 +461,7 @@ namespace TestsUI
             {
                 List<VisualElement> medallions = cardHolder
                     .ElementAt(i)
-                    .Query<VisualElement>(className: "action-medallion")
+                    .Query<VisualElement>(className: "action-medallion--standard")
                     .ToList();
                 if (
                     medallions.Count == 3

--- a/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
+++ b/Assets/Tests/PlayMode/TestsUI/GameUITests.cs
@@ -166,12 +166,10 @@ namespace TestsUI
             ).resolvedStyle.height;
 
             uint[] actionPointStates = { 3, 2, 1, 0 };
-            uint previousActionPoints = actionController.ActionPoints;
             foreach (uint actionPoints in actionPointStates)
             {
-                if (previousActionPoints > actionPoints)
-                    actionController.SpendActions(previousActionPoints - actionPoints);
-                previousActionPoints = actionPoints;
+                while (actionController.ActionPoints > actionPoints)
+                    Assert.IsTrue(actionController.TryCommitInteract());
 
                 yield return WaitUntilWithTimeout(
                     timeout,
@@ -222,6 +220,75 @@ namespace TestsUI
                     "Action medallion container height should not shift as AP changes."
                 );
             }
+        }
+
+        [UnityTest]
+        public IEnumerator QuickenedMedallionProjectsBridgeRefreshAndTypedSpend()
+        {
+            VisualElement cardHolder = null;
+            yield return WaitUntilWithTimeout(
+                timeout,
+                () =>
+                {
+                    cardHolder = root.Q<VisualElement>("CardHolder");
+                    player = CombatManagerInterface.GetInstance().WhosTurn();
+                    return cardHolder != null && cardHolder.childCount > 0 && player != null;
+                }
+            );
+            ActionController controller = player.GetComponent<ActionController>();
+            Assert.IsNotNull(controller);
+            Assert.IsTrue(
+                controller.TryGetCombatRules(
+                    out UnityCombatRulesBridge bridge,
+                    out CreatureId actor
+                )
+            );
+            int cardIndex = CombatManagerInterface.GetInstance().GetCombatants().IndexOf(player);
+            Assert.GreaterOrEqual(cardIndex, 0);
+            Assert.Less(cardIndex, cardHolder.childCount);
+            VisualElement quickened = cardHolder
+                .ElementAt(cardIndex)
+                .Q<VisualElement>(className: "action-medallion--quickened");
+            Assert.IsNotNull(quickened);
+
+            Assert.That(
+                bridge.Dispatch(
+                    new ApplyConditionOp(
+                        "Quickened",
+                        actor,
+                        actor,
+                        RuleSource.FromSlug("hud-quickened-interact"),
+                        EffectDuration.Indefinite,
+                        new QuickenedConditionState(new[] { InteractActionDefinition.DefinitionId })
+                    )
+                ),
+                Is.TypeOf<ResolvedOpResult<ConditionApplicationOutcome>>()
+            );
+            CombatManagerInterface combatManager = CombatManagerInterface.GetInstance();
+            int remainingTurns = combatManager.GetCombatants().Count + 1;
+            do
+            {
+                combatManager.NextTurn();
+            } while (combatManager.WhosTurn() != player && remainingTurns-- > 0);
+            Assert.AreSame(player, combatManager.WhosTurn());
+
+            yield return WaitUntilWithTimeout(
+                timeout,
+                () =>
+                    controller.OptionalActionAvailable
+                    && quickened.ClassListContains("action-medallion--filled")
+            );
+            Assert.AreEqual(3u, controller.ActionPoints);
+
+            Assert.IsTrue(controller.TryCommitInteract());
+
+            yield return WaitUntilWithTimeout(
+                timeout,
+                () =>
+                    !controller.OptionalActionAvailable
+                    && quickened.ClassListContains("action-medallion--empty")
+            );
+            Assert.AreEqual(3u, controller.ActionPoints);
         }
 
         [UnityTest]
@@ -518,7 +585,8 @@ namespace TestsUI
             ActionController actionController = player.GetComponent<ActionController>();
             Assert.IsNotNull(actionController, "Current player has no ActionController.");
 
-            actionController.SpendActions(actionController.ActionPoints);
+            while (actionController.ActionPoints > 0)
+                Assert.IsTrue(actionController.TryCommitInteract());
             yield return null;
 
             Assert.AreEqual(
@@ -558,7 +626,8 @@ namespace TestsUI
             {
                 combatManager.NextTurn();
             } while (combatManager.WhosTurn() != player && remainingTurns-- > 0);
-            actionController.SpendActions(2);
+            Assert.IsTrue(actionController.TryCommitInteract());
+            Assert.IsTrue(actionController.TryCommitInteract());
             yield return null;
 
             Assert.IsTrue(

--- a/Assets/UIStuff/HUD/HUDController.cs
+++ b/Assets/UIStuff/HUD/HUDController.cs
@@ -451,7 +451,7 @@ public class HUDController
             UpdateActionPointMedallions(
                 cardInstance,
                 GetStandardActionsRemaining(Players[i].GetComponent<ActionController>()),
-                quickenedResourceAvailable: false
+                GetOptionalActionAvailable(Players[i].GetComponent<ActionController>())
             );
         }
     }
@@ -1152,7 +1152,7 @@ public class HUDController
                 UpdateActionPointMedallions(
                     card,
                     GetStandardActionsRemaining(p.GetComponent<ActionController>()),
-                    quickenedResourceAvailable: false
+                    GetOptionalActionAvailable(p.GetComponent<ActionController>())
                 );
                 if (p.hp <= 0)
                 {
@@ -1211,6 +1211,9 @@ public class HUDController
     {
         return actionController == null ? 0 : checked((int)actionController.ActionPoints);
     }
+
+    private static bool GetOptionalActionAvailable(ActionController actionController) =>
+        actionController != null && actionController.OptionalActionAvailable;
 
     private static void UpdateActionPointMedallions(
         VisualElement card,

--- a/Assets/UIStuff/HUD/HUDController.cs
+++ b/Assets/UIStuff/HUD/HUDController.cs
@@ -66,10 +66,6 @@ public class HUDController
     private const float SlideDuration = 0.4f;
     private const float LogHiddenPercent = 80f;
     private const float PanelHiddenPercent = 80f;
-    private const int MaxActionMedallions = 3;
-    private const string ActionMedallionClass = "action-medallion";
-    private const string ActionMedallionFilledClass = "action-medallion--filled";
-    private const string ActionMedallionEmptyClass = "action-medallion--empty";
     public const string DisabledHudButtonClass = "btn-hud-disabled";
 
     //####Player Queue Card Variables####
@@ -452,7 +448,11 @@ public class HUDController
                     if (isDungeonExploration)
                         SelectExplorationController(captured.GetComponent<ActionController>());
                 });
-            UpdateActionPointMedallions(cardInstance, Players[i].GetComponent<ActionController>());
+            UpdateActionPointMedallions(
+                cardInstance,
+                GetStandardActionsRemaining(Players[i].GetComponent<ActionController>()),
+                quickenedResourceAvailable: false
+            );
         }
     }
 
@@ -1149,7 +1149,11 @@ public class HUDController
                     // card.style.opacity = 0.5f;
                     cardVE.AddToClassList("card-inactive");
                 }
-                UpdateActionPointMedallions(card, p.GetComponent<ActionController>());
+                UpdateActionPointMedallions(
+                    card,
+                    GetStandardActionsRemaining(p.GetComponent<ActionController>()),
+                    quickenedResourceAvailable: false
+                );
                 if (p.hp <= 0)
                 {
                     continue;
@@ -1203,20 +1207,78 @@ public class HUDController
         }
     }
 
-    private void UpdateActionPointMedallions(VisualElement card, ActionController actionController)
+    private static int GetStandardActionsRemaining(ActionController actionController)
     {
-        List<VisualElement> medallions = card.Query<VisualElement>(className: ActionMedallionClass)
-            .ToList();
-        int actionPoints =
-            actionController != null
-                ? Mathf.Clamp((int)actionController.ActionPoints, 0, MaxActionMedallions)
-                : 0;
+        return actionController == null ? 0 : checked((int)actionController.ActionPoints);
+    }
 
-        for (int i = 0; i < medallions.Count; i++)
+    private static void UpdateActionPointMedallions(
+        VisualElement card,
+        int standardActionsRemaining,
+        bool quickenedResourceAvailable
+    )
+    {
+        ActionMedallionPresenter.Render(card, standardActionsRemaining, quickenedResourceAvailable);
+    }
+}
+
+/// <summary>
+/// Projects independently supplied action resources onto the fixed player-card medallion slots.
+/// </summary>
+internal static class ActionMedallionPresenter
+{
+    internal const int StandardMedallionCount = 3;
+    internal const string StandardMedallionClass = "action-medallion--standard";
+    internal const string QuickenedMedallionClass = "action-medallion--quickened";
+    internal const string FilledClass = "action-medallion--filled";
+    internal const string EmptyClass = "action-medallion--empty";
+
+    /// <summary>
+    /// Renders ordinary actions and the separate Quickened resource without combining their counts.
+    /// </summary>
+    /// <param name="card">The instantiated player-card visual tree.</param>
+    /// <param name="standardActionsRemaining">The projected number of ordinary actions remaining.</param>
+    /// <param name="quickenedResourceAvailable">
+    /// Whether the separately projected Quickened action resource remains available.
+    /// </param>
+    internal static void Render(
+        VisualElement card,
+        int standardActionsRemaining,
+        bool quickenedResourceAvailable
+    )
+    {
+        if (card == null)
+            throw new ArgumentNullException(nameof(card));
+
+        List<VisualElement> standardMedallions = card.Query<VisualElement>(
+                className: StandardMedallionClass
+            )
+            .ToList();
+        if (standardMedallions.Count != StandardMedallionCount)
         {
-            bool filled = i < actionPoints;
-            medallions[i].EnableInClassList(ActionMedallionFilledClass, filled);
-            medallions[i].EnableInClassList(ActionMedallionEmptyClass, !filled);
+            throw new InvalidOperationException(
+                $"A player card must contain exactly {StandardMedallionCount} standard action medallions."
+            );
         }
+
+        VisualElement quickenedMedallion = card.Q<VisualElement>(
+            className: QuickenedMedallionClass
+        );
+        if (quickenedMedallion == null)
+            throw new InvalidOperationException(
+                "A player card must contain a Quickened medallion."
+            );
+
+        int filledStandardCount = Mathf.Clamp(standardActionsRemaining, 0, StandardMedallionCount);
+        for (int i = 0; i < standardMedallions.Count; i++)
+            SetFilled(standardMedallions[i], i < filledStandardCount);
+
+        SetFilled(quickenedMedallion, quickenedResourceAvailable);
+    }
+
+    private static void SetFilled(VisualElement medallion, bool filled)
+    {
+        medallion.EnableInClassList(FilledClass, filled);
+        medallion.EnableInClassList(EmptyClass, !filled);
     }
 }

--- a/Assets/UIStuff/HUD/HUDController.cs
+++ b/Assets/UIStuff/HUD/HUDController.cs
@@ -524,10 +524,11 @@ public class HUDController
                     if (isDungeonExploration)
                         SelectExplorationController(captured.GetComponent<ActionController>());
                 });
+            ActionController actionController = Players[i].GetComponent<ActionController>();
             UpdateActionPointMedallions(
                 cardInstance,
-                GetStandardActionsRemaining(Players[i].GetComponent<ActionController>()),
-                GetOptionalActionAvailable(Players[i].GetComponent<ActionController>())
+                GetStandardActionsRemaining(actionController),
+                GetOptionalActionAvailable(actionController)
             );
         }
     }
@@ -1286,10 +1287,11 @@ public class HUDController
                     // card.style.opacity = 0.5f;
                     cardVE.AddToClassList("card-inactive");
                 }
+                ActionController actionController = p.GetComponent<ActionController>();
                 UpdateActionPointMedallions(
                     card,
-                    GetStandardActionsRemaining(p.GetComponent<ActionController>()),
-                    GetOptionalActionAvailable(p.GetComponent<ActionController>())
+                    GetStandardActionsRemaining(actionController),
+                    GetOptionalActionAvailable(actionController)
                 );
                 if (p.hp <= 0)
                 {

--- a/Assets/UIStuff/HUD/Player_Card.uss
+++ b/Assets/UIStuff/HUD/Player_Card.uss
@@ -62,10 +62,10 @@
     flex-wrap: nowrap;
     flex-grow: 0;
     flex-shrink: 0;
-    width: 192px;
+    width: 220px;
     height: 96px;
-    min-width: 192px;
-    max-width: 192px;
+    min-width: 220px;
+    max-width: 220px;
     min-height: 96px;
     max-height: 96px;
 }
@@ -126,4 +126,29 @@
 .action-medallion--empty > .action-medallion-core {
     background-color: rgba(18, 16, 15, 0.72);
     border-color: rgb(83, 60, 42);
+}
+
+.action-medallion--quickened.action-medallion--filled {
+    background-color: rgb(54, 133, 163);
+    border-color: rgb(166, 235, 255);
+}
+
+.action-medallion--quickened {
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
+.action-medallion--quickened.action-medallion--filled > .action-medallion-core {
+    background-color: rgb(190, 242, 255);
+    border-color: rgb(18, 62, 84);
+}
+
+.action-medallion--quickened.action-medallion--empty {
+    background-color: rgba(19, 31, 38, 0.82);
+    border-color: rgb(61, 112, 128);
+}
+
+.action-medallion--quickened.action-medallion--empty > .action-medallion-core {
+    background-color: rgba(15, 25, 30, 0.72);
+    border-color: rgb(42, 77, 89);
 }

--- a/Assets/UIStuff/HUD/Player_Card_Template.uxml
+++ b/Assets/UIStuff/HUD/Player_Card_Template.uxml
@@ -8,14 +8,17 @@
             <ui:Label name="HealthBarLabel" text="10/10" class="health-bar-label" style="margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0; padding-top: 0; padding-right: 0; padding-bottom: 0; padding-left: 0;" />
         </ui:VisualElement>
         <ui:Image name="PortraitImage" style="width: 100%; height: 140px; flex-grow: 0; flex-shrink: 0; background-color: rgba(0, 0, 0, 0); flex-direction: column; align-items: auto; margin-top: 0; margin-bottom: 3px;" />
-        <ui:VisualElement name="ActionPointContainer" class="action-point-container" style="flex-grow: 0; flex-shrink: 0; align-self: stretch; height: 96px; width: 192px;">
-            <ui:VisualElement name="ActionMedallion0" class="action-medallion action-medallion--empty">
+        <ui:VisualElement name="ActionPointContainer" class="action-point-container" style="flex-grow: 0; flex-shrink: 0; align-self: center; height: 96px; width: 220px;">
+            <ui:VisualElement name="ActionMedallion0" class="action-medallion action-medallion--standard action-medallion--empty">
                 <ui:VisualElement class="action-medallion-core" />
             </ui:VisualElement>
-            <ui:VisualElement name="ActionMedallion1" class="action-medallion action-medallion--empty">
+            <ui:VisualElement name="ActionMedallion1" class="action-medallion action-medallion--standard action-medallion--empty">
                 <ui:VisualElement class="action-medallion-core" />
             </ui:VisualElement>
-            <ui:VisualElement name="ActionMedallion2" class="action-medallion action-medallion--empty">
+            <ui:VisualElement name="ActionMedallion2" class="action-medallion action-medallion--standard action-medallion--empty">
+                <ui:VisualElement class="action-medallion-core" />
+            </ui:VisualElement>
+            <ui:VisualElement name="QuickenedActionMedallion" class="action-medallion action-medallion--quickened action-medallion--empty">
                 <ui:VisualElement class="action-medallion-core" />
             </ui:VisualElement>
         </ui:VisualElement>

--- a/Docs/Encounter_Rules_Architecture.md
+++ b/Docs/Encounter_Rules_Architecture.md
@@ -18,7 +18,7 @@ controller and creature are attached to that exact bridge, the following state i
 | Slice | Authoritative rules state and boundary |
 | --- | --- |
 | Turn ownership | `EncounterState.CurrentTurn` and exact `TurnIdentity`; `ActionController.HasTurnAuthority` is a read projection. |
-| Actions and reactions | `ActionEconomyState`; `ActionController.ActionPoints` and `Reacted` project it. |
+| Actions and reactions | `ActionEconomyState` owns ordinary actions, an explicit optional `ActionAllowance`, and reaction availability. `ActionController.ActionPoints` is a standard-only legacy projection; the HUD reads standard and optional availability separately. |
 | Multiple attack penalty | `MultipleAttackPenaltyState`; `ActionController.StrikePenalty` projects its attack count. |
 | Health | `HealthState`; `CreatureComponent.Health`, `hp`, `maxHp`, and `tempHp` read it while attached. Health Facts project committed values and presentation back to Unity. A private temporary-Hit-Point pool revision distinguishes exact internal mutations for rollback safety but is deliberately absent from public equality, Facts, outcomes, and persistence. |
 | Position and movement | `RulesSnapshot.Positions`, movement budgets, permissions, and movement reducers. Token movement is a committed-Fact projection. |
@@ -26,7 +26,7 @@ controller and creature are attached to that exact bridge, the following state i
 | Active-effect timing | `ActiveEffectInstance` and `ActiveEffectTimingState`, advanced at encounter initiative boundaries. |
 | Base statistics | `RulesSnapshot.Statistics` owns immutable base attack, Armor Class, saves, skills, and normalized snapshot modifiers captured at enrollment. Unity adapters must read base fields, not `Resolve*` totals that already include active rules. |
 | Prepared rule participation | `RulesSnapshot.PreparedInputs` owns normalized creature facts and `RulesSnapshot.RuleBindings` alone controls whether definition-owned compiled behavior participates. `PreparedRulePackage` is only the ephemeral compiler result used to seed those slices. |
-| Migrated action slices | Stride, Strike, Reload, Rage, and supported Cast a Spell variants use rules operations, validation, action lifecycle, reducers, and state. |
+| Migrated action slices | Stride, Strike, Reload, Interact, Rage, and supported Cast a Spell variants use rules operations, validation, action lifecycle, reducers, and state. |
 
 Cutover never means “try rules, then fall back.” A detached `ActionController` exposes deliberately
 unavailable read projections (`HasTurnAuthority == false`, zero action points, `Reacted == false`,
@@ -49,13 +49,14 @@ constructs the only production module sequence:
 1. `UnityPreparedRulesEncounterModule`
 2. `RottingAuraEncounterModule`
 3. `ConditionEncounterModule`
-4. `SlowedEncounterModule` (enrollment only)
-5. `UnityRageEncounterModule`
-6. `UnityStrikeEncounterModule`
-7. `UnitySpellcastingEncounterModule`
-8. `UnityLightEncounterModule`
-9. `UnityHealthProjectionModule`
-10. `UnityEncounterProjectionModule`
+4. `SlowedEncounterModule`
+5. `UnityInteractEncounterModule`
+6. `UnityRageEncounterModule`
+7. `UnityStrikeEncounterModule`
+8. `UnitySpellcastingEncounterModule`
+9. `UnityLightEncounterModule`
+10. `UnityHealthProjectionModule`
+11. `UnityEncounterProjectionModule`
 
 Before registry construction, `UnityEncounterModuleSet.Create` materializes and validates every
 additional module exactly once, preserving the caller-supplied extension order. It then performs a
@@ -68,7 +69,9 @@ separate, explicit static-composition pass that cannot be deferred to `Configure
   `PreparedRuleDefinitionSpec`, `RageRules.DefineRuleBindings(registryBuilder)`,
   `registryBuilder.AddOutcomeRule()`,
   `registryBuilder.Define(UnitySpellcastingEncounterModule.RestoredTimedEffectDefinitionId)`, and
-  each distinct spell-effect `DefinitionId` from `spellCatalog.Definitions`.
+  each distinct spell-effect `DefinitionId` from `spellCatalog.Definitions`. It then defines the
+  complete condition registry through `ConditionRuleDefinitions.DefineAll(registryBuilder)` and the
+  No Reactions binding through `SlowedEncounterModule.DefineRules(registryBuilder)`.
 - It invokes `ConfigureRegistry` for each additional module that implements the stateless
   `IUnityEncounterRegistryModule` capability, in that same extension order, and only then calls the
   single `registryBuilder.Build()`.
@@ -81,7 +84,8 @@ inspect combatants, self-register, retain the builder, or construct a second reg
 `RuleRegistry` is immutable. `CombatActionCatalog` is instead a stable composed interface over
 encounter-live adapters. Both are constructed before `UnityCombatRulesBridge` supplies them to
 `UseActionLifecycle(modules.ActionCatalog)`, `UseActiveEffectRules(modules.Registry)`, and
-`UseEncounterRules(..., modules.Registry)`, and before any module's `ConfigureDispatcher` pass.
+`UseEncounterRules(composition.CreateTurnStartAdapters(), modules.Registry,
+composition.CreateTurnResourceStrategy())`, and before any module's `ConfigureDispatcher` pass.
 The shared registry instance keeps Unity enrollment and encounter join reducers under the same
 definition authority. The catalog's composed capabilities are stable, but
 combatant-specific data remains encounter-live:
@@ -110,7 +114,13 @@ Each pass filters the same sequence by capability, preserving supplied order:
 | --- | --- |
 | `IUnityEncounterRegistryModule.ConfigureRegistry` | Contribute stateless effect and binding definitions before the encounter's single registry build. Additional modules are invoked in their explicit supplied order. |
 | `IUnityEncounterDispatcherModule.ConfigureDispatcher` | Register feature-owned handlers, reducers, validators, and engine composition with `RuleDispatcherBuilder`. |
-| `IUnityEncounterTurnStartModule.CreateTurnStartAdapter` | Supply a completion-only transitional `IEncounterTurnStartAdapter`. Adapters run sequentially in module order. |
+| `IUnityEncounterTurnResourceModule.CreateTurnResourceProvider` | Contribute feature-owned turn-resource inputs to the one generic deterministic refresh strategy. Providers run in module order. |
+| `IUnityEncounterTurnStartModule.CreateTurnStartAdapter` | Supply a completion-only transitional `IEncounterTurnStartAdapter`. Rotting Aura is the only production adapter; adapters run sequentially in module order. |
+
+The production turn-resource strategy therefore receives the condition module's Quickened,
+Slowed, and Stunned provider first, followed by the Slowed module's No Reactions provider. This
+ordered provider set is the only production source for turn-start action, optional-action, and
+reaction availability.
 | `IUnityEncounterRuntimeModule.RegisterRuntime` | Register observers and other encounter-scoped resources into the supplied `CompositeLifetime`. |
 | `IUnityEncounterTopologyModule.RefreshTopology` | Refresh a feature-owned Unity topology adapter after a live grid change. |
 | `IUnityCombatantEnrollmentModule.PrepareCombatant` | Precompute state and Unity installation contributions for every enrolled combatant. |
@@ -453,8 +463,10 @@ encounter handlers and engine reducers. Its current division of responsibility i
   `EncounterState.IsTurnStartPending` is set, advancement resumes `BeginInitiativeTurnOp` for the
   exact already published actor, round, and roster slot instead of consuming another boundary.
 - `BeginInitiativeTurnHandler`: reset movement budget, run ordered completion-only turn-start
-  adapters, stop if the actor is defeated, then commit the exact turn with the temporary ordinary
-  three-action and one-reaction default. The published-boundary checkpoint stores only the next
+  adapters, stop if the actor is defeated, resolve the composed turn-resource strategy from the
+  post-adapter snapshot, then atomically commit the exact turn and any elected Stunned
+  update or expiration. Resource gained/lost Facts are staged before `TurnBeganFact`. The
+  published-boundary checkpoint stores only the next
   adapter index; each adapter completion commits before the next adapter runs, so a fresh-root
   recovery resumes only unfinished adapters. The narrow
   `CommitFinalDamageBatchAndCompleteAdapter` boundary lets a transitional adapter atomically commit
@@ -490,6 +502,27 @@ or resolving the profile, validating, or committing costs again; a conflicting i
 Disruption advances that checkpoint to `Interrupted`, and a feature's final atomic reducer advances it to
 `Resolved` with the outcome. Feature code must not spend the same costs or publish a parallel
 action-begun event.
+
+The lifecycle validates generic feature-owned permissions before concrete validators. Stunned uses
+that boundary to reject actions, reactions, and free actions while any source remains. Cost
+commitment receives the trusted parent definition ID and the frozen profile, and the same pure
+payment helper drives availability. Only an exact eligible one-action invocation may spend its
+optional allowance, before ordinary actions; multi-action activities never use it. There is no
+untyped or parallel action-cost commitment API.
+
+Condition modules supply Quickened, Slowed, and elected Stunned inputs to the generic turn-resource
+strategy. Quickened sources union to at most one allowance, unrestricted dominance is preserved,
+and the greatest Slowed value and elected Stunned value use one maximum loss rather than summing.
+Loss removes the optional allowance before only as many ordinary actions as remain necessary.
+Valued Stunned is decremented only by the resources the elected highest value caused to be lost;
+that same decrement is applied independently to every active valued Stunned source so separate
+sources remain separate without becoming additive. Exact multi-effect updates and expirations
+share the turn-begin transaction. A persistent owner-scoped condition listener handles either
+valued or duration-only Stunned gained or updated during the actor's current turn by causally
+dispatching an exact-version reducer after the current activity commits. Valued Stunned drains at
+most the actor's remaining optional and standard resources, preserving the reaction when fully
+consumed and disabling it while Stunned remains. Duration-only Stunned immediately drains all
+remaining action resources and disables the reaction without consuming the condition.
 
 Cast a Spell uses snapshot membership as the boundary for actor-owned metadata. An actor absent
 from the captured snapshot receives the selected definition and variant profile without a
@@ -682,9 +715,10 @@ shrink them through vertical migrations:
   every applicable aura before mutation, then atomically commits the ordered final-damage batch and
   adapter checkpoint through encounter rules before presentation, so post-commit failure cannot
   replay any aura damage.
-- `SlowedEncounterModule` preserves the authored passive's stable active-effect and binding
-  identity at enrollment, but intentionally has no turn-start adapter or action/reaction resource
-  authority. Later rules-native resource integration must consume that state directly.
+- `SlowedEncounterModule` enrolls the authored zombie passive as two durable rules identities:
+  indefinite Slowed 1 and a separate stateless no-reactions binding. Both initial enrollment and
+  reinforcement replay converge on those identities. Slowed participates through the condition
+  resource strategy; only the separate binding suppresses reaction refresh and typed reaction use.
 - `UnityStrikeContext` and `UnitySpellAttackContext` adapt current creature/equipment/team/grid data
   into rule definitions and validation. They are feature-owned adapters, not alternate authorities.
 - Strike reinforcement replay compares the complete actor-owned equipment and ammunition

--- a/Docs/Encounter_Rules_Architecture.md
+++ b/Docs/Encounter_Rules_Architecture.md
@@ -49,7 +49,7 @@ constructs the only production module sequence:
 1. `UnityPreparedRulesEncounterModule`
 2. `RottingAuraEncounterModule`
 3. `ConditionEncounterModule`
-4. `SlowedEncounterModule`
+4. `SlowedEncounterModule` (enrollment only)
 5. `UnityRageEncounterModule`
 6. `UnityStrikeEncounterModule`
 7. `UnitySpellcastingEncounterModule`
@@ -110,7 +110,7 @@ Each pass filters the same sequence by capability, preserving supplied order:
 | --- | --- |
 | `IUnityEncounterRegistryModule.ConfigureRegistry` | Contribute stateless effect and binding definitions before the encounter's single registry build. Additional modules are invoked in their explicit supplied order. |
 | `IUnityEncounterDispatcherModule.ConfigureDispatcher` | Register feature-owned handlers, reducers, validators, and engine composition with `RuleDispatcherBuilder`. |
-| `IUnityEncounterTurnStartModule.CreateTurnStartAdapter` | Supply a transitional `IEncounterTurnStartAdapter`. Adapters run sequentially in module order. |
+| `IUnityEncounterTurnStartModule.CreateTurnStartAdapter` | Supply a completion-only transitional `IEncounterTurnStartAdapter`. Adapters run sequentially in module order. |
 | `IUnityEncounterRuntimeModule.RegisterRuntime` | Register observers and other encounter-scoped resources into the supplied `CompositeLifetime`. |
 | `IUnityEncounterTopologyModule.RefreshTopology` | Refresh a feature-owned Unity topology adapter after a live grid change. |
 | `IUnityCombatantEnrollmentModule.PrepareCombatant` | Precompute state and Unity installation contributions for every enrolled combatant. |
@@ -452,17 +452,15 @@ encounter handlers and engine reducers. Its current division of responsibility i
   or ineligible roster slots, and effect timing in deterministic order. When
   `EncounterState.IsTurnStartPending` is set, advancement resumes `BeginInitiativeTurnOp` for the
   exact already published actor, round, and roster slot instead of consuming another boundary.
-- `BeginInitiativeTurnHandler`: reset movement budget, run ordered turn-start adapters, stop if the
-  actor is defeated, then commit the exact turn and final action contribution. The published-boundary
-  checkpoint stores the next adapter index and current contribution; each adapter result commits
-  before the next adapter runs, so a fresh-root recovery resumes only unfinished adapters. The engine
-  checkpoints a successfully returned adapter, not partial internal work: an adapter with multiple
-  commits must itself be transactional or exact-replay-safe on internal failure. The narrow
+- `BeginInitiativeTurnHandler`: reset movement budget, run ordered completion-only turn-start
+  adapters, stop if the actor is defeated, then commit the exact turn with the temporary ordinary
+  three-action and one-reaction default. The published-boundary checkpoint stores only the next
+  adapter index; each adapter completion commits before the next adapter runs, so a fresh-root
+  recovery resumes only unfinished adapters. The narrow
   `CommitFinalDamageBatchAndCompleteAdapter` boundary lets a transitional adapter atomically commit
   an ordered same-actor damage batch and its completion checkpoint before fallible presentation;
-  an adapter using it may perform only presentation before returning the checkpointed contribution.
-  A completed
-  zero-HP turn-start attempt atomically clears the published-boundary checkpoint with
+  an adapter using it may perform only presentation before returning. A completed zero-HP
+  turn-start attempt atomically clears the published-boundary checkpoint with
   `InitiativeTurnStartSkippedFact` before deferred defeat reactions run, so rescuing the actor does
   not replay adapters for the already resolved slot.
 - `EndTurnHandler`: require the exact current `TurnIdentity`, run turn-end work, reset movement,
@@ -618,7 +616,7 @@ framework.
 6. **Add topology or turn-start capabilities only if required.** Implement
    `IUnityEncounterTopologyModule` for a live geometry adapter. Use
    `IUnityEncounterTurnStartModule` only for a transitional Unity-owned calculation that cannot yet
-   be a rules feature; Rotting Aura and Slowed are current seams, not templates for new rules.
+   be a rules feature; Rotting Aura is the current seam, not a template for new rules.
 7. **Complete static composition, then add the module once.** Every `RuleDefinitionId` used by an
    `ActiveRuleBinding` or `ActiveEffectInstance` must be defined before the production registry's
    single `Build`. A built-in module may be wired explicitly in `UnityEncounterModuleSet.Create`.
@@ -684,8 +682,9 @@ shrink them through vertical migrations:
   every applicable aura before mutation, then atomically commits the ordered final-damage batch and
   adapter checkpoint through encounter rules before presentation, so post-commit failure cannot
   replay any aura damage.
-- `SlowedEncounterModule` obtains the current action contribution through
-  `ActionController.CalculateTurnStartActions` and legacy `ResetActionPointsEvent` listeners.
+- `SlowedEncounterModule` preserves the authored passive's stable active-effect and binding
+  identity at enrollment, but intentionally has no turn-start adapter or action/reaction resource
+  authority. Later rules-native resource integration must consume that state directly.
 - `UnityStrikeContext` and `UnitySpellAttackContext` adapt current creature/equipment/team/grid data
   into rule definitions and validation. They are feature-owned adapters, not alternate authorities.
 - Strike reinforcement replay compares the complete actor-owned equipment and ammunition


### PR DESCRIPTION
## Stack

- Depends on #205, which depends on #204.
- Review and merge #204, then #205, then this PR.
- This PR targets `codex/issue-133-condition-stack`.

Replaces ghosted PR #203 on the same implementation branch, with the verified lower-stack review fix propagated through both dependencies.

## Summary

- Makes `RulesStore` the sole authority for standard actions, the optional Quickened action, and reactions.
- Implements Slowed, Stunned, and Quickened turn-resource semantics, including mid-turn changes, max-not-sum reductions, optional-first eligible spending, and typed action restrictions.
- Routes Stride, Strike, Cast a Spell, Rage, and Interact through generic typed action authorization; no untyped spending or legacy action reset/fallback path remains.
- Preserves zombie no-reaction behavior as a separate generic rule binding and makes AI consume the same authoritative resources.
- Adds the fourth Quickened HUD medallion while preserving fail-closed HUD lifecycle, exploration hiding, and Tactics behavior.
- Makes door interaction atomic: validate a pure door-state precondition, pay through `InteractActionOp`, then enforce the synchronous mutation invariant.
- Requires encounter conclusion policy explicitly at every encounter construction/start boundary; no compatibility default or overload remains.

## Key invariants

- Missing or incomplete combat-rules attachment fails closed.
- Unity action counters are projections only; they never authorize or spend combat resources.
- Turn-resource providers compose through one deterministic strategy; condition values reduce by maximum, not by summing.
- A paid Interact cannot silently fail door mutation after successful preflight.
- Encounter policy, published-boundary checkpoints, receipts, and reinforcement assignment state survive every state transition.

## Verification

- current head: `30ee5cce1e87c88e4cecedc09a5659c8bc0f1510`
- focused EditMode: 374/374
- focused PlayMode: 138/138
- post-gate focused HUD EditMode: 9/9
- post-gate focused HUD PlayMode: 17/17
- full EditMode: 1283/1283
- full PlayMode: 197/197
- compiler warnings/errors: 0/0
- CSharpier: 419/419 files clean
- staged diff and legacy/fallback invariant scans: passed

## Review status

- historical fresh exact-diff `gpt-5.6-sol` xhigh review of feature SHA `43884b45277825dbdd1df065bc3a7c45d73d0d77` against `8c5168f3f27c3e64d5d414da9b8c13a59d2500b0`: no actionable findings
- the current head includes the later tested stack reconciliation and narrow compile correction; per the review workflow it was not sent through a second local review
- Copilot reviewed exact head `30ee5cc` (82/83 files; only a generated `.meta` file excluded) and generated no new comments or threads
- the suppressed `SequencedMindlessController.EndTurn` note was rejected after lifecycle audit: the tests use a standalone rules bridge, release that bridge explicitly, clear the coroutine before the override, and destroy the singleton manager during teardown; calling the base method would only invoke an unrelated no-op manager path
- suppressed duplicate HUD component-lookups were accepted and fixed in `cf3920f` by reusing method-local `ActionController` values; no persistent cache or lifecycle state was added

## Game View evidence

Captured from feature SHA `43884b45277825dbdd1df065bc3a7c45d73d0d77`; current behavior was revalidated by the focused and full suites above.

Quickened Interact available: three standard medallions remain filled and the separate blue Quickened medallion is filled.

![Quickened Interact available](https://gist.githubusercontent.com/clausman/e0eac653cdc14d6e61ee5f90714b5fb4/raw/b91485f4d39c4a8916b46a79f23a8ea8e01805e3/quickened-interact-available.png)

After typed Interact: the three standard medallions remain filled and the Quickened medallion is empty.

![Quickened Interact spent](https://gist.githubusercontent.com/clausman/e0eac653cdc14d6e61ee5f90714b5fb4/raw/bd8af8fd1bc98edcc3d568cf602b454e997d7005/quickened-interact-spent.png)

[Full-resolution evidence Gist](https://gist.github.com/clausman/e0eac653cdc14d6e61ee5f90714b5fb4)

This completes the remaining implementation slice for #133 after #204 and #205. Keep #133 open until the full stack is merged.
